### PR TITLE
Fix up dependencies / project files

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,30 +4,30 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Microsoft Extensions -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.5" />
-    <!-- Microsoft Semantic Kernel -->
-    <PackageVersion Include="Microsoft.SemanticKernel.Agents.Core" Version="1.53.1" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Agents.OpenAI" Version="1.53.1-preview" />
-    <!-- OpenTelemetry -->
-    <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
 
+    <!-- Product dependencies netstandard -->
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+
+    <!-- Product dependencies shared -->
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="9.0.6" />
+
+    <!-- Testing / samples dependencies -->
+    <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Agents.Core" Version="1.59.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Agents.OpenAI" Version="1.59.0-preview" />
+    <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
-    <!-- System Packages -->
-    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.Net.ServerSentEvents" Version="9.0.5" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    <!-- JSON Schema -->
-    <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
-    <!-- Resilience & Utilities -->
     <PackageVersion Include="Polly" Version="8.4.2" />
-    <!-- Test Packages -->
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    
+    <!-- Build / infrastructure dependencies -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="nuget">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+
+</configuration>

--- a/src/A2A.AspNetCore/A2A.AspNetCore.csproj
+++ b/src/A2A.AspNetCore/A2A.AspNetCore.csproj
@@ -13,16 +13,12 @@
 		<IsPackable>true</IsPackable>
 	</PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\A2A.Core\A2A.Core.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/A2A.Core/A2A.Core.csproj
+++ b/src/A2A.Core/A2A.Core.csproj
@@ -5,18 +5,23 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<!-- NuGet Package Properties -->
-		<PackageId>A2A.Core</PackageId>
-		<Description>Core .NET SDK for the Agent2Agent(A2A) protocol.</Description>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<IsPackable>true</IsPackable>
-	</PropertyGroup>
+    <!-- NuGet Package Properties -->
+    <PackageId>A2A.Core</PackageId>
+    <Description>Core .NET SDK for the Agent2Agent(A2A) protocol.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+  
+  <!-- Dependencies only needed by netstandard2.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" />
-		<PackageReference Include="System.Net.ServerSentEvents" />
-		<PackageReference Include="System.Text.Json" />
-	</ItemGroup>
+  <!-- Dependencies needed by all -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="System.Net.ServerSentEvents" />
+  </ItemGroup>
 
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />


### PR DESCRIPTION
- Add a nuget.config to address build warnings and to ensure known feeds are being used
- Remove dependencies not necessary for net8+ builds
- Restructure package list to clarify which dependencies are used for what purpose