### PR TITLE
feat: support for multiple push notifications

### DIFF
--- a/samples/A2ACli/Host/A2ACli.cs
+++ b/samples/A2ACli/Host/A2ACli.cs
@@ -233,7 +233,7 @@ public static class A2ACli
             payload.Configuration.PushNotification = new PushNotificationConfig
             {
                 Url = $"http://{notificationReceiverHost}:{notificationReceiverPort}/notify",
-                Authentication = new AuthenticationInfo
+                Authentication = new PushNotificationAuthenticationInfo
                 {
                     Schemes = ["bearer"]
                 }

--- a/samples/AgentServer/AgentServer.http
+++ b/samples/AgentServer/AgentServer.http
@@ -206,3 +206,92 @@ Content-Type: application/json
         }
     }
 }
+
+### PUSH NOTIFICATIONS
+
+### Send message to create a task for push notifications
+# @name task
+POST {{host}}/echotasks
+Content-Type: application/json
+{
+    "id": "3",
+    "jsonrpc": "2.0",
+    "method": "message/send",
+    "params": {
+          "message": {
+            "messageId": "12345",
+            "role": "user",
+            "parts": [
+                {
+                    "kind": "text",
+                    "text": "Generate an image of a cat"
+                }
+            ]
+        }
+    }
+}
+###
+
+### Set push notification for the task
+POST {{host}}/echotasks
+Content-Type: application/json
+{
+    "id": "3",
+    "jsonrpc": "2.0",
+    "method": "tasks/pushNotificationConfig/set",
+    "params": {
+          "taskId": "{{task.response.body.$.result.id}}",
+          "pushNotificationConfig": {
+              "url": "http://localhost",
+              "token": "client-token"
+          }
+    }
+}
+###
+
+@pushNotificationId=12345
+
+### Set push notification with id for the task
+POST {{host}}/echotasks
+Content-Type: application/json
+{
+    "id": "3",
+    "jsonrpc": "2.0",
+    "method": "tasks/pushNotificationConfig/set",
+    "params": {
+        "taskId": "{{task.response.body.$.result.id}}",
+        "pushNotificationConfig": {
+            "id": "{{pushNotificationId}}",
+            "url": "http://localhost",
+            "token": "client-token"
+        }
+    }
+}
+###
+
+### Get push notification for the task.
+POST {{host}}/echotasks
+Content-Type: application/json
+{
+    "id": "3",
+    "jsonrpc": "2.0",
+    "method": "tasks/pushNotificationConfig/get",
+    "params": {
+        "id": "{{task.response.body.$.result.id}}"
+    }
+}
+###
+
+### Get push notification by id for the task
+POST {{host}}/echotasks
+Content-Type: application/json
+{
+    "id": "3",
+    "jsonrpc": "2.0",
+    "method": "tasks/pushNotificationConfig/get",
+    "params": {
+        "id": "{{task.response.body.$.result.id}}",
+        "pushNotificationConfigId": "{{pushNotificationId}}"
+    }
+}
+###

--- a/samples/AgentServer/AgentServerHttp.http
+++ b/samples/AgentServer/AgentServerHttp.http
@@ -1,10 +1,10 @@
 @host = http://localhost:5048
 
 ### Query agent card for the echo agent
-GET {{host}}/echo/card
+GET {{host}}/echo/v1/card
 
 ### Send a message to the echo agent
-POST {{host}}/echo/send
+POST {{host}}/echo/v1/message:send
 Content-Type: application/json
 
 {
@@ -19,10 +19,9 @@ Content-Type: application/json
             ]
         }
 }
-
 
 ### Send a message to the echo agent that creates a task
-POST {{host}}/echotasks/send
+POST {{host}}/echotasks/v1/message:send
 Content-Type: application/json
 
 {
@@ -38,24 +37,72 @@ Content-Type: application/json
         }
 }
 
-
-
 ###
-GET {{host}}/echo/tasks/12345
+GET {{host}}/echo/v1/tasks/12345
 
 ### SendSubscribe a task to the echo agent
-POST {{host}}/echo/tasks/sendsubscribeTaskId2/sendsubscribe
+POST {{host}}/echo/v1/tasks/sendsubscribeTaskId2/subscribe
 Content-Type: application/json
 
 {
         "message": {
+            "messageId": "12345",
             "role": "user",
             "parts": [
                 {
-                    "type": "text",
+                    "kind": "text",
                     "text": "Hello, world!"
                 }
             ]
         }
 }
 
