### PR TITLE
Fix: capability issues

### DIFF
--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -171,17 +171,9 @@ public static class A2AJsonRpcProcessor
                 var taskEvents = taskManager.SubscribeToTaskAsync(taskIdParams);
                 return new JsonRpcStreamedResult(taskEvents, requestId);
             case A2AMethods.MessageStream:
-                try
-                {
-                    var taskSendParams = DeserializeOrThrow<MessageSendParams>(parameters.Value);
-                    var sendEvents = await taskManager.SendMessageStreamAsync(taskSendParams);
-                    return new JsonRpcStreamedResult(sendEvents, requestId);
-                }
-                catch (Exception ex)
-                {
-                    activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                    return new JsonRpcResponseResult(JsonRpcResponse.InternalErrorResponse(requestId, ex.Message));
-                }
+                var taskSendParams = DeserializeOrThrow<MessageSendParams>(parameters.Value);
+                var sendEvents = await taskManager.SendMessageStreamAsync(taskSendParams);
+                return new JsonRpcStreamedResult(sendEvents, requestId);
             default:
                 activity?.SetStatus(ActivityStatusCode.Error, "Invalid method");
                 return new JsonRpcResponseResult(JsonRpcResponse.MethodNotFoundResponse(requestId));

--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using System.Diagnostics;
 using System.Text.Json;
 
@@ -28,6 +29,7 @@ public static class A2AJsonRpcProcessor
     /// <param name="taskManager">The task manager instance for handling A2A operations.</param>
     /// <param name="request">Http request containing the JSON-RPC request body.</param>
     /// <returns>An HTTP result containing either a single JSON-RPC response or a streaming SSE response.</returns>
+    [Produces("text/event-stream")]
     internal static async Task<IResult> ProcessRequest(ITaskManager taskManager, HttpRequest request)
     {
         using var activity = ActivitySource.StartActivity("HandleA2ARequest", ActivityKind.Server);
@@ -90,29 +92,29 @@ public static class A2AJsonRpcProcessor
         switch (method)
         {
             case A2AMethods.MessageSend:
-                var taskSendParams = DeserializeOrThrow<MessageSendParams>();
+                var taskSendParams = DeserializeOrThrow<MessageSendParams>(parameters.Value);
                 var a2aResponse = await taskManager.SendMessageAsync(taskSendParams);
                 response = JsonRpcResponse.CreateJsonRpcResponse(requestId, a2aResponse);
                 break;
             case A2AMethods.TaskGet:
-                var taskIdParams = DeserializeOrThrow<TaskQueryParams>();
+                var taskIdParams = DeserializeOrThrow<TaskQueryParams>(parameters.Value);
                 var getAgentTask = await taskManager.GetTaskAsync(taskIdParams);
                 response = getAgentTask is null
                     ? JsonRpcResponse.TaskNotFoundResponse(requestId)
                     : JsonRpcResponse.CreateJsonRpcResponse(requestId, getAgentTask);
                 break;
             case A2AMethods.TaskCancel:
-                var taskIdParamsCancel = DeserializeOrThrow<TaskIdParams>();
+                var taskIdParamsCancel = DeserializeOrThrow<TaskIdParams>(parameters.Value);
                 var cancelledTask = await taskManager.CancelTaskAsync(taskIdParamsCancel);
                 response = JsonRpcResponse.CreateJsonRpcResponse(requestId, cancelledTask);
                 break;
             case A2AMethods.TaskPushNotificationConfigSet:
-                var taskPushNotificationConfig = DeserializeOrThrow<TaskPushNotificationConfig>();
+                var taskPushNotificationConfig = DeserializeOrThrow<TaskPushNotificationConfig>(parameters.Value);
                 var setConfig = await taskManager.SetPushNotificationAsync(taskPushNotificationConfig);
                 response = JsonRpcResponse.CreateJsonRpcResponse(requestId, setConfig);
                 break;
             case A2AMethods.TaskPushNotificationConfigGet:
-                var notificationConfigParams = DeserializeOrThrow<GetTaskPushNotificationConfigParams>();
+                var notificationConfigParams = DeserializeOrThrow<GetTaskPushNotificationConfigParams>(parameters.Value);
                 var getConfig = await taskManager.GetPushNotificationAsync(notificationConfigParams);
                 response = JsonRpcResponse.CreateJsonRpcResponse(requestId, getConfig);
                 break;
@@ -121,22 +123,22 @@ public static class A2AJsonRpcProcessor
                 break;
         }
 
-        T DeserializeOrThrow<T>() where T : class
-        {
-            T? parms;
-            try
-            {
-                parms = parameters.Value.Deserialize(A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(T))) as T;
-            }
-            catch (JsonException)
-            {
-                parms = null;
-            }
+        return new JsonRpcResponseResult(response);
+    }
 
