### PR TITLE
feat: Clean up A2AClient

### DIFF
--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.ServerSentEvents;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 
@@ -6,127 +7,138 @@ namespace A2A;
 
 public class A2AClient : IA2AClient
 {
-    private readonly HttpClient _client;
+    private static readonly HttpClient s_sharedClient = new();
 
-    public A2AClient(HttpClient client)
+    private readonly HttpClient _httpClient;
+
+    public A2AClient(HttpClient? httpClient = null)
     {
-        _client = client;
+        _httpClient = httpClient ?? s_sharedClient;
     }
 
-    public Task<A2AResponse> SendMessageAsync(MessageSendParams taskSendParams) =>
-        RpcRequest(
+    public Task<A2AResponse> SendMessageAsync(MessageSendParams taskSendParams, CancellationToken cancellationToken = default) =>
+        SendRpcRequestAsync(
             taskSendParams,
             A2AMethods.MessageSend,
             A2AJsonUtilities.JsonContext.Default.MessageSendParams,
-            A2AJsonUtilities.JsonContext.Default.A2AResponse);
+            A2AJsonUtilities.JsonContext.Default.A2AResponse,
+            cancellationToken);
 
-    public Task<AgentTask> GetTaskAsync(string taskId) =>
-        RpcRequest(
+    public Task<AgentTask> GetTaskAsync(string taskId, CancellationToken cancellationToken = default) =>
+        SendRpcRequestAsync(
             new() { Id = taskId },
             A2AMethods.TaskGet,
             A2AJsonUtilities.JsonContext.Default.TaskIdParams,
-            A2AJsonUtilities.JsonContext.Default.AgentTask);
+            A2AJsonUtilities.JsonContext.Default.AgentTask,
+            cancellationToken);
 
-    public Task<AgentTask> CancelTaskAsync(TaskIdParams taskIdParams) =>
-        RpcRequest(
+    public Task<AgentTask> CancelTaskAsync(TaskIdParams taskIdParams, CancellationToken cancellationToken = default) =>
+        SendRpcRequestAsync(
             taskIdParams,
             A2AMethods.TaskCancel,
             A2AJsonUtilities.JsonContext.Default.TaskIdParams,
-            A2AJsonUtilities.JsonContext.Default.AgentTask);
+            A2AJsonUtilities.JsonContext.Default.AgentTask,
+            cancellationToken);
 
-    public Task<TaskPushNotificationConfig> SetPushNotificationAsync(TaskPushNotificationConfig pushNotificationConfig) =>
-        RpcRequest(
+    public Task<TaskPushNotificationConfig> SetPushNotificationAsync(TaskPushNotificationConfig pushNotificationConfig, CancellationToken cancellationToken = default) =>
+        SendRpcRequestAsync(
             pushNotificationConfig,
             "task/pushNotification/set",
             A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig,
-            A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig);
+            A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig,
+            cancellationToken);
 
-    public Task<TaskPushNotificationConfig> GetPushNotificationAsync(TaskIdParams taskIdParams) =>
-        RpcRequest(
+    public Task<TaskPushNotificationConfig> GetPushNotificationAsync(TaskIdParams taskIdParams, CancellationToken cancellationToken = default) =>
+        SendRpcRequestAsync(
             taskIdParams,
             "task/pushNotification/get",
             A2AJsonUtilities.JsonContext.Default.TaskIdParams,
-            A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig);
+            A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig,
+            cancellationToken);
 
-    public async IAsyncEnumerable<SseItem<A2AEvent>> SendMessageStreamAsync(MessageSendParams taskSendParams)
-    {
-        var request = new JsonRpcRequest()
-        {
-            Id = Guid.NewGuid().ToString(),
-            Method = A2AMethods.MessageStream,
-            Params = JsonSerializer.SerializeToElement(taskSendParams, A2AJsonUtilities.JsonContext.Default.MessageSendParams),
-        };
-        var response = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "")
-        {
-            Content = new JsonRpcContent(request)
-        });
-        response.EnsureSuccessStatusCode();
-        using var stream = await response.Content.ReadAsStreamAsync();
-        var sseParser = SseParser.Create(stream, (eventType, data) =>
-        {
-            var reader = new Utf8JsonReader(data);
-            return JsonSerializer.Deserialize(ref reader, A2AJsonUtilities.JsonContext.Default.A2AEvent) ?? throw new InvalidOperationException("Failed to deserialize the event.");
-        });
-        await foreach (var item in sseParser.EnumerateAsync())
-        {
-            yield return item;
-        }
-    }
+    public IAsyncEnumerable<SseItem<A2AEvent>> SendMessageStreamAsync(MessageSendParams taskSendParams, CancellationToken cancellationToken = default) =>
+        SendRpcSseRequestAsync(
+            taskSendParams,
+            A2AMethods.MessageStream,
+            A2AJsonUtilities.JsonContext.Default.MessageSendParams,
+            A2AJsonUtilities.JsonContext.Default.A2AEvent,
+            cancellationToken);
 
