### PR TITLE
chore: add cancellation token requested checks to in-memory task store

### DIFF
--- a/src/A2A/Server/InMemoryTaskStore.cs
+++ b/src/A2A/Server/InMemoryTaskStore.cs
@@ -17,7 +17,7 @@ public sealed class InMemoryTaskStore : ITaskStore
         }
 
         return string.IsNullOrEmpty(taskId)
-            ? Task.FromException<AgentTask?>(new ArgumentNullException(taskId))
+            ? Task.FromException<AgentTask?>(new ArgumentNullException(nameof(taskId)))
             : Task.FromResult(_taskCache.TryGetValue(taskId, out var task) ? task : null);
     }
 
@@ -31,7 +31,7 @@ public sealed class InMemoryTaskStore : ITaskStore
 
         if (string.IsNullOrEmpty(taskId))
         {
-            return Task.FromException<TaskPushNotificationConfig?>(new ArgumentNullException(taskId));
+            return Task.FromException<TaskPushNotificationConfig?>(new ArgumentNullException(nameof(taskId)));
         }
 
         if (!_pushNotificationCache.TryGetValue(taskId, out var pushNotificationConfigs))
@@ -54,7 +54,7 @@ public sealed class InMemoryTaskStore : ITaskStore
 
         if (string.IsNullOrEmpty(taskId))
         {
-            return Task.FromException<AgentTaskStatus>(new ArgumentNullException(taskId));
+            return Task.FromException<AgentTaskStatus>(new ArgumentNullException(nameof(taskId)));
         }
 
         if (!_taskCache.TryGetValue(taskId, out var task))

--- a/src/A2A/Server/InMemoryTaskStore.cs
+++ b/src/A2A/Server/InMemoryTaskStore.cs
@@ -9,14 +9,26 @@ public sealed class InMemoryTaskStore : ITaskStore
     private readonly Dictionary<string, List<TaskPushNotificationConfig>> _pushNotificationCache = [];
 
     /// <inheritdoc />
-    public Task<AgentTask?> GetTaskAsync(string taskId, CancellationToken cancellationToken = default) =>
-        string.IsNullOrEmpty(taskId)
+    public Task<AgentTask?> GetTaskAsync(string taskId, CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<AgentTask?>(cancellationToken);
+        }
+
+        return string.IsNullOrEmpty(taskId)
             ? Task.FromException<AgentTask?>(new ArgumentNullException(taskId))
             : Task.FromResult(_taskCache.TryGetValue(taskId, out var task) ? task : null);
