### PR TITLE
perf: use source generated logging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -272,9 +272,6 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-# EA0002: Use 'System.TimeProvider' to make the code easier to test
-dotnet_diagnostic.EA0002.severity = warning
-
 dotnet_naming_style.asyncsuffix.required_prefix = 
 dotnet_naming_style.asyncsuffix.required_suffix = Async
 dotnet_naming_style.asyncsuffix.word_separator = 

--- a/.editorconfig
+++ b/.editorconfig
@@ -263,3 +263,6 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# EA0002: Use 'System.TimeProvider' to make the code easier to test
+dotnet_diagnostic.EA0002.severity = warning

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,15 +3,13 @@
     <!-- Enable central package management, https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-  
   <ItemGroup>
     <!-- Product dependencies netstandard -->
+    <PackageVersion Include="Microsoft.Extensions.ExtraAnalyzers" Version="8.0.0-rc.2.23510.2" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-
     <!-- Product dependencies shared -->
     <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.0-preview.5.25277.114" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0-preview.5.25277.114" />
-
     <!-- Testing / samples dependencies -->
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
@@ -28,13 +26,11 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageVersion Include="Polly" Version="8.4.2" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
-
     <!-- Build / infrastructure dependencies -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
-
     <!-- Code analyzers -->
     <PackageVersion Include="Roslynator.Analyzers" Version="4.13.1" />
     <PackageReference Include="Roslynator.Analyzers">

--- a/src/A2A.AspNetCore/A2A.AspNetCore.csproj
+++ b/src/A2A.AspNetCore/A2A.AspNetCore.csproj
@@ -1,31 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 
-    <PublishAot>true</PublishAot>
-    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
-    <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsNamespaces>
+        <PublishAot>true</PublishAot>
+        <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+        <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsNamespaces>
 
-    <!-- NuGet Package Properties -->
-    <PackageId>A2A.AspNetCore</PackageId>
-    <Description>ASP.NET Core extensions for the Agent2Agent (A2A) protocol.</Description>
-    <PackageTags>Agent2Agent;a2a;agent;ai;llm;aspnetcore</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <IsPackable>true</IsPackable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+        <!-- NuGet Package Properties -->
+        <PackageId>A2A.AspNetCore</PackageId>
+        <Description>ASP.NET Core extensions for the Agent2Agent (A2A) protocol.</Description>
+        <PackageTags>Agent2Agent;a2a;agent;ai;llm;aspnetcore</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <IsPackable>true</IsPackable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.Extensions.ExtraAnalyzers">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\A2A\A2A.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\A2A\A2A.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\README.md" pack="true" PackagePath="\" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\README.md" pack="true" PackagePath="\" />
+    </ItemGroup>
 
 </Project>

--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -84,12 +84,12 @@ internal static class A2AHttpProcessor
         }
         catch (A2AException ex)
         {
-            logger.LogError(ex, "A2A error retrieving task");
+            logger.AAErrorRetrievingTask(ex);
             return MapA2AExceptionToHttpResult(ex);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error retrieving task");
+            logger.ErrorRetrievingTask(ex);
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
     }
@@ -194,12 +194,12 @@ internal static class A2AHttpProcessor
         }
         catch (A2AException ex)
         {
-            logger.LogError(ex, "A2A error sending subscribe message to task");
+            logger.AAErrorSendingSubscribeMessageToTask(ex);
             return MapA2AExceptionToHttpResult(ex);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error sending subscribe message to task");
+            logger.ErrorSendingSubscribeMessageToTask(ex);
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
     }
@@ -315,12 +315,12 @@ internal static class A2AHttpProcessor
         }
         catch (A2AException ex)
         {
-            logger.LogError(ex, "A2A error retrieving push notification");
+            logger.AAErrorRetrievingPushNotification(ex);
             return MapA2AExceptionToHttpResult(ex);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error retrieving push notification");
+            logger.ErrorRetrievingPushNotification(ex);
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
     }

--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -43,12 +43,12 @@ internal static class A2AHttpProcessor
         }
         catch (A2AException ex)
         {
-            logger.LogError(ex, "A2A error retrieving agent card");
+            logger.AAErrorRetrievingAgentCard(ex);
             return Task.FromResult(MapA2AExceptionToHttpResult(ex));
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error retrieving agent card");
+            logger.ErrorRetrievingAgentCard(ex);
             return Task.FromResult(Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError));
         }
     }
@@ -122,12 +122,12 @@ internal static class A2AHttpProcessor
         }
         catch (A2AException ex)
         {
-            logger.LogError(ex, "A2A error cancelling task");
+            logger.AAErrorCancellingTask(ex);
             return MapA2AExceptionToHttpResult(ex);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error cancelling task");
+            logger.ErrorCancellingTask(ex);
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
     }
@@ -159,12 +159,12 @@ internal static class A2AHttpProcessor
         }
         catch (A2AException ex)
         {
-            logger.LogError(ex, "A2A error sending message to task");
+            logger.AAErrorSendingMessageToTask(ex);
             return MapA2AExceptionToHttpResult(ex);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error sending message to task");
+            logger.ErrorSendingMessageToTask(ex);
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
     }
