### PR TITLE
fix: don't augment task when trimming history

### DIFF
--- a/src/A2A/Models/A2AResponse.cs
+++ b/src/A2A/Models/A2AResponse.cs
@@ -10,6 +10,7 @@ namespace A2A;
 [JsonDerivedType(typeof(TaskArtifactUpdateEvent), "artifact-update")]
 [JsonDerivedType(typeof(Message), "message")]
 [JsonDerivedType(typeof(AgentTask), "task")]
+[JsonDerivedType(typeof(TrimmedAgentTask))]
 public abstract class A2AEvent
 {
 }
@@ -20,6 +21,7 @@ public abstract class A2AEvent
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
 [JsonDerivedType(typeof(Message), "message")]
 [JsonDerivedType(typeof(AgentTask), "task")]
+[JsonDerivedType(typeof(TrimmedAgentTask))]
 public abstract class A2AResponse : A2AEvent
 {
 }

--- a/src/A2A/Models/A2AResponse.cs
+++ b/src/A2A/Models/A2AResponse.cs
@@ -10,7 +10,6 @@ namespace A2A;
 [JsonDerivedType(typeof(TaskArtifactUpdateEvent), "artifact-update")]
 [JsonDerivedType(typeof(Message), "message")]
 [JsonDerivedType(typeof(AgentTask), "task")]
-[JsonDerivedType(typeof(TrimmedAgentTask))]
 public abstract class A2AEvent
 {
 }
@@ -21,7 +20,6 @@ public abstract class A2AEvent
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
 [JsonDerivedType(typeof(Message), "message")]
 [JsonDerivedType(typeof(AgentTask), "task")]
-[JsonDerivedType(typeof(TrimmedAgentTask))]
 public abstract class A2AResponse : A2AEvent
 {
 }

--- a/src/A2A/Models/AgentTask.cs
+++ b/src/A2A/Models/AgentTask.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -6,59 +7,74 @@ namespace A2A;
 /// <summary>
 /// Represents a task that can be processed by an agent.
 /// </summary>
-public sealed class AgentTask : A2AResponse
+public class AgentTask : A2AResponse
 {
     /// <summary>
     /// Unique identifier for the task.
     /// </summary>
     [JsonPropertyName("id")]
     [JsonRequired]
-    public string Id { get; set; } = string.Empty;
+    public virtual string Id { get; set; } = string.Empty;
 
     /// <summary>
     /// Server-generated id for contextual alignment across interactions.
     /// </summary>
     [JsonPropertyName("contextId")]
     [JsonRequired]
-    public string ContextId { get; set; } = string.Empty;
+    public virtual string ContextId { get; set; } = string.Empty;
 
     /// <summary>
     /// Current status of the task.
     /// </summary>
     [JsonPropertyName("status")]
     [JsonRequired]
-    public AgentTaskStatus Status { get; set; } = new AgentTaskStatus();
+    public virtual AgentTaskStatus Status { get; set; } = new AgentTaskStatus();
 
     /// <summary>
     /// Collection of artifacts created by the agent.
     /// </summary>
     [JsonPropertyName("artifacts")]
-    public List<Artifact>? Artifacts { get; set; }
+    public virtual List<Artifact>? Artifacts { get; set; }
 
     /// <summary>
     /// Collection of messages in the task history.
     /// </summary>
     [JsonPropertyName("history")]
-    public List<Message>? History { get; set; } = [];
+    public virtual List<Message>? History { get; set; } = [];
 
     /// <summary>
     /// Extension metadata.
     /// </summary>
     [JsonPropertyName("metadata")]
-    public Dictionary<string, JsonElement>? Metadata { get; set; }
+    public virtual Dictionary<string, JsonElement>? Metadata { get; set; }
+}
 