+### PUSH NOTIFICATIONS
+
+### Send message to create a task for push notifications
+# @name task
+POST {{host}}/echotasks/v1/message:send
+Content-Type: application/json
+
+{
+        "message": {
+            "messageId": "12345",
+            "role": "user",
+            "parts": [
+                {
+                    "kind": "text",
+                    "text": "Generate an image of a cat"
+                }
+            ]
+        }
+}
+###
+
+### Set push notification for the task
+POST {{host}}/echotasks/v1/tasks/{{task.response.body.$.id}}/pushNotificationConfigs
+Content-Type: application/json
+{
+    "url": "http://localhost",
+    "token": "client-token"
+}
+###
+
+@pushNotificationId=12345
+
+### Set push notification with id for the task
+POST {{host}}/echotasks/v1/tasks/{{task.response.body.$.id}}/pushNotificationConfigs
+Content-Type: application/json
+{
+    "id": "{{pushNotificationId}}",
+    "url": "http://localhost",
+    "token": "client-token"
+}
+###
+
+### Get push notification for a task
+GET {{host}}/echotasks/v1/tasks/{{task.response.body.$.id}}/pushNotificationConfigs
+###
+
+### Get push notification by id for a task
+GET {{host}}/echotasks/v1/tasks/{{task.response.body.$.id}}/pushNotificationConfigs/{{pushNotificationId}}
+###

--- a/samples/AgentServer/AgentServerHttp.http
+++ b/samples/AgentServer/AgentServerHttp.http
@@ -41,7 +41,7 @@ Content-Type: application/json
 GET {{host}}/echo/v1/tasks/12345
 
 ### SendSubscribe a task to the echo agent