@@ -229,12 +229,12 @@ internal static class A2AHttpProcessor
         }
         catch (A2AException ex)
         {
-            logger.LogError(ex, "A2A error resubscribing to task");
+            logger.AAErrorSubscribingToTask(ex);
             return MapA2AExceptionToHttpResult(ex);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error subscribing to task");
+            logger.ErrorSubscribingToTask(ex);
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
     }
@@ -274,12 +274,12 @@ internal static class A2AHttpProcessor
         }
         catch (A2AException ex)
         {
-            logger.LogError(ex, "A2A error configuring push notification");
+            logger.AAErrorConfiguringPushNotification(ex);
             return MapA2AExceptionToHttpResult(ex);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error configuring push notification");
+            logger.ErrorConfiguringPushNotification(ex);
             return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
         }
     }

--- a/src/A2A.AspNetCore/Log.cs
+++ b/src/A2A.AspNetCore/Log.cs
@@ -1,0 +1,41 @@
+﻿
+namespace A2A.AspNetCore
+{
+#pragma warning disable CS8019
+    using Microsoft.Extensions.Logging;
+    using System;
+#pragma warning restore CS8019
+
+    static partial class Log
+    {
+        [LoggerMessage(0, LogLevel.Error, "A2A error retrieving agent card")]
+        internal static partial void AAErrorRetrievingAgentCard(this ILogger logger, Exception exception);
+
+        [LoggerMessage(1, LogLevel.Error, "Error retrieving agent card")]
+        internal static partial void ErrorRetrievingAgentCard(this ILogger logger, Exception exception);
+
+        [LoggerMessage(2, LogLevel.Error, "A2A error cancelling task")]
+        internal static partial void AAErrorCancellingTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(3, LogLevel.Error, "Error cancelling task")]
+        internal static partial void ErrorCancellingTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(4, LogLevel.Error, "A2A error sending message to task")]
+        internal static partial void AAErrorSendingMessageToTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(5, LogLevel.Error, "Error sending message to task")]
+        internal static partial void ErrorSendingMessageToTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(6, LogLevel.Error, "A2A error subscribing to task")]
+        internal static partial void AAErrorSubscribingToTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(7, LogLevel.Error, "Error subscribing to task")]
+        internal static partial void ErrorSubscribingToTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(8, LogLevel.Error, "A2A error configuring push notification")]
+        internal static partial void AAErrorConfiguringPushNotification(this ILogger logger, Exception exception);
+
+        [LoggerMessage(9, LogLevel.Error, "Error configuring push notification")]
+        internal static partial void ErrorConfiguringPushNotification(this ILogger logger, Exception exception);
+    }
+}

--- a/src/A2A.AspNetCore/Log.cs
+++ b/src/A2A.AspNetCore/Log.cs
@@ -37,5 +37,23 @@ namespace A2A.AspNetCore
 
         [LoggerMessage(9, LogLevel.Error, "Error configuring push notification")]
         internal static partial void ErrorConfiguringPushNotification(this ILogger logger, Exception exception);
+
+        [LoggerMessage(10, LogLevel.Error, "A2A error retrieving task")]
+        internal static partial void AAErrorRetrievingTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(11, LogLevel.Error, "Error retrieving task")]
+        internal static partial void ErrorRetrievingTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(12, LogLevel.Error, "A2A error retrieving push notification")]
+        internal static partial void AAErrorRetrievingPushNotification(this ILogger logger, Exception exception);
+
+        [LoggerMessage(13, LogLevel.Error, "Error retrieving push notification")]
+        internal static partial void ErrorRetrievingPushNotification(this ILogger logger, Exception exception);
+
+        [LoggerMessage(14, LogLevel.Error, "A2A error sending subscribe message to task")]
+        internal static partial void AAErrorSendingSubscribeMessageToTask(this ILogger logger, Exception exception);
+
+        [LoggerMessage(15, LogLevel.Error, "Error sending subscribe message to task")]
+        internal static partial void ErrorSendingSubscribeMessageToTask(this ILogger logger, Exception exception);
     }
 }

--- a/src/A2A/A2A.csproj
+++ b/src/A2A/A2A.csproj
@@ -25,6 +25,10 @@
 
   <!-- Dependencies needed by all -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.ExtraAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="System.Linq.AsyncEnumerable" />
     <PackageReference Include="System.Net.ServerSentEvents" />

--- a/src/A2A/Client/A2ACardResolver.cs
+++ b/src/A2A/Client/A2ACardResolver.cs
@@ -75,7 +75,7 @@ public sealed class A2ACardResolver
         }
         catch (JsonException ex)
         {
-            _logger.FailedToParseAgentCardJSON(ex);
+            _logger.FailedToParseAgentCardJson(ex);
             throw new A2AException($"Failed to parse JSON: {ex.Message}");
         }
         catch (HttpRequestException ex)
@@ -86,7 +86,7 @@ public sealed class A2ACardResolver
 #endif
                 HttpStatusCode.InternalServerError;
 