-            return parms ?? throw new A2AException("Invalid parameters", A2AErrorCode.InvalidParams);
+    private static T DeserializeOrThrow<T>(JsonElement? jsonParamValue) where T : class
+    {
+        T? parms;
+        try
+        {
+            parms = jsonParamValue?.Deserialize(A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(T))) as T;
+        }
+        catch (JsonException)
+        {
+            parms = null;
         }
 
-        return new JsonRpcResponseResult(response);
+        return parms ?? throw new A2AException("Invalid parameters", A2AErrorCode.InvalidParams);
     }
 
     /// <summary>
@@ -164,26 +166,14 @@ public static class A2AJsonRpcProcessor
 
         switch (method)
         {
-            case A2AMethods.TaskResubscribe:
-                var taskIdParams = (TaskIdParams?)parameters.Value.Deserialize(A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(TaskIdParams)));
-                if (taskIdParams == null)
-                {
-                    activity?.SetStatus(ActivityStatusCode.Error, "Invalid parameters");
-                    return new JsonRpcResponseResult(JsonRpcResponse.InvalidParamsResponse(requestId));
-                }
-
+            case A2AMethods.TaskSubscribe:
+                var taskIdParams = DeserializeOrThrow<TaskIdParams>(parameters.Value);
                 var taskEvents = taskManager.SubscribeToTaskAsync(taskIdParams);
                 return new JsonRpcStreamedResult(taskEvents, requestId);
             case A2AMethods.MessageStream:
                 try
                 {
-                    var taskSendParams = (MessageSendParams?)parameters.Value.Deserialize(A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(MessageSendParams)));
-                    if (taskSendParams == null)
-                    {
-                        activity?.SetStatus(ActivityStatusCode.Error, "Invalid parameters");
-                        return new JsonRpcResponseResult(JsonRpcResponse.InvalidParamsResponse(requestId));
-                    }
-
+                    var taskSendParams = DeserializeOrThrow<MessageSendParams>(parameters.Value);
                     var sendEvents = await taskManager.SendMessageStreamAsync(taskSendParams);
                     return new JsonRpcStreamedResult(sendEvents, requestId);
                 }

--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -78,10 +78,10 @@ public sealed class A2AClient : IA2AClient
             cancellationToken);
 
     /// <inheritdoc />
-    public IAsyncEnumerable<SseItem<A2AEvent>> ResubscribeToTaskAsync(string taskId, CancellationToken cancellationToken = default) =>
+    public IAsyncEnumerable<SseItem<A2AEvent>> SubscribeToTaskAsync(string taskId, CancellationToken cancellationToken = default) =>
         SendRpcSseRequestAsync(
             new() { Id = string.IsNullOrEmpty(taskId) ? throw new ArgumentNullException(nameof(taskId)) : taskId },
-            A2AMethods.TaskResubscribe,
+            A2AMethods.TaskSubscribe,
             A2AJsonUtilities.JsonContext.Default.TaskIdParams,
             A2AJsonUtilities.JsonContext.Default.A2AEvent,
             cancellationToken);

--- a/src/A2A/Client/IA2AClient.cs
+++ b/src/A2A/Client/IA2AClient.cs
@@ -48,7 +48,7 @@ public interface IA2AClient
     /// <param name="taskId">The ID of the task to resubscribe to.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>An async enumerable of server-sent events containing task updates.</returns>