+internal sealed class TrimmedAgentTask(AgentTask taskToTrim, int? historyLength) : AgentTask
+{
+    public override List<Artifact>? Artifacts { get => taskToTrim.Artifacts; set => taskToTrim.Artifacts = value; }
+    public override string ContextId { get => taskToTrim.ContextId; set => taskToTrim.ContextId = value; }
+    public override List<Message>? History { get => (historyLength is { } len && taskToTrim.History?.Count is { } c && c > len) ? [.. taskToTrim.History!.Skip(Math.Max(0, c - len))] : taskToTrim.History; set => taskToTrim.History = value; }
+    public override string Id { get => taskToTrim.Id; set => taskToTrim.Id = value; }
+    public override Dictionary<string, JsonElement>? Metadata { get => taskToTrim.Metadata; set => taskToTrim.Metadata = value; }
+    public override AgentTaskStatus Status { get => taskToTrim.Status; set => taskToTrim.Status = value; }
+}
+
+/// <summary>
+/// Provides extension methods for <see cref="AgentTask"/>.
+/// </summary>
+public static class AgentTaskExtensions
+{
     /// <summary>
-    /// Trims the <see cref="History"/> collection to the specified length, keeping only the most recent messages.
+    /// Trims the <see cref="AgentTask.History"/> collection to the specified length, keeping only the most recent messages.
     /// </summary>
+    /// <param name="task">
+    /// The <see cref="AgentTask"/> whose history should be trimmed.
+    /// </param>
     /// <param name="toLength">
     /// The maximum number of messages to retain in the history. If <c>null</c> or greater than the current count, no trimming occurs.
     /// </param>
-    public void TrimHistory(int? toLength)
-    {
-        // Trim history if historyLength is specified
-        if (toLength is { } historyLength && this.History?.Count > historyLength)
-        {
-            this.History = [.. this.History.Skip(Math.Max(0, this.History.Count - historyLength))];
-        }
-    }
+    /// <returns>
+    /// An <see cref="AgentTask"/> with the history trimmed to the specified length.
+    /// </returns>
+    public static AgentTask WithHistoryTrimmedTo(this AgentTask task, int? toLength) => new TrimmedAgentTask(task, toLength);
 }

--- a/src/A2A/Models/AgentTask.cs
+++ b/src/A2A/Models/AgentTask.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -7,56 +6,46 @@ namespace A2A;
 /// <summary>
 /// Represents a task that can be processed by an agent.
 /// </summary>