-            _logger.HTTPRequestFailedWithStatusCodeStatusCode(ex, statusCode);
+            _logger.HttpRequestFailedWithStatusCode(ex, statusCode);
             throw new A2AException("HTTP request failed", ex);
         }
     }

--- a/src/A2A/Client/A2ACardResolver.cs
+++ b/src/A2A/Client/A2ACardResolver.cs
@@ -53,7 +53,7 @@ public sealed class A2ACardResolver
         if (_logger.IsEnabled(LogLevel.Information))
         {
             Debug.Assert(_agentCardPath.IsAbsoluteUri || _httpClient.BaseAddress is not null);
-            _logger.LogInformation("Fetching agent card from '{Url}'", _agentCardPath.IsAbsoluteUri ?
+            _logger.FetchingAgentCardFromUrl(_agentCardPath.IsAbsoluteUri ?
                 _agentCardPath :
                 new Uri(_httpClient.BaseAddress!, _agentCardPath.ToString()));
         }
@@ -75,7 +75,7 @@ public sealed class A2ACardResolver
         }
         catch (JsonException ex)
         {
-            _logger.LogError(ex, "Failed to parse agent card JSON");
+            _logger.FailedToParseAgentCardJSON(ex);
             throw new A2AException($"Failed to parse JSON: {ex.Message}");
         }
         catch (HttpRequestException ex)
@@ -86,7 +86,7 @@ public sealed class A2ACardResolver
 #endif
                 HttpStatusCode.InternalServerError;
 
-            _logger.LogError(ex, "HTTP request failed with status code {StatusCode}", statusCode);
+            _logger.HTTPRequestFailedWithStatusCodeStatusCode(ex, statusCode);
             throw new A2AException("HTTP request failed", ex);
         }
     }

--- a/src/A2A/Client/JsonRpcContent.cs
+++ b/src/A2A/Client/JsonRpcContent.cs
@@ -36,7 +36,7 @@ public sealed class JsonRpcContent : HttpContent
     private JsonRpcContent(object? contentToSerialize, JsonTypeInfo contentTypeInfo)
     {
         _contentToSerialize = contentToSerialize;
-        _contentTypeInfo = contentTypeInfo ?? throw new ArgumentNullException(nameof(contentTypeInfo));
+        _contentTypeInfo = contentTypeInfo;
         Headers.TryAddWithoutValidation("Content-Type", "application/json");
     }
 

--- a/src/A2A/GlobalSuppressions.cs
+++ b/src/A2A/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Reliability", "EA0002:Use 'System.TimeProvider' to make the code easier to test", Justification = "Not going to adhere to this (yet)", Scope = "module")]

--- a/src/A2A/GlobalSuppressions.cs
+++ b/src/A2A/GlobalSuppressions.cs
@@ -6,3 +6,4 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Reliability", "EA0002:Use 'System.TimeProvider' to make the code easier to test", Justification = "Not going to adhere to this (yet)", Scope = "module")]
+[assembly: SuppressMessage("Performance", "EA0006:Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance", Justification = "Not going to adhere to this (yet)", Scope = "module")]

--- a/src/A2A/Log.cs
+++ b/src/A2A/Log.cs
@@ -12,9 +12,9 @@ namespace A2A
         internal static partial void FetchingAgentCardFromUrl(this ILogger logger, Uri Url);
 
         [LoggerMessage(1, LogLevel.Error, "Failed to parse agent card JSON")]
-        internal static partial void FailedToParseAgentCardJSON(this ILogger logger, Exception exception);
+        internal static partial void FailedToParseAgentCardJson(this ILogger logger, Exception exception);
 
         [LoggerMessage(2, LogLevel.Error, "HTTP request failed with status code {StatusCode}")]
-        internal static partial void HTTPRequestFailedWithStatusCodeStatusCode(this ILogger logger, Exception exception, System.Net.HttpStatusCode StatusCode);
+        internal static partial void HttpRequestFailedWithStatusCode(this ILogger logger, Exception exception, System.Net.HttpStatusCode StatusCode);
     }
 }

--- a/src/A2A/Log.cs
+++ b/src/A2A/Log.cs
@@ -1,0 +1,20 @@
+﻿
+namespace A2A
+{
+#pragma warning disable CS8019
+    using Microsoft.Extensions.Logging;
+    using System;
+#pragma warning restore CS8019
+
+    static partial class Log
+    {
+        [LoggerMessage(0, LogLevel.Information, "Fetching agent card from '{Url}'")]
+        internal static partial void FetchingAgentCardFromUrl(this ILogger logger, Uri Url);
+
+        [LoggerMessage(1, LogLevel.Error, "Failed to parse agent card JSON")]
+        internal static partial void FailedToParseAgentCardJSON(this ILogger logger, Exception exception);
+
+        [LoggerMessage(2, LogLevel.Error, "HTTP request failed with status code {StatusCode}")]
+        internal static partial void HTTPRequestFailedWithStatusCodeStatusCode(this ILogger logger, Exception exception, System.Net.HttpStatusCode StatusCode);
+    }
+}


### PR DESCRIPTION
Adds the `ExtraAnalyzers` package to aid in the detection & migration of logging code to source-generated logging for performance.

Fixes #77 