-    IAsyncEnumerable<SseItem<A2AEvent>> ResubscribeToTaskAsync(string taskId, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<SseItem<A2AEvent>> SubscribeToTaskAsync(string taskId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sets or updates the push notification configuration for a specific task.

--- a/src/A2A/JsonRpc/A2AMethods.cs
+++ b/src/A2A/JsonRpc/A2AMethods.cs
@@ -28,7 +28,7 @@ public static class A2AMethods
     /// <summary>
     /// Method for resubscribing to task updates.
     /// </summary>
-    public const string TaskResubscribe = "tasks/resubscribe";
+    public const string TaskSubscribe = "tasks/subscribe";
 
     /// <summary>
     /// Method for setting push notification configuration.
@@ -45,12 +45,12 @@ public static class A2AMethods
     /// </summary>
     /// <param name="method">The method name to check.</param>
     /// <returns>True if the method requires streaming, false otherwise.</returns>
-    public static bool IsStreamingMethod(string method) => method is MessageStream or TaskResubscribe;
+    public static bool IsStreamingMethod(string method) => method is MessageStream or TaskSubscribe;
 
     /// <summary>
     /// Determines if a method name is valid for A2A JSON-RPC.
     /// </summary>
     /// <param name="method">The method name to validate.</param>
     /// <returns>True if the method is valid, false otherwise.</returns>
-    public static bool IsValidMethod(string method) => method is MessageSend or MessageStream or TaskGet or TaskCancel or TaskResubscribe or TaskPushNotificationConfigSet or TaskPushNotificationConfigGet;
+    public static bool IsValidMethod(string method) => method is MessageSend or MessageStream or TaskGet or TaskCancel or TaskSubscribe or TaskPushNotificationConfigSet or TaskPushNotificationConfigGet;
 }

--- a/src/A2A/Models/AgentCapabilities.cs
+++ b/src/A2A/Models/AgentCapabilities.cs
@@ -29,5 +29,5 @@ public sealed class AgentCapabilities
     /// Extensions supported by this agent.
     /// </summary>
     [JsonPropertyName("extensions")]
-    public List<AgentExtension>? Extensions { get; set; }
+    public List<AgentExtension> Extensions { get; set; } = [];
 }

--- a/src/A2A/Models/AgentCard.cs
+++ b/src/A2A/Models/AgentCard.cs
@@ -133,7 +133,7 @@ public sealed class AgentCard
     /// The client can use any of the supported transports.
     /// </remarks>
     [JsonPropertyName("additionalInterfaces")]
-    public List<AgentInterface>? AdditionalInterfaces { get; set; }
+    public List<AgentInterface> AdditionalInterfaces { get; set; } = [];
 
     /// <summary>
     /// The transport of the preferred endpoint.

--- a/tests/A2A.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.UnitTests/Client/A2AClientTests.cs
@@ -516,7 +516,7 @@ public class A2AClientTests
         var taskId = "task-123";
 
         // Act
-        await foreach (var _ in sut.ResubscribeToTaskAsync(taskId))
+        await foreach (var _ in sut.SubscribeToTaskAsync(taskId))
         {
             break; // Only need to trigger the request
         }
@@ -525,7 +525,7 @@ public class A2AClientTests
         Assert.NotNull(capturedRequest);
 
         var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