-    public async IAsyncEnumerable<SseItem<A2AEvent>> ResubscribeToTaskAsync(string taskId)
-    {
-        var request = new JsonRpcRequest()
-        {
-            Id = Guid.NewGuid().ToString(),
-            Method = A2AMethods.TaskResubscribe,
-            Params = JsonSerializer.SerializeToElement(new TaskIdParams() { Id = taskId }, A2AJsonUtilities.JsonContext.Default.TaskIdParams),
-        };
-        var response = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "")
-        {
-            Content = new JsonRpcContent(request)
-        });
-        response.EnsureSuccessStatusCode();
-        using var stream = await response.Content.ReadAsStreamAsync();
-        var sseParser = SseParser.Create(stream, (eventType, data) =>
-        {
-            var reader = new Utf8JsonReader(data);
-            return JsonSerializer.Deserialize(ref reader, A2AJsonUtilities.JsonContext.Default.A2AEvent) ?? throw new InvalidOperationException("Failed to deserialize the event.");
-        });
-        await foreach (var item in sseParser.EnumerateAsync())
-        {
-            yield return item;
-        }
-    }
+    public IAsyncEnumerable<SseItem<A2AEvent>> ResubscribeToTaskAsync(string taskId, CancellationToken cancellationToken = default) =>
+        SendRpcSseRequestAsync(
+            new() { Id = taskId },
+            A2AMethods.TaskResubscribe,
+            A2AJsonUtilities.JsonContext.Default.TaskIdParams,
+            A2AJsonUtilities.JsonContext.Default.A2AEvent,
+            cancellationToken);
 
-    private async Task<TOutput> RpcRequest<TInput, TOutput>(
+    private async Task<TOutput> SendRpcRequestAsync<TInput, TOutput>(
         TInput jsonRpcParams,
         string method,
         JsonTypeInfo<TInput> inputTypeInfo,
-        JsonTypeInfo<TOutput> outputTypeInfo) where TOutput : class
+        JsonTypeInfo<TOutput> outputTypeInfo,
+        CancellationToken cancellationToken) where TOutput : class
     {
-        var request = new JsonRpcRequest()
-        {
-            Id = Guid.NewGuid().ToString(),
-            Method = method,
-            Params = JsonSerializer.SerializeToElement(jsonRpcParams, inputTypeInfo),
-        };
+        using var responseStream = await SendAndReadResponseStream(jsonRpcParams, method, inputTypeInfo, cancellationToken).ConfigureAwait(false);
 
-        using var response = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "")
-        {
-            Content = new JsonRpcContent(request)
-        });
-        response.EnsureSuccessStatusCode();
-        if (response.Content.Headers.ContentType?.MediaType != "application/json")
-        {
-            throw new InvalidOperationException("Invalid content type.");
-        }
-
-        using var responseStream = await response.Content.ReadAsStreamAsync();
-
-        var responseObject = await JsonSerializer.DeserializeAsync(responseStream, A2AJsonUtilities.JsonContext.Default.JsonRpcResponse) ??
+        var responseObject = await JsonSerializer.DeserializeAsync(responseStream, A2AJsonUtilities.JsonContext.Default.JsonRpcResponse, cancellationToken) ??
             throw new InvalidOperationException("Failed to deserialize the response.");
 
         return responseObject.Result?.Deserialize(outputTypeInfo) ??
             throw new InvalidOperationException("Response does not contain a result.");
