### PR TITLE
fix: Client error 405 Method Not Allowed when discover the agent card

### DIFF
--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -38,7 +38,7 @@ public static class A2ARouteBuilderExtensions
 
         routeGroup.MapGet($"{path}/.well-known/agent.json", (HttpRequest request) =>
         {
-            var agentUrl = $"{request.Scheme}://{request.Host}{request.Path}";
+            var agentUrl = $"{request.Scheme}://{request.Host}{path}";
             var agentCard = taskManager.OnAgentCardQuery(agentUrl);
             return Results.Ok(agentCard);
         });


### PR DESCRIPTION

After checking the [`A2A Inspector`](https://github.com/a2aproject/a2a-inspector), I found out the issue was due to a mistake in the .NET code for discovering the host URL (with subpath) instead of `/.well-known/agent.json`. Check the official Agent URL in the picture below.

<img width="816" height="852" alt="image" src="https://github.com/user-attachments/assets/e097a52f-3f79-48f9-9ea9-e9ee6ccde86d" />

I did a fix and it works correctly. This PR also fix the issue at https://github.com/a2aproject/a2a-dotnet/issues/47