### PR TITLE
fix: fix sse deserialization

### DIFF
--- a/samples/Client/Program.cs
+++ b/samples/Client/Program.cs
@@ -187,6 +187,8 @@ internal sealed class Program
         {
             Message = new Message
             {
+                MessageId = Guid.NewGuid().ToString("N"),
+                ContextId = currentSessionId,
                 Role = MessageRole.User,
                 Parts =
                 [
@@ -217,6 +219,18 @@ internal sealed class Program
                     if (agentTask.Artifacts != null && agentTask.Artifacts.Count > 0)
                     {
                         Console.WriteLine($"Artifacts count: {agentTask.Artifacts.Count}");
+                    }
+                    break;
+                case Message message:
+                    taskId = message.TaskId;
+                    Console.WriteLine($"Received message {message.MessageId} with role {message.Role}");
+                    if (message.Parts.Count > 0)
+                    {
+                        Console.WriteLine($"Message parts count: {message.Parts.Count}");
+                        foreach (var part in message.Parts.OfType<TextPart>())
+                        {
+                            Console.WriteLine(part.Text);
+                        }
                     }
                     break;
                 default:

--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -100,10 +100,14 @@ public sealed class A2AClient : IA2AClient
             "application/json",
             cancellationToken).ConfigureAwait(false);
 
-        var responseObject = await JsonSerializer.DeserializeAsync(responseStream, A2AJsonUtilities.JsonContext.Default.JsonRpcResponse, cancellationToken) ??
-            throw new InvalidOperationException("Failed to deserialize the response.");
+        var responseObject = await JsonSerializer.DeserializeAsync(responseStream, A2AJsonUtilities.JsonContext.Default.JsonRpcResponse, cancellationToken);
 
-        return responseObject.Result?.Deserialize(outputTypeInfo) ??
+        if (responseObject?.Error is { } error)
+        {
+            throw new InvalidOperationException($"JSON-RPC error ({error.Code}): {error.Message}");
+        }
+
+        return responseObject?.Result?.Deserialize(outputTypeInfo) ??
             throw new InvalidOperationException("Response does not contain a result.");
     }
 
@@ -125,15 +129,14 @@ public sealed class A2AClient : IA2AClient
         {
             var reader = new Utf8JsonReader(data);
 
-            var jsonRpcResponse = JsonSerializer.Deserialize(ref reader, A2AJsonUtilities.JsonContext.Default.JsonRpcResponse) ??
-                throw new InvalidOperationException("Failed to deserialize the response.");
+            var responseObject = JsonSerializer.Deserialize(ref reader, A2AJsonUtilities.JsonContext.Default.JsonRpcResponse);
 
-            if (jsonRpcResponse.Result == null)
+            if (responseObject?.Error is { } error)
             {
-                throw new InvalidOperationException("The response does not contain a result.");
+                throw new InvalidOperationException($"JSON-RPC error ({error.Code}): {error.Message}");
             }
 
-            return JsonSerializer.Deserialize(jsonRpcResponse.Result, outputTypeInfo) ??
+            return JsonSerializer.Deserialize(responseObject?.Result, outputTypeInfo) ??
                 throw new InvalidOperationException("Failed to deserialize the event.");
         });
 

--- a/tests/A2A.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.UnitTests/Client/A2AClientTests.cs
@@ -379,8 +379,13 @@ public class A2AClientTests
         };
 
         HttpRequestMessage? capturedRequest = null;
-        // Simulate a minimal valid SSE response (empty event stream)
-        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes("event: message\ndata: {}\n\n"));
+        // Simulate a minimal valid SSE response
+        var jsonRpcResponse = JsonSerializer.Serialize(new JsonRpcResponse
+        {
+            Id = "test-id",
+            Result = JsonSerializer.SerializeToNode(new { })
+        });
+        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes($"event: message\ndata: {jsonRpcResponse}\n\n"));
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(sseStream)
@@ -437,8 +442,12 @@ public class A2AClientTests
             ContextId = "ctx-789"
         };
         var sseEventJson = JsonSerializer.Serialize<A2AEvent>(expectedMessage, A2AJsonUtilities.DefaultOptions);
-        var sseData = $"event: message\ndata: {sseEventJson}\n\n";
-        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes(sseData));
+        var jsonRpcResponse = JsonSerializer.Serialize(new JsonRpcResponse
+        {
+            Id = "test-id",
+            Result = JsonSerializer.SerializeToNode(expectedMessage, A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(A2AEvent)))
+        });
+        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes($"event: message\ndata: {jsonRpcResponse}\n\n"));
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(sseStream)
@@ -477,8 +486,13 @@ public class A2AClientTests
         // Arrange
         var taskId = "task-123";
         HttpRequestMessage? capturedRequest = null;
-        // Simulate a minimal valid SSE response (empty event stream)
-        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes("event: message\ndata: {}\n\n"));
+        // Simulate a minimal valid SSE response
+        var jsonRpcResponse = JsonSerializer.Serialize(new JsonRpcResponse
+        {
+            Id = "test-id",
+            Result = JsonSerializer.SerializeToNode(new { })
+        });
+        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes($"event: message\ndata: {jsonRpcResponse}\n\n"));
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(sseStream)
@@ -520,9 +534,12 @@ public class A2AClientTests
             TaskId = "task-456",
             ContextId = "ctx-789"
         };