+    }
+
+    private async IAsyncEnumerable<SseItem<TOutput>> SendRpcSseRequestAsync<TInput, TOutput>(
+        TInput jsonRpcParams,
+        string method,
+        JsonTypeInfo<TInput> inputTypeInfo,
+        JsonTypeInfo<TOutput> outputTypeInfo,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        using var responseStream = await SendAndReadResponseStream(jsonRpcParams, method, inputTypeInfo, cancellationToken).ConfigureAwait(false);
+
+        var sseParser = SseParser.Create(responseStream, (eventType, data) =>
+        {
+            var reader = new Utf8JsonReader(data);
+            return JsonSerializer.Deserialize(ref reader, outputTypeInfo) ?? throw new InvalidOperationException("Failed to deserialize the event.");
+        });
+
+        await foreach (var item in sseParser.EnumerateAsync(cancellationToken))
+        {
+            yield return item;
+        }
+    }
+
+    private async ValueTask<Stream> SendAndReadResponseStream<TInput>(
+        TInput jsonRpcParams,
+        string method,
+        JsonTypeInfo<TInput> inputTypeInfo,
+        CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.SendAsync(new(HttpMethod.Post, "")
+        {
+            Content = new JsonRpcContent(new JsonRpcRequest()
+            {
+                Id = Guid.NewGuid().ToString(),
+                Method = method,
+                Params = JsonSerializer.SerializeToElement(jsonRpcParams, inputTypeInfo),
+            })
+        }, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+        try
+        {
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadAsStreamAsync(
+#if NET
+                cancellationToken
+#endif
+                );
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
     }
 }

--- a/src/A2A/Client/IA2AClient.cs
+++ b/src/A2A/Client/IA2AClient.cs
@@ -4,11 +4,11 @@ namespace A2A;
 
 public interface IA2AClient
 {
-    Task<A2AResponse> SendMessageAsync(MessageSendParams taskSendParams);
-    Task<AgentTask> GetTaskAsync(string taskId);
-    Task<AgentTask> CancelTaskAsync(TaskIdParams taskIdParams);
-    IAsyncEnumerable<SseItem<A2AEvent>> SendMessageStreamAsync(MessageSendParams taskSendParams);
-    IAsyncEnumerable<SseItem<A2AEvent>> ResubscribeToTaskAsync(string taskId);
-    Task<TaskPushNotificationConfig> SetPushNotificationAsync(TaskPushNotificationConfig pushNotificationConfig);
-    Task<TaskPushNotificationConfig> GetPushNotificationAsync(TaskIdParams taskIdParams);
+    Task<A2AResponse> SendMessageAsync(MessageSendParams taskSendParams, CancellationToken cancellationToken = default);
+    Task<AgentTask> GetTaskAsync(string taskId, CancellationToken cancellationToken = default);
+    Task<AgentTask> CancelTaskAsync(TaskIdParams taskIdParams, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<SseItem<A2AEvent>> SendMessageStreamAsync(MessageSendParams taskSendParams, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<SseItem<A2AEvent>> ResubscribeToTaskAsync(string taskId, CancellationToken cancellationToken = default);
+    Task<TaskPushNotificationConfig> SetPushNotificationAsync(TaskPushNotificationConfig pushNotificationConfig, CancellationToken cancellationToken = default);
+    Task<TaskPushNotificationConfig> GetPushNotificationAsync(TaskIdParams taskIdParams, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
- Add cancellation token
- Deduplicate SSE methods
- Use ResponseHeadersRead to avoid buffering responses
- Use shared HttpClient singleton if no client is provided
- Tweak naming