-        Assert.Equal("tasks/resubscribe", requestJson.RootElement.GetProperty("method").GetString());
+        Assert.Equal("tasks/subscribe", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
         var parameters = requestJson.RootElement.GetProperty("params").Deserialize<TaskIdParams>();
@@ -556,7 +556,7 @@ public class A2AClientTests
 
         // Act
         SseItem<A2AEvent>? result = null;
-        await foreach (var item in sut.ResubscribeToTaskAsync("task-123"))
+        await foreach (var item in sut.SubscribeToTaskAsync("task-123"))
         {
             result = item;
             break;

--- a/tests/A2A.UnitTests/JsonRpc/A2AMethodsTests.cs
+++ b/tests/A2A.UnitTests/JsonRpc/A2AMethodsTests.cs
@@ -21,7 +21,7 @@ public class A2AMethodsTests
     public void IsStreamingMethod_ReturnsTrue_ForTaskResubscribe()
     {
         // Arrange
-        var method = A2AMethods.TaskResubscribe;
+        var method = A2AMethods.TaskSubscribe;
 
         // Act
         var result = A2AMethods.IsStreamingMethod(method);

--- a/tests/A2A.UnitTests/JsonRpc/JsonRpcRequestConverterTests.cs
+++ b/tests/A2A.UnitTests/JsonRpc/JsonRpcRequestConverterTests.cs
@@ -120,7 +120,7 @@ public class JsonRpcRequestConverterTests
     [InlineData("message/stream")]
     [InlineData("tasks/get")]
     [InlineData("tasks/cancel")]
-    [InlineData("tasks/resubscribe")]
+    [InlineData("tasks/subscribe")]
     [InlineData("tasks/pushNotificationConfig/set")]
     [InlineData("tasks/pushNotificationConfig/get")]
     public void Read_ValidMethods_ReturnsCorrectMethod(string method)
@@ -464,7 +464,7 @@ public class JsonRpcRequestConverterTests
     [InlineData("message/stream")]
     [InlineData("tasks/get")]
     [InlineData("tasks/cancel")]
-    [InlineData("tasks/resubscribe")]
+    [InlineData("tasks/subscribe")]
     [InlineData("tasks/pushNotificationConfig/set")]
     [InlineData("tasks/pushNotificationConfig/get")]
     public void RoundTrip_AllValidMethods_PreservesMethod(string method)


### PR DESCRIPTION
This pull request introduces several changes to improve parameter handling, streamline method naming, and enhance the default initialization of certain properties. The most notable updates include refactoring the `DeserializeOrThrow` method to accept `JsonElement` parameters, renaming the "resubscribe" functionality to "subscribe" for clarity, and ensuring default values for nullable list properties.

### Parameter Handling Improvements:
* Refactored the `DeserializeOrThrow` method to accept a `JsonElement?` parameter for improved deserialization flexibility in `A2AJsonRpcProcessor`. This change replaces inline deserialization logic across multiple methods. (`src/A2A.AspNetCore/A2AJsonRpcProcessor.cs`, [[1]](diffhunk://#diff-587ed423c9bb3a9004b03a533b85262ec873214605e0511640a6a409e7a8cb8bL93-R117) [[2]](diffhunk://#diff-587ed423c9bb3a9004b03a533b85262ec873214605e0511640a6a409e7a8cb8bL124-R134)

### Method Naming Updates:
* Renamed "TaskResubscribe" to "TaskSubscribe" across the codebase for consistency and clarity. This includes updates to method names, constants, and associated unit tests. (`src/A2A/JsonRpc/A2AMethods.cs`, [[1]](diffhunk://#diff-2e2bfdbf21413622a440028f18a6419d0edd37e9d934d590e1ab514ccba1bec5L31-R31) [[2]](diffhunk://#diff-2e2bfdbf21413622a440028f18a6419d0edd37e9d934d590e1ab514ccba1bec5L48-R55); `src/A2A/Client/A2AClient.cs`, [[3]](diffhunk://#diff-1a49da6365a3136f1994b50e90cbfe237e8762b18ce18f508b93a682a5bfdee9L81-R84); `src/A2A/Client/IA2AClient.cs`, [[4]](diffhunk://#diff-c1f3e0260434fb43a1c5ff66122171411254e4d12f78b40f7b76836f5830ef64L51-R51); `tests/A2A.UnitTests`, [[5]](diffhunk://#diff-f2c72ad4a863a8cb5d28a1753616fc2683d698454a71cc30ca2ff86b1156cdb3L519-R519) [[6]](diffhunk://#diff-f2c72ad4a863a8cb5d28a1753616fc2683d698454a71cc30ca2ff86b1156cdb3L528-R528) [[7]](diffhunk://#diff-f2c72ad4a863a8cb5d28a1753616fc2683d698454a71cc30ca2ff86b1156cdb3L559-R559) [[8]](diffhunk://#diff-1d71016139557a60feec6ef999eb1779891f19b7865e4e6fa4d10aaf1693543bL24-R24) [[9]](diffhunk://#diff-aae35d701c3de74cb038e9bef031aef61b94abf0c64d9439d79240a562c912c9L123-R123) [[10]](diffhunk://#diff-aae35d701c3de74cb038e9bef031aef61b94abf0c64d9439d79240a562c912c9L467-R467)

### Default Property Initialization:
* Updated nullable list properties `Extensions` in `AgentCapabilities` and `AdditionalInterfaces` in `AgentCard` to ensure they are initialized with empty lists by default. (`src/A2A/Models/AgentCapabilities.cs`, [[1]](diffhunk://#diff-5795da126b276fe19968185011e7c6551ebc16f0ba3607fdc3240a68f92a4556L32-R32); `src/A2A/Models/AgentCard.cs`, [[2]](diffhunk://#diff-3df8fa0478ac06341779a182639023407ea22d0f6c35add467c4d93afefb6fa8L136-R136)

Fixes #53 - gets us to the following:

```shell
FAILED tests/optional/capabilities/test_message_send_capabilities.py::test_message_send_continue_with_contextid - AssertionError: assert False
FAILED tests/optional/capabilities/test_streaming_methods.py::test_tasks_resubscribe - KeyError: 'result'
FAILED tests/optional/capabilities/test_streaming_methods.py::test_tasks_resubscribe_nonexistent - AssertionError: Streaming capability declared but Content-Type is not text/event-stream
```

which will need to be resolved once various bugs in a2a-tck are fixed.