-        var sseEventJson = JsonSerializer.Serialize<A2AEvent>(expectedMessage, A2AJsonUtilities.DefaultOptions);
-        var sseData = $"event: message\ndata: {sseEventJson}\n\n";
-        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes(sseData));
+        var jsonRpcResponse = JsonSerializer.Serialize(new JsonRpcResponse
+        {
+            Id = "test-id",
+            Result = JsonSerializer.SerializeToNode(expectedMessage, A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(A2AEvent)))
+        });
+        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes($"event: message\ndata: {jsonRpcResponse}\n\n"));
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(sseStream)

--- a/tests/A2A.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.UnitTests/Client/A2AClientTests.cs
@@ -570,6 +570,55 @@ public class A2AClientTests
         Assert.Equal(expectedMessage.ContextId, message.ContextId);
     }
 
+    [Fact]
+    public async Task SendMessageStreamAsync_ThrowsOnJsonRpcError()
+    {
+        // Arrange
+        var jsonRpcErrorResponse = JsonSerializer.Serialize(JsonRpcResponse.InvalidParamsResponse("test-id"));
+        var sseStream = new MemoryStream(Encoding.UTF8.GetBytes($"event: message\ndata: {jsonRpcErrorResponse}\n\n"));
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(sseStream)
+        };
+        response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/event-stream");
+        var sut = CreateA2AClient(response);
+        var sendParams = new MessageSendParams();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in sut.SendMessageStreamAsync(sendParams))
+            {
+                // Should throw before yielding any items
+            }
+        });
+
+        Assert.Contains("-32602", exception.Message);
+        Assert.Contains("Invalid parameters", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_ThrowsOnJsonRpcError()
+    {
+        // Arrange
+        var jsonRpcErrorResponse = JsonSerializer.Serialize(JsonRpcResponse.MethodNotFoundResponse("test-id"));
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(jsonRpcErrorResponse, Encoding.UTF8, "application/json")
+        };
+        var sut = CreateA2AClient(response);
+        var sendParams = new MessageSendParams();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await sut.SendMessageAsync(sendParams);
+        });
+
+        Assert.Contains("-32601", exception.Message);
+        Assert.Contains("Method not found", exception.Message);
+    }
+
     private static A2AClient CreateA2AClient<T>(T result, Action<HttpRequestMessage>? onRequest = null)
     {
         var jsonResponse = JsonSerializer.Serialize(new JsonRpcResponse

--- a/tests/A2A.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.UnitTests/Client/A2AClientTests.cs
@@ -444,7 +444,7 @@ public class A2AClientTests
         var jsonRpcResponse = JsonSerializer.Serialize(new JsonRpcResponse
         {
             Id = "test-id",
-            Result = JsonSerializer.SerializeToNode(expectedMessage, A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(A2AEvent)))
+            Result = JsonSerializer.SerializeToNode<A2AEvent>(expectedMessage, A2AJsonUtilities.DefaultOptions)
         });
         var sseStream = new MemoryStream(Encoding.UTF8.GetBytes($"event: message\ndata: {jsonRpcResponse}\n\n"));
         var response = new HttpResponseMessage(HttpStatusCode.OK)
@@ -536,7 +536,7 @@ public class A2AClientTests
         var jsonRpcResponse = JsonSerializer.Serialize(new JsonRpcResponse
         {
             Id = "test-id",
-            Result = JsonSerializer.SerializeToNode(expectedMessage, A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(A2AEvent)))
+            Result = JsonSerializer.SerializeToNode<A2AEvent>(expectedMessage, A2AJsonUtilities.DefaultOptions)
         });
         var sseStream = new MemoryStream(Encoding.UTF8.GetBytes($"event: message\ndata: {jsonRpcResponse}\n\n"));
         var response = new HttpResponseMessage(HttpStatusCode.OK)

--- a/tests/A2A.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.UnitTests/Client/A2AClientTests.cs
@@ -441,7 +441,6 @@ public class A2AClientTests
             TaskId = "task-456",
             ContextId = "ctx-789"
         };
-        var sseEventJson = JsonSerializer.Serialize<A2AEvent>(expectedMessage, A2AJsonUtilities.DefaultOptions);
         var jsonRpcResponse = JsonSerializer.Serialize(new JsonRpcResponse
         {
             Id = "test-id",


### PR DESCRIPTION
This PR fixes the deserialization of SSE events by polymorphically deserializing the event data from the result property (see the JSON example below) instead of the event(entire JSON object) itself:  
```json  
{  
    "id": "4e5f4e5a-9b2c-485b-b6dc-4ddbeb1988d1",  
    "jsonrpc": "2.0",  
    "result": {  
        "kind": "message",  
        "messageId": "36818e79-700c-4795-a2e5-bf7f48f38fb3",  
        "parts": [  
            {  
                "kind": "text",  
                "text": "Hello World"  
            }  
        ],  
        "role": "agent"  
    }  
}  
```