### PR TITLE
make A2AHttpProcessor as it does not expose any public methods

### DIFF
--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -13,7 +13,7 @@ namespace A2A.AspNetCore;
 /// Provides methods for processing agent card queries, task operations, message sending,
 /// and push notification configuration through HTTP endpoints.
 /// </remarks>
-public static class A2AHttpProcessor
+internal static class A2AHttpProcessor
 {
     /// <summary>
     /// OpenTelemetry ActivitySource for tracing HTTP processor operations.


### PR DESCRIPTION
All the extension methods it provides are internal and they are consumed by the public `A2ARouteBuilderExtensions` type.

There is a chance these methods were supposed to be public and the type should be kept public. Please let me know.