-public class AgentTask : A2AResponse
+public sealed class AgentTask : A2AResponse
 {
     /// <summary>
     /// Unique identifier for the task.
     /// </summary>
     [JsonPropertyName("id")]
     [JsonRequired]
-    public virtual string Id { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
 
     /// <summary>
     /// Server-generated id for contextual alignment across interactions.
     /// </summary>
     [JsonPropertyName("contextId")]
     [JsonRequired]
-    public virtual string ContextId { get; set; } = string.Empty;
+    public string ContextId { get; set; } = string.Empty;
 
     /// <summary>
     /// Current status of the task.
     /// </summary>
     [JsonPropertyName("status")]
     [JsonRequired]
-    public virtual AgentTaskStatus Status { get; set; } = new AgentTaskStatus();
+    public AgentTaskStatus Status { get; set; } = new AgentTaskStatus();
 
     /// <summary>
     /// Collection of artifacts created by the agent.
     /// </summary>
     [JsonPropertyName("artifacts")]
-    public virtual List<Artifact>? Artifacts { get; set; }
+    public List<Artifact>? Artifacts { get; set; }
 
     /// <summary>
     /// Collection of messages in the task history.
     /// </summary>
     [JsonPropertyName("history")]
-    public virtual List<Message>? History { get; set; } = [];
+    public List<Message>? History { get; set; } = [];
 
     /// <summary>
     /// Extension metadata.
     /// </summary>
     [JsonPropertyName("metadata")]
-    public virtual Dictionary<string, JsonElement>? Metadata { get; set; }
-}
-
-internal sealed class TrimmedAgentTask(AgentTask taskToTrim, int? historyLength) : AgentTask
-{
-    public override List<Artifact>? Artifacts { get => taskToTrim.Artifacts; set => taskToTrim.Artifacts = value; }
-    public override string ContextId { get => taskToTrim.ContextId; set => taskToTrim.ContextId = value; }
-    public override List<Message>? History { get => (historyLength is { } len && taskToTrim.History?.Count is { } c && c > len) ? [.. taskToTrim.History!.Skip(Math.Max(0, c - len))] : taskToTrim.History; set => taskToTrim.History = value; }
-    public override string Id { get => taskToTrim.Id; set => taskToTrim.Id = value; }
-    public override Dictionary<string, JsonElement>? Metadata { get => taskToTrim.Metadata; set => taskToTrim.Metadata = value; }
-    public override AgentTaskStatus Status { get => taskToTrim.Status; set => taskToTrim.Status = value; }
+    public Dictionary<string, JsonElement>? Metadata { get; set; }
 }
 
 /// <summary>
@@ -65,16 +54,26 @@ internal sealed class TrimmedAgentTask(AgentTask taskToTrim, int? historyLength)
 public static class AgentTaskExtensions
 {
     /// <summary>
-    /// Trims the <see cref="AgentTask.History"/> collection to the specified length, keeping only the most recent messages.
+    /// Returns a new <see cref="AgentTask"/> with the <see cref="AgentTask.History"/> collection trimmed to the specified length.
     /// </summary>
-    /// <param name="task">
-    /// The <see cref="AgentTask"/> whose history should be trimmed.
-    /// </param>
-    /// <param name="toLength">
-    /// The maximum number of messages to retain in the history. If <c>null</c> or greater than the current count, no trimming occurs.
-    /// </param>
-    /// <returns>
-    /// An <see cref="AgentTask"/> with the history trimmed to the specified length.
-    /// </returns>
-    public static AgentTask WithHistoryTrimmedTo(this AgentTask task, int? toLength) => new TrimmedAgentTask(task, toLength);
+    /// <param name="task">The <see cref="AgentTask"/> whose history should be trimmed.</param>
+    /// <param name="toLength">The maximum number of messages to retain in the history. If <c>null</c> or greater than the current count, the original task is returned.</param>
+    /// <returns>A new <see cref="AgentTask"/> with the history trimmed, or the original task if no trimming is necessary.</returns>
+    public static AgentTask WithHistoryTrimmedTo(this AgentTask task, int? toLength)
+    {
+        if (toLength is not { } len || task.History is not { Count: > 0 } history || history.Count <= len)
+        {
+            return task;
+        }
+
+        return new AgentTask
+        {
+            Id = task.Id,
+            ContextId = task.ContextId,
+            Status = task.Status,
+            Artifacts = task.Artifacts,
+            Metadata = task.Metadata,
+            History = [.. history.Skip(history.Count - len)],
+        };
+    }
 }

--- a/src/A2A/Properties/AssemblyInfo.cs
+++ b/src/A2A/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("A2A.UnitTests")]
+[assembly: InternalsVisibleTo("A2A.AspNetCore.UnitTests")]

--- a/src/A2A/Server/TaskManager.cs
+++ b/src/A2A/Server/TaskManager.cs
@@ -187,7 +187,7 @@ public sealed class TaskManager : ITaskManager
             await OnTaskUpdated(task, cancellationToken).ConfigureAwait(false);
         }
 
-        return task.WithHistoryTrimmedTo(messageSendParams.Configuration?.HistoryLength) as TrimmedAgentTask;
+        return task.WithHistoryTrimmedTo(messageSendParams.Configuration?.HistoryLength);
     }
 
     /// <inheritdoc />

--- a/src/A2A/Server/TaskManager.cs
+++ b/src/A2A/Server/TaskManager.cs
@@ -120,9 +120,7 @@ public sealed class TaskManager : ITaskManager
         var task = await _taskStore.GetTaskAsync(taskIdParams.Id, cancellationToken).ConfigureAwait(false);
         activity?.SetTag("task.found", task != null);
 
-        task?.TrimHistory(taskIdParams.HistoryLength);
-
-        return task;
+        return task?.WithHistoryTrimmedTo(taskIdParams.HistoryLength);
     }
 
     /// <inheritdoc />
@@ -184,14 +182,12 @@ public sealed class TaskManager : ITaskManager
             task.History ??= [];
             task.History.Add(messageSendParams.Message);
 