+    }
 
     /// <inheritdoc />
     public Task<TaskPushNotificationConfig?> GetPushNotificationAsync(string taskId, string notificationConfigId, CancellationToken cancellationToken = default)
     {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<TaskPushNotificationConfig?>(cancellationToken);
+        }
+
         if (string.IsNullOrEmpty(taskId))
         {
             return Task.FromException<TaskPushNotificationConfig?>(new ArgumentNullException(taskId));
@@ -35,6 +47,11 @@ public sealed class InMemoryTaskStore : ITaskStore
     /// <inheritdoc />
     public Task<AgentTaskStatus> UpdateStatusAsync(string taskId, TaskState status, Message? message = null, CancellationToken cancellationToken = default)
     {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<AgentTaskStatus>(cancellationToken);
+        }
+
         if (string.IsNullOrEmpty(taskId))
         {
             return Task.FromException<AgentTaskStatus>(new ArgumentNullException(taskId));
@@ -54,6 +71,11 @@ public sealed class InMemoryTaskStore : ITaskStore
     /// <inheritdoc />
     public Task SetTaskAsync(AgentTask task, CancellationToken cancellationToken = default)
     {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
         _taskCache[task.Id] = task;
         return Task.CompletedTask;
     }
@@ -61,6 +83,11 @@ public sealed class InMemoryTaskStore : ITaskStore
     /// <inheritdoc />
     public Task SetPushNotificationConfigAsync(TaskPushNotificationConfig pushNotificationConfig, CancellationToken cancellationToken = default)
     {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
         if (pushNotificationConfig is null)
         {
             return Task.FromException(new ArgumentNullException(nameof(pushNotificationConfig)));
@@ -80,6 +107,11 @@ public sealed class InMemoryTaskStore : ITaskStore
     /// <inheritdoc />
     public Task<IEnumerable<TaskPushNotificationConfig>> GetPushNotificationsAsync(string taskId, CancellationToken cancellationToken = default)
     {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IEnumerable<TaskPushNotificationConfig>>(cancellationToken);
+        }
+
         if (!_pushNotificationCache.TryGetValue(taskId, out var pushNotificationConfigs))
         {
             return Task.FromResult<IEnumerable<TaskPushNotificationConfig>>([]);

--- a/tests/A2A.UnitTests/Server/InMemoryTaskStoreTests.cs
+++ b/tests/A2A.UnitTests/Server/InMemoryTaskStoreTests.cs
@@ -175,4 +175,108 @@ public class InMemoryTaskStoreTests
         Assert.NotNull(result);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task GetTaskAsync_ShouldReturnCanceledTask_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var task = sut.GetTaskAsync("test-id", cts.Token);
+
+        // Assert
+        Assert.True(task.IsCanceled);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task GetPushNotificationAsync_ShouldReturnCanceledTask_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var task = sut.GetPushNotificationAsync("test-id", "config-id", cts.Token);
+
+        // Assert
+        Assert.True(task.IsCanceled);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_ShouldReturnCanceledTask_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var task = sut.UpdateStatusAsync("test-id", TaskState.Working, cancellationToken: cts.Token);
+
+        // Assert
+        Assert.True(task.IsCanceled);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task SetTaskAsync_ShouldReturnCanceledTask_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+        var agentTask = new AgentTask { Id = "test-id", Status = new AgentTaskStatus { State = TaskState.Submitted } };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var task = sut.SetTaskAsync(agentTask, cts.Token);
+
+        // Assert
+        Assert.True(task.IsCanceled);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task SetPushNotificationConfigAsync_ShouldReturnCanceledTask_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+        var config = new TaskPushNotificationConfig();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var task = sut.SetPushNotificationConfigAsync(config, cts.Token);
+
+        // Assert
+        Assert.True(task.IsCanceled);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task GetPushNotificationsAsync_ShouldReturnCanceledTask_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var task = sut.GetPushNotificationsAsync("test-id", cts.Token);
+
+        // Assert
+        Assert.True(task.IsCanceled);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+    }
 }

--- a/tests/A2A.UnitTests/Server/TaskManagerTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskManagerTests.cs
@@ -528,4 +528,142 @@ public class TaskManagerTests
         Assert.Equal("Msg5", (resultTask.History[1].Parts[0] as TextPart)?.Text);
         Assert.Equal("Check", (resultTask.History[2].Parts[0] as TextPart)?.Text);
     }
+
+    [Fact]
+    public async Task CreateTaskAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.CreateTaskAsync(cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task CancelTaskAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+        var taskIdParams = new TaskIdParams { Id = "test-id" };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.CancelTaskAsync(taskIdParams, cts.Token));
+    }
+
+    [Fact]
+    public async Task GetTaskAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+        var taskQueryParams = new TaskQueryParams { Id = "test-id" };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.GetTaskAsync(taskQueryParams, cts.Token));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+        var messageSendParams = new MessageSendParams();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.SendMessageAsync(messageSendParams, cts.Token));
+    }
+
+    [Fact]
+    public async Task SendMessageStreamAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+        var messageSendParams = new MessageSendParams();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.SendMessageStreamAsync(messageSendParams, cts.Token));
+    }
+
+    [Fact]
+    public void SubscribeToTaskAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+        var taskIdParams = new TaskIdParams { Id = "test-id" };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        Assert.Throws<OperationCanceledException>(() => taskManager.SubscribeToTaskAsync(taskIdParams, cts.Token));
+    }
+
+    [Fact]
+    public async Task SetPushNotificationAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+        var pushNotificationConfig = new TaskPushNotificationConfig();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.SetPushNotificationAsync(pushNotificationConfig, cts.Token));
+    }
+
+    [Fact]
+    public async Task GetPushNotificationAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+        var notificationConfigParams = new GetTaskPushNotificationConfigParams { Id = "test-id" };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.GetPushNotificationAsync(notificationConfigParams, cts.Token));
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.UpdateStatusAsync("test-id", TaskState.Working, cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task ReturnArtifactAsync_ShouldThrowOperationCanceledException_WhenCancellationTokenIsCanceled()
+    {
+        // Arrange
+        var taskManager = new TaskManager();
+        var artifact = new Artifact();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() => taskManager.ReturnArtifactAsync("test-id", artifact, cts.Token));
+    }
 }


### PR DESCRIPTION
1. Addresses: [https://github.com/a2aproject/a2a-dotnet/pull/70#discussion_r221937183](https://github.com/a2aproject/a2a-dotnet/pull/70#discussion_r221937183)  
2. Uses `nameof` to get the parameter name for argument null exceptions in the in-memory task store.  
3. Adds unit tests to verify cancellation checks in the in-memory task store and task manager classes.