-POST {{host}}/echo/v1/tasks/sendsubscribeTaskId2/subscribe
+POST {{host}}/echo/tasks/sendsubscribeTaskId2/sendsubscribe
 Content-Type: application/json
 
 {

--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -85,8 +85,8 @@ public static class A2ARouteBuilderExtensions
         routeGroup.MapPost("/tasks/{id}/send", (string id, [FromBody] MessageSendParams sendParams, int? historyLength, string? metadata) =>
             A2AHttpProcessor.SendTaskMessage(taskManager, logger, id, sendParams, historyLength, metadata));
 
-        // /v1/tasks/{id}/sendSubscribe endpoint
-        routeGroup.MapPost("v1/tasks/{id}/subscribe", (string id, [FromBody] MessageSendParams sendParams, int? historyLength, string? metadata) =>
+        // /tasks/{id}/sendSubscribe endpoint
+        routeGroup.MapPost("/tasks/{id}/sendSubscribe", (string id, [FromBody] MessageSendParams sendParams, int? historyLength, string? metadata) =>
             A2AHttpProcessor.SendSubscribeTaskMessage(taskManager, logger, id, sendParams, historyLength, metadata));
 
         // /tasks/{id}/resubscribe endpoint

--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -83,8 +83,8 @@ public static class A2ARouteBuilderExtensions
         // /tasks/{id}/resubscribe endpoint
         routeGroup.MapPost("/tasks/{id}/resubscribe", (string id) => A2AHttpProcessor.ResubscribeTask(taskManager, logger, id));
 
-        // /tasks/{id}/pushNotification endpoint - PUT
-        routeGroup.MapPut("/tasks/{id}/pushNotification", (string id, [FromBody] PushNotificationConfig pushNotificationConfig) =>
+        // /tasks/{id}/pushNotification endpoint - POST
+        routeGroup.MapPost("/tasks/{id}/pushNotificationConfigs", (string id, [FromBody] PushNotificationConfig pushNotificationConfig) =>
             A2AHttpProcessor.SetPushNotification(taskManager, logger, id, pushNotificationConfig));
 
         // /v1/tasks/{id}/pushNotification endpoint - GET

--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -59,7 +59,8 @@ public static class A2ARouteBuilderExtensions
         var routeGroup = endpoints.MapGroup(path);
 
         // /v1/card endpoint - Agent discovery
-        routeGroup.MapGet("v1/card", async context => await A2AHttpProcessor.GetAgentCard(taskManager, logger, $"{context.Request.Scheme}://{context.Request.Host}{path}"));
+        routeGroup.MapGet("v1/card", async context => await
+            A2AHttpProcessor.GetAgentCard(taskManager, logger, $"{context.Request.Scheme}://{context.Request.Host}{path}"));
 
         // /v1/tasks/{id} endpoint
         routeGroup.MapGet("v1/tasks/{id}", (string id, [FromQuery] int? historyLength, [FromQuery] string? metadata) =>
@@ -76,19 +77,21 @@ public static class A2ARouteBuilderExtensions
         routeGroup.MapPost("/tasks/{id}/send", (string id, [FromBody] MessageSendParams sendParams, int? historyLength, string? metadata) =>
             A2AHttpProcessor.SendTaskMessage(taskManager, logger, id, sendParams, historyLength, metadata));
 
-        // /tasks/{id}/sendSubscribe endpoint
-        routeGroup.MapPost("/tasks/{id}/sendSubscribe", (string id, [FromBody] MessageSendParams sendParams, int? historyLength, string? metadata) =>
+        // /v1/tasks/{id}/sendSubscribe endpoint
+        routeGroup.MapPost("v1/tasks/{id}/subscribe", (string id, [FromBody] MessageSendParams sendParams, int? historyLength, string? metadata) =>
             A2AHttpProcessor.SendSubscribeTaskMessage(taskManager, logger, id, sendParams, historyLength, metadata));
 
         // /tasks/{id}/resubscribe endpoint
-        routeGroup.MapPost("/tasks/{id}/resubscribe", (string id) => A2AHttpProcessor.ResubscribeTask(taskManager, logger, id));
+        routeGroup.MapPost("/tasks/{id}/resubscribe", (string id) =>
+            A2AHttpProcessor.ResubscribeTask(taskManager, logger, id));
 
-        // /tasks/{id}/pushNotification endpoint - POST
-        routeGroup.MapPost("/tasks/{id}/pushNotificationConfigs", (string id, [FromBody] PushNotificationConfig pushNotificationConfig) =>
+        // /v1/tasks/{id}/pushNotificationConfigs endpoint - POST
+        routeGroup.MapPost("v1/tasks/{id}/pushNotificationConfigs", (string id, [FromBody] PushNotificationConfig pushNotificationConfig) =>
             A2AHttpProcessor.SetPushNotification(taskManager, logger, id, pushNotificationConfig));
 
-        // /v1/tasks/{id}/pushNotification endpoint - GET
-        routeGroup.MapGet("v1/tasks/{id}/pushNotificationConfigs", (string id) => A2AHttpProcessor.GetPushNotification(taskManager, logger, id));
+        // /v1/tasks/{id}/pushNotificationConfigs endpoint - GET
+        routeGroup.MapGet("v1/tasks/{id}/pushNotificationConfigs/{notificationConfigId?}", (string id, string? notificationConfigId) =>
+            A2AHttpProcessor.GetPushNotification(taskManager, logger, id, notificationConfigId));
 
         return routeGroup;
     }

--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -278,16 +278,17 @@ public static class A2AHttpProcessor
     /// </remarks>
     /// <param name="taskManager">The task manager instance for accessing push notification configurations.</param>
     /// <param name="logger">Logger instance for recording operation details and errors.</param>
-    /// <param name="id">The unique identifier of the task to get push notification configuration for.</param>
+    /// <param name="taskId">The unique identifier of the task to get push notification configuration for.</param>
+    /// <param name="notificationConfigId">The unique identifier of the push notification configuration to retrieve.</param>
     /// <returns>An HTTP result containing the push notification configuration or a not found/error response.</returns>
-    internal static async Task<IResult> GetPushNotification(TaskManager taskManager, ILogger logger, string id)
+    internal static async Task<IResult> GetPushNotification(TaskManager taskManager, ILogger logger, string taskId, string? notificationConfigId)
     {
         using var activity = ActivitySource.StartActivity("GetPushNotification", ActivityKind.Server);
-        activity?.AddTag("task.id", id);
+        activity?.AddTag("task.id", taskId);
 
         try
         {
-            var taskIdParams = new TaskIdParams { Id = id };
+            var taskIdParams = new GetTaskPushNotificationConfigParams { Id = taskId, PushNotificationConfigId = notificationConfigId };
             var result = await taskManager.GetPushNotificationAsync(taskIdParams);
 
             if (result == null)

--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -122,13 +122,13 @@ public static class A2AJsonRpcProcessor
                 response = JsonRpcResponse.CreateJsonRpcResponse(requestId, setConfig);
                 break;
             case A2AMethods.TaskPushNotificationConfigGet:
-                var taskIdParamsGetConfig = (TaskIdParams?)parameters.Value.Deserialize(A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(TaskIdParams))!);
-                if (taskIdParamsGetConfig == null)
+                var notificationConfigParams = (GetTaskPushNotificationConfigParams?)parameters.Value.Deserialize(A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(GetTaskPushNotificationConfigParams))!);
+                if (notificationConfigParams == null)
                 {
                     response = JsonRpcResponse.InvalidParamsResponse(requestId);
                     break;
                 }
-                var getConfig = await taskManager.GetPushNotificationAsync(taskIdParamsGetConfig);
+                var getConfig = await taskManager.GetPushNotificationAsync(notificationConfigParams);
                 response = JsonRpcResponse.CreateJsonRpcResponse(requestId, getConfig);
                 break;
             default:

--- a/src/A2A/A2AJsonUtilities.cs
+++ b/src/A2A/A2AJsonUtilities.cs
@@ -44,6 +44,7 @@ public static partial class A2AJsonUtilities
     [JsonSerializable(typeof(A2AResponse))]
     [JsonSerializable(typeof(AgentCard))]
     [JsonSerializable(typeof(AgentTask))]
+    [JsonSerializable(typeof(GetTaskPushNotificationConfigParams))]
     [JsonSerializable(typeof(MessageSendParams))]
     [JsonSerializable(typeof(TaskIdParams))]
     [JsonSerializable(typeof(TaskPushNotificationConfig))]

--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -62,7 +62,7 @@ public sealed class A2AClient : IA2AClient
     /// <inheritdoc />
     public Task<TaskPushNotificationConfig> GetPushNotificationAsync(GetTaskPushNotificationConfigParams notificationConfigParams, CancellationToken cancellationToken = default) =>
         SendRpcRequestAsync(
-            notificationConfigParams,
+            notificationConfigParams ?? throw new ArgumentNullException(nameof(notificationConfigParams)),
             A2AMethods.TaskPushNotificationConfigGet,
             A2AJsonUtilities.JsonContext.Default.GetTaskPushNotificationConfigParams,
             A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig,

--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -60,11 +60,11 @@ public sealed class A2AClient : IA2AClient
             cancellationToken);
 
     /// <inheritdoc />
-    public Task<TaskPushNotificationConfig> GetPushNotificationAsync(TaskIdParams taskIdParams, CancellationToken cancellationToken = default) =>
+    public Task<TaskPushNotificationConfig> GetPushNotificationAsync(GetTaskPushNotificationConfigParams notificationConfigParams, CancellationToken cancellationToken = default) =>
         SendRpcRequestAsync(
-            taskIdParams,
+            notificationConfigParams,
             A2AMethods.TaskPushNotificationConfigGet,
-            A2AJsonUtilities.JsonContext.Default.TaskIdParams,
+            A2AJsonUtilities.JsonContext.Default.GetTaskPushNotificationConfigParams,
             A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig,
             cancellationToken);
 

--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -54,7 +54,7 @@ public sealed class A2AClient : IA2AClient
     public Task<TaskPushNotificationConfig> SetPushNotificationAsync(TaskPushNotificationConfig pushNotificationConfig, CancellationToken cancellationToken = default) =>
         SendRpcRequestAsync(
             pushNotificationConfig,
-            "task/pushNotification/set",
+            A2AMethods.TaskPushNotificationConfigSet,
             A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig,
             A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig,
             cancellationToken);
@@ -63,7 +63,7 @@ public sealed class A2AClient : IA2AClient
     public Task<TaskPushNotificationConfig> GetPushNotificationAsync(TaskIdParams taskIdParams, CancellationToken cancellationToken = default) =>
         SendRpcRequestAsync(
             taskIdParams,
-            "task/pushNotification/get",
+            A2AMethods.TaskPushNotificationConfigGet,
             A2AJsonUtilities.JsonContext.Default.TaskIdParams,
             A2AJsonUtilities.JsonContext.Default.TaskPushNotificationConfig,
             cancellationToken);

--- a/src/A2A/Client/IA2AClient.cs
+++ b/src/A2A/Client/IA2AClient.cs
@@ -61,8 +61,8 @@ public interface IA2AClient
     /// <summary>
     /// Retrieves the push notification configuration for a specific task.
     /// </summary>
-    /// <param name="taskIdParams">Parameters containing the task ID.</param>
+    /// <param name="notificationConfigParams">Parameters containing the task ID and optional push notification config ID.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>The push notification configuration for the specified task.</returns>
-    Task<TaskPushNotificationConfig> GetPushNotificationAsync(TaskIdParams taskIdParams, CancellationToken cancellationToken = default);
+    Task<TaskPushNotificationConfig> GetPushNotificationAsync(GetTaskPushNotificationConfigParams notificationConfigParams, CancellationToken cancellationToken = default);
 }

--- a/src/A2A/JsonRpc/A2AMethods.cs
+++ b/src/A2A/JsonRpc/A2AMethods.cs
@@ -33,12 +33,12 @@ public static class A2AMethods
     /// <summary>
     /// Method for setting push notification configuration.
     /// </summary>
-    public const string TaskPushNotificationConfigSet = "tasks/pushnotificationconfig/set";
+    public const string TaskPushNotificationConfigSet = "tasks/pushNotificationConfig/set";
 
     /// <summary>
     /// Method for getting push notification configuration.
     /// </summary>
-    public const string TaskPushNotificationConfigGet = "tasks/pushnotificationconfig/get";
+    public const string TaskPushNotificationConfigGet = "tasks/pushNotificationConfig/get";
 
     /// <summary>
     /// Determines if a method requires streaming response handling.

--- a/src/A2A/Models/GetTaskPushNotificationConfigParams.cs
+++ b/src/A2A/Models/GetTaskPushNotificationConfigParams.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace A2A;
+
+/// <summary>
+/// Parameters for fetching a pushNotificationConfiguration associated with a Task.
+/// </summary>
+public sealed class GetTaskPushNotificationConfigParams
+{
+    /// <summary>
+    /// Task id.
+    /// </summary>
+    [JsonPropertyName("id")]
+    [JsonRequired]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Extension metadata.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, JsonElement>? Metadata { get; set; }
+
+    /// <summary>
+    /// Optional push notification configuration ID to retrieve a specific configuration.
+    /// </summary>
+    [JsonPropertyName("pushNotificationConfigId")]
+    public string? PushNotificationConfigId { get; set; }
+}

--- a/src/A2A/Models/PushNotificationAuthenticationInfo.cs
+++ b/src/A2A/Models/PushNotificationAuthenticationInfo.cs
@@ -5,7 +5,7 @@ namespace A2A;
 /// <summary>
 /// Defines authentication details for push notifications.
 /// </summary>
-public sealed class AuthenticationInfo
+public sealed class PushNotificationAuthenticationInfo
 {
     /// <summary>
     /// Supported authentication schemes - e.g. Basic, Bearer.

--- a/src/A2A/Models/PushNotificationConfig.cs
+++ b/src/A2A/Models/PushNotificationConfig.cs
@@ -15,6 +15,12 @@ public sealed class PushNotificationConfig
     public string Url { get; set; } = string.Empty;
 
     /// <summary>
+    /// Optional server-generated identifier for the push notification configuration to support multiple callbacks.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>
     /// Token unique to this task/session.
     /// </summary>
     [JsonPropertyName("token")]
@@ -24,5 +30,5 @@ public sealed class PushNotificationConfig
     /// Authentication details for push notifications.
     /// </summary>
     [JsonPropertyName("authentication")]
-    public AuthenticationInfo? Authentication { get; set; }
+    public PushNotificationAuthenticationInfo? Authentication { get; set; }
 }

--- a/src/A2A/Server/ITaskStore.cs
+++ b/src/A2A/Server/ITaskStore.cs
@@ -16,8 +16,9 @@ public interface ITaskStore
     /// Retrieves push notification configuration for a task.
     /// </summary>
     /// <param name="taskId">The ID of the task.</param>
+    /// <param name="notificationConfigId">The ID of the push notification configuration.</param>
     /// <returns>The push notification configuration if found, null otherwise.</returns>
-    Task<TaskPushNotificationConfig?> GetPushNotificationAsync(string taskId);
+    Task<TaskPushNotificationConfig?> GetPushNotificationAsync(string taskId, string notificationConfigId);
 
     /// <summary>
     /// Updates the status of a task.
@@ -41,4 +42,11 @@ public interface ITaskStore
     /// <param name="pushNotificationConfig">The push notification configuration.</param>
     /// <returns>A task representing the operation.</returns>
     Task SetPushNotificationConfigAsync(TaskPushNotificationConfig pushNotificationConfig);
+
+    /// <summary>
+    /// Retrieves push notifications for a task.
+    /// </summary>
+    /// <param name="taskId">The ID of the task.</param>
+    /// <returns>A list of push notification configurations for the task.</returns>
+    Task<IEnumerable<TaskPushNotificationConfig>> GetPushNotificationsAsync(string taskId);
 }

--- a/src/A2A/Server/TaskManager.cs
+++ b/src/A2A/Server/TaskManager.cs
@@ -337,7 +337,7 @@ public sealed class TaskManager : ITaskManager
         if (task == null)
         {
             activity?.SetTag("task.found", false);
-            throw new ArgumentException("Task not found or invalid TaskIdParams.");
+            throw new ArgumentException($"Task with {notificationConfigParams.Id} not found.");
         }
 
         TaskPushNotificationConfig? pushNotificationConfig = null;

--- a/src/A2A/Server/TaskManager.cs
+++ b/src/A2A/Server/TaskManager.cs
@@ -320,19 +320,39 @@ public sealed class TaskManager : ITaskManager
     /// <remarks>
     /// Returns the callback URL and authentication settings configured for receiving task update notifications.
     /// </remarks>
-    /// <param name="taskIdParams">Parameters containing the task ID to get push notification configuration for.</param>
+    /// <param name="notificationConfigParams">Parameters containing the task ID and optional push notification config ID.</param>
     /// <returns>The push notification configuration if found, null otherwise.</returns>
-    public async Task<TaskPushNotificationConfig?> GetPushNotificationAsync(TaskIdParams? taskIdParams)
+    public async Task<TaskPushNotificationConfig?> GetPushNotificationAsync(GetTaskPushNotificationConfigParams? notificationConfigParams)
     {
-        if (taskIdParams == null)
+        if (notificationConfigParams == null)
         {
-            throw new ArgumentNullException(nameof(taskIdParams), "TaskIdParams cannot be null.");
+            throw new ArgumentNullException(nameof(notificationConfigParams), "GetTaskPushNotificationConfigParams cannot be null.");
         }
 
         using var activity = ActivitySource.StartActivity("GetPushNotification", ActivityKind.Server);
-        activity?.SetTag("task.id", taskIdParams.Id);
+        activity?.SetTag("task.id", notificationConfigParams.Id);
+        activity?.SetTag("push.config.id", notificationConfigParams.PushNotificationConfigId);
 
-        var pushNotificationConfig = await _taskStore.GetPushNotificationAsync(taskIdParams.Id);
+        var task = await _taskStore.GetTaskAsync(notificationConfigParams.Id);
+        if (task == null)
+        {
+            activity?.SetTag("task.found", false);
+            throw new ArgumentException("Task not found or invalid TaskIdParams.");
+        }
+
+        TaskPushNotificationConfig? pushNotificationConfig = null;
+
+        if (!string.IsNullOrEmpty(notificationConfigParams.PushNotificationConfigId))
+        {
+            pushNotificationConfig = await _taskStore.GetPushNotificationAsync(notificationConfigParams.Id, notificationConfigParams.PushNotificationConfigId!);
+        }
+        else
+        {
+            var pushNotificationConfigs = await _taskStore.GetPushNotificationsAsync(notificationConfigParams.Id);
+
+            pushNotificationConfig = pushNotificationConfigs.FirstOrDefault();
+        }
+
         activity?.SetTag("config.found", pushNotificationConfig != null);
         return pushNotificationConfig;
     }

--- a/tests/A2A.AspNetCore.UnitTests/ClientTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/ClientTests.cs
@@ -113,8 +113,9 @@ public class ClientTests : IClassFixture<JsonSchemaFixture>
                         PushNotificationConfig = new PushNotificationConfig
                         {
                             Url = "http://example.org/notify",
+                            Id = "response-config-id",
                             Token = "test-token",
-                            Authentication = new AuthenticationInfo
+                            Authentication = new PushNotificationAuthenticationInfo
                             {
                                 Schemes = ["Bearer"]
                             }
@@ -139,8 +140,9 @@ public class ClientTests : IClassFixture<JsonSchemaFixture>
             PushNotificationConfig = new PushNotificationConfig()
             {
                 Url = "http://example.org/notify",
+                Id = "request-config-id",
                 Token = "test-token",
-                Authentication = new AuthenticationInfo()
+                Authentication = new PushNotificationAuthenticationInfo()
                 {
                     Schemes = ["Bearer"],
                 }

--- a/tests/A2A.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.UnitTests/Client/A2AClientTests.cs
@@ -240,8 +240,9 @@ public class A2AClientTests
             PushNotificationConfig = new PushNotificationConfig
             {
                 Url = "http://push-url",
+                Id = "push-config-123",
                 Token = "tok",
-                Authentication = new AuthenticationInfo
+                Authentication = new PushNotificationAuthenticationInfo
                 {
                     Schemes = ["Bearer"],
                 }
@@ -255,13 +256,14 @@ public class A2AClientTests
         Assert.NotNull(capturedRequest);
 
         var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
-        Assert.Equal("task/pushNotification/set", requestJson.RootElement.GetProperty("method").GetString());
+        Assert.Equal("tasks/pushNotificationConfig/set", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
         var parameters = requestJson.RootElement.GetProperty("params").Deserialize<TaskPushNotificationConfig>();
         Assert.NotNull(parameters);
         Assert.Equal(pushConfig.TaskId, parameters.TaskId);
         Assert.Equal(pushConfig.PushNotificationConfig.Url, parameters.PushNotificationConfig.Url);
+        Assert.Equal(pushConfig.PushNotificationConfig.Id, parameters.PushNotificationConfig.Id);
         Assert.Equal(pushConfig.PushNotificationConfig.Token, parameters.PushNotificationConfig.Token);
         Assert.Equal(pushConfig.PushNotificationConfig.Authentication!.Schemes, parameters.PushNotificationConfig.Authentication!.Schemes);
     }
@@ -276,8 +278,9 @@ public class A2AClientTests
             PushNotificationConfig = new PushNotificationConfig
             {
                 Url = "http://push-url",
+                Id = "push-config-456",
                 Token = "tok",
-                Authentication = new AuthenticationInfo
+                Authentication = new PushNotificationAuthenticationInfo
                 {
                     Schemes = ["Bearer"],
                 }
@@ -320,7 +323,7 @@ public class A2AClientTests
         Assert.NotNull(capturedRequest);
 
         var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
-        Assert.Equal("task/pushNotification/get", requestJson.RootElement.GetProperty("method").GetString());
+        Assert.Equal("tasks/pushNotificationConfig/get", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
         var parameters = requestJson.RootElement.GetProperty("params").Deserialize<TaskIdParams>();
@@ -340,7 +343,7 @@ public class A2AClientTests
             {
                 Url = "http://push-url2",
                 Token = "tok2",
-                Authentication = new AuthenticationInfo
+                Authentication = new PushNotificationAuthenticationInfo
                 {
                     Schemes = ["Bearer"]
                 }

--- a/tests/A2A.UnitTests/Server/InMemoryTaskStoreTests.cs
+++ b/tests/A2A.UnitTests/Server/InMemoryTaskStoreTests.cs
@@ -62,20 +62,16 @@ public class InMemoryTaskStoreTests
     }
 
     [Fact]
-    public async Task SetPushNotificationConfigAsync_And_GetPushNotificationAsync_ShouldStoreAndRetrieveConfig()
+    public async Task GetPushNotificationAsync_ShouldReturnNull_WhenTaskDoesNotExist()
     {
         // Arrange
         var sut = new InMemoryTaskStore();
-        var config = new TaskPushNotificationConfig { TaskId = "task3", PushNotificationConfig = new PushNotificationConfig { Url = "http://test" } };
 
         // Act
-        await sut.SetPushNotificationConfigAsync(config);
-        var result = await sut.GetPushNotificationAsync("task3");
+        var result = await sut.GetPushNotificationAsync("missing", "config-missing");
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal("task3", result!.TaskId);
-        Assert.Equal("http://test", result.PushNotificationConfig.Url);
+        Assert.Null(result);
     }
 
     [Fact]
@@ -84,10 +80,99 @@ public class InMemoryTaskStoreTests
         // Arrange
         var sut = new InMemoryTaskStore();
 
+        await sut.SetPushNotificationConfigAsync(new TaskPushNotificationConfig { TaskId = "task-id", PushNotificationConfig = new() { Id = "config-id" } });
+
         // Act
-        var result = await sut.GetPushNotificationAsync("missing");
+        var result = await sut.GetPushNotificationAsync("missing", "config-missing");
 
         // Assert
         Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetPushNotificationAsync_ShouldReturnCorrectConfig_WhenMultipleConfigsExistForSameTask()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+        var taskId = "task-with-multiple-configs";
+
+        var config1 = new TaskPushNotificationConfig
+        {
+            TaskId = taskId,
+            PushNotificationConfig = new PushNotificationConfig
+            {
+                Url = "http://config1",
+                Id = "config-id-1",
+                Token = "token1"
+            }
+        };
+
+        var config2 = new TaskPushNotificationConfig
+        {
+            TaskId = taskId,
+            PushNotificationConfig = new PushNotificationConfig
+            {
+                Url = "http://config2",
+                Id = "config-id-2",
+                Token = "token2"
+            }
+        };
+
+        var config3 = new TaskPushNotificationConfig
+        {
+            TaskId = taskId,
+            PushNotificationConfig = new PushNotificationConfig
+            {
+                Url = "http://config3",
+                Id = "config-id-3",
+                Token = "token3"
+            }
+        };
+
+        // Act - Store multiple configs for the same task
+        await sut.SetPushNotificationConfigAsync(config1);
+        await sut.SetPushNotificationConfigAsync(config2);
+        await sut.SetPushNotificationConfigAsync(config3);
+
+        // Get specific configs by both taskId and notificationConfigId
+        var result1 = await sut.GetPushNotificationAsync(taskId, "config-id-1");
+        var result2 = await sut.GetPushNotificationAsync(taskId, "config-id-2");
+        var result3 = await sut.GetPushNotificationAsync(taskId, "config-id-3");
+        var resultNotFound = await sut.GetPushNotificationAsync(taskId, "non-existent-config");
+
+        // Assert - Verify each call returns the correct specific config
+        Assert.NotNull(result1);
+        Assert.Equal(taskId, result1!.TaskId);
+        Assert.Equal("config-id-1", result1.PushNotificationConfig.Id);
+        Assert.Equal("http://config1", result1.PushNotificationConfig.Url);
+        Assert.Equal("token1", result1.PushNotificationConfig.Token);
+
+        Assert.NotNull(result2);
+        Assert.Equal(taskId, result2!.TaskId);
+        Assert.Equal("config-id-2", result2.PushNotificationConfig.Id);
+        Assert.Equal("http://config2", result2.PushNotificationConfig.Url);
+        Assert.Equal("token2", result2.PushNotificationConfig.Token);
+
+        Assert.NotNull(result3);
+        Assert.Equal(taskId, result3!.TaskId);
+        Assert.Equal("config-id-3", result3.PushNotificationConfig.Id);
+        Assert.Equal("http://config3", result3.PushNotificationConfig.Url);
+        Assert.Equal("token3", result3.PushNotificationConfig.Token);
+
+        Assert.Null(resultNotFound);
+    }
+
+    [Fact]
+    public async Task GetPushNotificationsAsync_ShouldReturnEmptyList_WhenNoConfigsExistForTask()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+
+        // Act
+        var result = await sut.GetPushNotificationsAsync("task-without-configs");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
     }
 }

--- a/tests/A2A.UnitTests/Server/InMemoryTaskStoreTests.cs
+++ b/tests/A2A.UnitTests/Server/InMemoryTaskStoreTests.cs
@@ -83,7 +83,7 @@ public class InMemoryTaskStoreTests
         await sut.SetPushNotificationConfigAsync(new TaskPushNotificationConfig { TaskId = "task-id", PushNotificationConfig = new() { Id = "config-id" } });
 
         // Act
-        var result = await sut.GetPushNotificationAsync("missing", "config-missing");
+        var result = await sut.GetPushNotificationAsync("task-id", "config-missing");
 
         // Assert
         Assert.Null(result);

--- a/tests/A2A.UnitTests/Server/TaskManagerTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskManagerTests.cs
@@ -360,19 +360,23 @@ public class TaskManagerTests
     {
         // Arrange
         var sut = new TaskManager();
+
+        // Create the task first
+        var task = await sut.CreateTaskAsync();
+
         var config = new TaskPushNotificationConfig
         {
-            TaskId = "task-push-2",
+            TaskId = task.Id,
             PushNotificationConfig = new PushNotificationConfig { Url = "http://callback2" }
         };
         await sut.SetPushNotificationAsync(config);
 
         // Act
-        var result = await sut.GetPushNotificationAsync(new TaskIdParams { Id = "task-push-2" });
+        var result = await sut.GetPushNotificationAsync(new GetTaskPushNotificationConfigParams { Id = task.Id });
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal("task-push-2", result.TaskId);
+        Assert.Equal(task.Id, result.TaskId);
         Assert.Equal("http://callback2", result.PushNotificationConfig.Url);
     }
 
@@ -428,5 +432,62 @@ public class TaskManagerTests
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => sut.ResubscribeAsync(null));
+    }
+
+    [Fact]
+    public async Task GetPushNotificationAsync_ReturnsFirstConfig_WhenMultipleConfigsExistAndNoConfigIdSpecified()
+    {
+        // Arrange
+        var sut = new TaskManager();
+        var task = await sut.CreateTaskAsync();
+
+        // Create multiple push notification configs for the same task
+        var config1 = new TaskPushNotificationConfig
+        {
+            TaskId = task.Id,
+            PushNotificationConfig = new PushNotificationConfig
+            {
+                Id = "config-id-1",
+                Url = "http://first-config",
+                Token = "token1"
+            }
+        };
+
+        var config2 = new TaskPushNotificationConfig
+        {
+            TaskId = task.Id,
+            PushNotificationConfig = new PushNotificationConfig
+            {
+                Id = "config-id-2",
+                Url = "http://second-config",
+                Token = "token2"
+            }
+        };
+
+        var config3 = new TaskPushNotificationConfig
+        {
+            TaskId = task.Id,
+            PushNotificationConfig = new PushNotificationConfig
+            {
+                Id = "config-id-3",
+                Url = "http://third-config",
+                Token = "token3"
+            }
+        };
+
+        // Set all configs
+        await sut.SetPushNotificationAsync(config1);
+        await sut.SetPushNotificationAsync(config2);
+        await sut.SetPushNotificationAsync(config3);
+
+        // Act - Get push notification without specifying a config ID (should return first one)
+        var result = await sut.GetPushNotificationAsync(new GetTaskPushNotificationConfigParams { Id = task.Id });
+
+        // Assert - Should return the first config that was added
+        Assert.NotNull(result);
+        Assert.Equal(task.Id, result.TaskId);
+        Assert.Equal("config-id-1", result.PushNotificationConfig.Id);
+        Assert.Equal("http://first-config", result.PushNotificationConfig.Url);
+        Assert.Equal("token1", result.PushNotificationConfig.Token);
     }
 }


### PR DESCRIPTION
This PR:
- Aligns http routes with those specified in https://github.com/a2aproject/A2A/blob/main/specification/grpc/a2a.proto.
- Introduces a new model class, `GetTaskPushNotificationConfigParams`, which replaces the deprecated `TaskIdParams` for obtaining task push notifications.
- Renames the `AuthenticationInfo` class to `PushNotificationAuthenticationInfo` to conform with the naming conventions in the A2A specification.
- Adds an `Id` property to the `PushNotificationConfig` class to uniquely identify each task push notification configuration among other configurations.
- Updates the task store to retrieve a list of push notification configurations by task id and return the specific push notification configuration based on both task id and push notification configuration id.

Contributes to: https://github.com/a2aproject/a2a-dotnet/issues/9

Out of scope: Support for listing and deleting task push notification configurations.