-            task.TrimHistory(messageSendParams.Configuration?.HistoryLength);
-
             await _taskStore.SetTaskAsync(task, cancellationToken).ConfigureAwait(false);
             using var createActivity = ActivitySource.StartActivity("OnTaskUpdated", ActivityKind.Server);
             await OnTaskUpdated(task, cancellationToken).ConfigureAwait(false);
         }
 
-        return task;
+        return task.WithHistoryTrimmedTo(messageSendParams.Configuration?.HistoryLength) as TrimmedAgentTask;
     }
 
     /// <inheritdoc />
@@ -263,8 +259,6 @@ public sealed class TaskManager : ITaskManager
             // If the task is found, update its status and history
             agentTask.History ??= [];
             agentTask.History.Add(messageSendParams.Message);
-
-            agentTask.TrimHistory(messageSendParams.Configuration?.HistoryLength);
 
             await _taskStore.SetTaskAsync(agentTask, cancellationToken).ConfigureAwait(false);
             enumerator = new TaskUpdateEventEnumerator();

--- a/tests/A2A.UnitTests/Server/TaskManagerTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskManagerTests.cs
@@ -587,8 +587,8 @@ public class TaskManagerTests
         {
             Message = {
                 TaskId = task.Id,
-                Parts = { new TextPart { Text = "hi again" } }
-            }
+                Parts = { new TextPart { Text = "hi again" } },
+            },
         }, default) as AgentTask;
         Assert.NotNull(task);
 
@@ -598,6 +598,48 @@ public class TaskManagerTests
 
         Assert.NotNull(task.History);
         Assert.Same(task.History[1], trimmedTask.History[0]);
+
+        Assert.Same(task.Status, trimmedTask.Status);
+        Assert.Same(task.Id, trimmedTask.Id);
+        Assert.Same(task.Metadata, trimmedTask.Metadata);
+        Assert.Same(task.Artifacts, trimmedTask.Artifacts);
+        Assert.Same(task.ContextId, trimmedTask.ContextId);
+
+        var trimmedSentTask = await taskManager.SendMessageAsync(new()
+        {
+            Message = {
+                TaskId = task.Id,
+                Parts = { new TextPart { Text = "hi again 3" } },
+            },
+            Configuration = new()
+            {
+                HistoryLength = 1,
+            },
+        }, default) as AgentTask;
+        Assert.NotNull(trimmedSentTask);
+        Assert.NotNull(trimmedSentTask?.History);
+        Assert.Single(trimmedSentTask.History);
+
+        task = await taskManager.GetTaskAsync(new() { Id = task.Id });
+        Assert.NotNull(task);
+
+        Assert.NotNull(task.History);
+        Assert.Same(task.History[2], trimmedSentTask.History[0]);
+
+        Assert.Same(task.Status, trimmedSentTask.Status);
+        Assert.Same(task.Id, trimmedSentTask.Id);
+        Assert.Same(task.Metadata, trimmedSentTask.Metadata);
+        Assert.Same(task.Artifacts, trimmedSentTask.Artifacts);
+        Assert.Same(task.ContextId, trimmedSentTask.ContextId);
+
+        var shouldbeSameTask = await taskManager.GetTaskAsync(new() { Id = task.Id });
+        Assert.NotNull(shouldbeSameTask);
+        Assert.Same(task.History, shouldbeSameTask.History);
+        Assert.Same(task.Status, shouldbeSameTask.Status);
+        Assert.Same(task.Id, shouldbeSameTask.Id);
+        Assert.Same(task.Metadata, shouldbeSameTask.Metadata);
+        Assert.Same(task.Artifacts, shouldbeSameTask.Artifacts);
+        Assert.Same(task.ContextId, shouldbeSameTask.ContextId);
     }
 
     [Fact]


### PR DESCRIPTION
Creates a `WithTrimmedHistory` extension method on `AgentTask` that does _not_ augment that actual history of the task, but instead creates a new instance of AgentTask with the history trimmed.
Additionally, created a UT that validates that, in this trimmed history, the objects are not _copies_ but instead are references to the original, so we aren't increasing memory usage when trimming

Fixes #91