### PR TITLE
feat: Clean up A2ACardResolver

### DIFF
--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -7,7 +7,7 @@ namespace A2A;
 
 public sealed class A2AClient : IA2AClient
 {
-    private static readonly HttpClient s_sharedClient = new();
+    internal static readonly HttpClient s_sharedClient = new();
 
     private readonly HttpClient _httpClient;
 

--- a/src/A2A/JsonRpc/ErrorTypes.cs
+++ b/src/A2A/JsonRpc/ErrorTypes.cs
@@ -1,4 +1,6 @@
-﻿namespace A2A;
+﻿using System.Net;
+
+namespace A2A;
 
 /// <summary>
 /// Base exception for A2A client errors
@@ -24,7 +26,7 @@ public class A2AClientHTTPException : A2AClientException
     /// <summary>
     /// The HTTP status code
     /// </summary>
-    public int StatusCode { get; }
+    public HttpStatusCode StatusCode { get; }
 
     /// <summary>
     /// The error message
@@ -36,8 +38,8 @@ public class A2AClientHTTPException : A2AClientException
     /// </summary>
     /// <param name="statusCode">The HTTP status code</param>
     /// <param name="message">The error message</param>
-    public A2AClientHTTPException(int statusCode, string message)
-        : base($"HTTP Error {statusCode}: {message}")
+    public A2AClientHTTPException(HttpStatusCode statusCode, string message)
+        : base($"HTTP Error {(int)statusCode}: {message}")
     {
         StatusCode = statusCode;
         ErrorMessage = message;

--- a/tests/A2A.UnitTests/JsonRpc/ErrorTypesTests.cs
+++ b/tests/A2A.UnitTests/JsonRpc/ErrorTypesTests.cs
@@ -1,4 +1,6 @@
-﻿namespace A2A.UnitTests.JsonRpc;
+﻿using System.Net;
+
+namespace A2A.UnitTests.JsonRpc;
 
 public class ErrorTypesTests
 {
@@ -20,10 +22,10 @@ public class ErrorTypesTests
     public void A2AClientHTTPError_PropertiesSetCorrectly()
     {
         // Act
-        var sut = new A2AClientHTTPException(404, "Not Found");
+        var sut = new A2AClientHTTPException(HttpStatusCode.NotFound, "Not Found");
 
         // Assert
-        Assert.Equal(404, sut.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, sut.StatusCode);
         Assert.Equal("Not Found", sut.ErrorMessage);
         Assert.Contains("404", sut.Message);
         Assert.Contains("Not Found", sut.Message);


### PR DESCRIPTION
- Support using a shared HttpClient
- Implement GetAgentCard with synchronous APIs on .NET Core
- Avoid response buffering
- Use HttpStatusCode enum rather than int
- Specify ConfigureAwait
- Avoid unnecessary null checks on _logger