### PR TITLE
feat: introduce AgentCardProvider

### DIFF
--- a/samples/AgentServer/EchoAgent.cs
+++ b/samples/AgentServer/EchoAgent.cs
@@ -7,7 +7,6 @@ public class EchoAgent
     public void Attach(ITaskManager taskManager)
     {
         taskManager.OnMessageReceived = ProcessMessageAsync;
-        taskManager.OnAgentCardQuery = GetAgentCardAsync;
     }
 
     private Task<A2AResponse> ProcessMessageAsync(MessageSendParams messageSendParams, CancellationToken cancellationToken)
@@ -34,29 +33,26 @@ public class EchoAgent
         return Task.FromResult<A2AResponse>(message);
     }
 
-    private Task<AgentCard> GetAgentCardAsync(string agentUrl, CancellationToken cancellationToken)
+    public AgentCard Card
     {
-        if (cancellationToken.IsCancellationRequested)
+        get
         {
-            return Task.FromCanceled<AgentCard>(cancellationToken);
+            var capabilities = new AgentCapabilities()
+            {
+                Streaming = true,
+                PushNotifications = false,
+            };
+
+            return new AgentCard()
+            {
+                Name = "Echo Agent",
+                Description = "Agent which will echo every message it receives.",
+                Version = "1.0.0",
+                DefaultInputModes = ["text"],
+                DefaultOutputModes = ["text"],
+                Capabilities = capabilities,
+                Skills = [],
+            };
         }
-
-        var capabilities = new AgentCapabilities()
-        {
-            Streaming = true,
-            PushNotifications = false,
-        };
-
-        return Task.FromResult(new AgentCard()
-        {
-            Name = "Echo Agent",
-            Description = "Agent which will echo every message it receives.",
-            Url = agentUrl,
-            Version = "1.0.0",
-            DefaultInputModes = ["text"],
-            DefaultOutputModes = ["text"],
-            Capabilities = capabilities,
-            Skills = [],
-        });
     }
 }

--- a/samples/AgentServer/EchoAgentWithTasks.cs
+++ b/samples/AgentServer/EchoAgentWithTasks.cs
@@ -12,7 +12,6 @@ public class EchoAgentWithTasks
         _taskManager = taskManager;
         taskManager.OnTaskCreated = ProcessMessageAsync;
         taskManager.OnTaskUpdated = ProcessMessageAsync;
-        taskManager.OnAgentCardQuery = GetAgentCardAsync;
     }
 
     private async Task ProcessMessageAsync(AgentTask task, CancellationToken cancellationToken)
@@ -41,30 +40,27 @@ public class EchoAgentWithTasks
             cancellationToken: cancellationToken);
     }
 
-    private Task<AgentCard> GetAgentCardAsync(string agentUrl, CancellationToken cancellationToken)
+    public AgentCard Card
     {
-        if (cancellationToken.IsCancellationRequested)
+        get
         {
-            return Task.FromCanceled<AgentCard>(cancellationToken);
+            var capabilities = new AgentCapabilities()
+            {
+                Streaming = true,
+                PushNotifications = false,
+            };
+
+            return new AgentCard()
+            {
+                Name = "Echo Agent",
+                Description = "Agent which will echo every message it receives.",
+                Version = "1.0.0",
+                DefaultInputModes = ["text"],
+                DefaultOutputModes = ["text"],
+                Capabilities = capabilities,
+                Skills = [],
+            };
         }
-
-        var capabilities = new AgentCapabilities()
-        {
-            Streaming = true,
-            PushNotifications = false,
-        };
-
-        return Task.FromResult(new AgentCard()
-        {
-            Name = "Echo Agent",
-            Description = "Agent which will echo every message it receives.",
-            Url = agentUrl,
-            Version = "1.0.0",
-            DefaultInputModes = ["text"],
-            DefaultOutputModes = ["text"],
-            Capabilities = capabilities,
-            Skills = [],
-        });
     }
 
     private static TaskState? GetTargetStateFromMetadata(Dictionary<string, JsonElement>? metadata)

--- a/samples/AgentServer/Program.cs
+++ b/samples/AgentServer/Program.cs
@@ -42,7 +42,7 @@ switch (agentType.ToLowerInvariant())
         var echoAgent = new EchoAgent();
         echoAgent.Attach(taskManager);
         app.MapA2A(taskManager, "/echo");
-        app.MapWellKnownAgentCard(taskManager, "/echo");
+        app.MapWellKnownAgentCard(echoAgent.Card, "/echo");
         app.MapHttpA2A(taskManager, "/echo");
         break;
 
@@ -50,7 +50,7 @@ switch (agentType.ToLowerInvariant())
         var echoAgentWithTasks = new EchoAgentWithTasks();
         echoAgentWithTasks.Attach(taskManager);
         app.MapA2A(taskManager, "/echotasks");
-        app.MapWellKnownAgentCard(taskManager, "/echotasks");
+        app.MapWellKnownAgentCard(echoAgentWithTasks.Card, "/echotasks");
         app.MapHttpA2A(taskManager, "/echotasks");
         break;
 
@@ -58,14 +58,14 @@ switch (agentType.ToLowerInvariant())
         var researcherAgent = new ResearcherAgent();
         researcherAgent.Attach(taskManager);
         app.MapA2A(taskManager, "/researcher");
-        app.MapWellKnownAgentCard(taskManager, "/researcher");
+        app.MapWellKnownAgentCard(researcherAgent.Card, "/researcher");
         break;
 
     case "speccompliance":
         var specComplianceAgent = new SpecComplianceAgent();
         specComplianceAgent.Attach(taskManager);
         app.MapA2A(taskManager, "/speccompliance");
-        app.MapWellKnownAgentCard(taskManager, "/speccompliance");
+        app.MapWellKnownAgentCard(specComplianceAgent.Card, "/speccompliance");
         break;
 
     default:

--- a/samples/AgentServer/ResearcherAgent.cs
+++ b/samples/AgentServer/ResearcherAgent.cs
@@ -32,7 +32,6 @@ public class ResearcherAgent
             var message = ((TextPart?)task.History?.Last()?.Parts?.FirstOrDefault())?.Text ?? string.Empty;
             await InvokeAsync(task.Id, message, cancellationToken);
         };
-        _taskManager.OnAgentCardQuery = GetAgentCardAsync;
     }
 
     // This is the main entry point for the agent. It is called when a task is created or updated.
@@ -143,29 +142,26 @@ public class ResearcherAgent
         _agentStates[taskId] = AgentState.WaitingForFeedbackOnPlan;
     }
 
-    private Task<AgentCard> GetAgentCardAsync(string agentUrl, CancellationToken cancellationToken)
+    public AgentCard Card
     {
-        if (cancellationToken.IsCancellationRequested)
+        get
         {
-            return Task.FromCanceled<AgentCard>(cancellationToken);
+            var capabilities = new AgentCapabilities()
+            {
+                Streaming = true,
+                PushNotifications = false,
+            };
+
+            return new AgentCard()
+            {
+                Name = "Researcher Agent",
+                Description = "Agent which conducts research.",
+                Version = "1.0.0",
+                DefaultInputModes = ["text"],
+                DefaultOutputModes = ["text"],
+                Capabilities = capabilities,
+                Skills = [],
+            };
         }
-
-        var capabilities = new AgentCapabilities()
-        {
-            Streaming = true,
-            PushNotifications = false,
-        };
-
-        return Task.FromResult(new AgentCard()
-        {
-            Name = "Researcher Agent",
-            Description = "Agent which conducts research.",
-            Url = agentUrl,
-            Version = "1.0.0",
-            DefaultInputModes = ["text"],
-            DefaultOutputModes = ["text"],
-            Capabilities = capabilities,
-            Skills = [],
-        });
     }
 }

--- a/samples/AgentServer/SpecComplianceAgent.cs
+++ b/samples/AgentServer/SpecComplianceAgent.cs
@@ -8,7 +8,6 @@ public class SpecComplianceAgent
 
     public void Attach(ITaskManager taskManager)
     {
-        taskManager.OnAgentCardQuery = GetAgentCard;
         taskManager.OnTaskCreated = OnTaskCreatedAsync;
         taskManager.OnTaskUpdated = OnTaskUpdatedAsync;
         _taskManager = taskManager;
@@ -39,29 +38,26 @@ public class SpecComplianceAgent
         }
     }
 
-    private Task<AgentCard> GetAgentCard(string agentUrl, CancellationToken cancellationToken)
+    public AgentCard Card
     {
-        if (cancellationToken.IsCancellationRequested)
+        get
         {
-            return Task.FromCanceled<AgentCard>(cancellationToken);
+            var capabilities = new AgentCapabilities()
+            {
+                Streaming = true,
+                PushNotifications = false,
+            };
+
+            return new AgentCard()
+            {
+                Name = "A2A Specification Compliance Agent",
+                Description = "Agent to run A2A specification compliance tests.",
+                Version = "1.0.0",
+                DefaultInputModes = ["text"],
+                DefaultOutputModes = ["text"],
+                Capabilities = capabilities,
+                Skills = [],
+            };
         }
-
-        var capabilities = new AgentCapabilities()
-        {
-            Streaming = true,
-            PushNotifications = false,
-        };
-
-        return Task.FromResult(new AgentCard()
-        {
-            Name = "A2A Specification Compliance Agent",
-            Description = "Agent to run A2A specification compliance tests.",
-            Url = agentUrl,
-            Version = "1.0.0",
-            DefaultInputModes = ["text"],
-            DefaultOutputModes = ["text"],
-            Capabilities = capabilities,
-            Skills = [],
-        });
     }
 }

--- a/samples/SemanticKernelAgent/Program.cs
+++ b/samples/SemanticKernelAgent/Program.cs
@@ -35,6 +35,6 @@ var agent = new SemanticKernelTravelAgent(configuration, httpClient, logger);
 var taskManager = new TaskManager();
 agent.Attach(taskManager);
 app.MapA2A(taskManager, string.Empty);
-app.MapWellKnownAgentCard(taskManager, string.Empty);
+app.MapWellKnownAgentCard(SemanticKernelTravelAgent.Card, string.Empty);
 
 await app.RunAsync();

--- a/samples/SemanticKernelAgent/SemanticKernelTravelAgent.cs
+++ b/samples/SemanticKernelAgent/SemanticKernelTravelAgent.cs
@@ -140,7 +140,6 @@ public class SemanticKernelTravelAgent : IDisposable
         _taskManager = taskManager;
         taskManager.OnTaskCreated = ExecuteAgentTaskAsync;
         taskManager.OnTaskUpdated = ExecuteAgentTaskAsync;
-        taskManager.OnAgentCardQuery = GetAgentCardAsync;
     }
 
     public async Task ExecuteAgentTaskAsync(AgentTask task, CancellationToken cancellationToken)
@@ -168,43 +167,40 @@ public class SemanticKernelTravelAgent : IDisposable
         await _taskManager.UpdateStatusAsync(task.Id, TaskState.Completed, cancellationToken: cancellationToken);
     }
 
-    public static Task<AgentCard> GetAgentCardAsync(string agentUrl, CancellationToken cancellationToken)
+    public static AgentCard Card
     {
-        if (cancellationToken.IsCancellationRequested)
+        get
         {
-            return Task.FromCanceled<AgentCard>(cancellationToken);
-        }
+            var capabilities = new AgentCapabilities()
+            {
+                Streaming = false,
+                PushNotifications = false,
+            };
 
-        var capabilities = new AgentCapabilities()
-        {
-            Streaming = false,
-            PushNotifications = false,
-        };
-
-        var skillTripPlanning = new AgentSkill()
-        {
-            Id = "trip_planning_sk",
-            Name = "Semantic Kernel Trip Planning",
-            Description = "Handles comprehensive trip planning, including currency exchanges, itinerary creation, sightseeing, dining recommendations, and event bookings using Frankfurter API for currency conversions.",
-            Tags = ["trip", "planning", "travel", "currency", "semantic-kernel"],
-            Examples =
-            [
-                "I am from Korea. Plan a budget-friendly day trip to Dublin including currency exchange.",
+            var skillTripPlanning = new AgentSkill()
+            {
+                Id = "trip_planning_sk",
+                Name = "Semantic Kernel Trip Planning",
+                Description = "Handles comprehensive trip planning, including currency exchanges, itinerary creation, sightseeing, dining recommendations, and event bookings using Frankfurter API for currency conversions.",
+                Tags = ["trip", "planning", "travel", "currency", "semantic-kernel"],
+                Examples =
+                [
+                    "I am from Korea. Plan a budget-friendly day trip to Dublin including currency exchange.",
                 "I am from Korea. What's the exchange rate and recommended itinerary for visiting Galway?",
             ],
-        };
+            };
 
-        return Task.FromResult(new AgentCard()
-        {
-            Name = "SK Travel Agent",
-            Description = "Semantic Kernel-based travel agent providing comprehensive trip planning services including currency exchange and personalized activity planning.",
-            Url = agentUrl,
-            Version = "1.0.0",
-            DefaultInputModes = ["text"],
-            DefaultOutputModes = ["text"],
-            Capabilities = capabilities,
-            Skills = [skillTripPlanning],
-        });
+            return new AgentCard()
+            {
+                Name = "SK Travel Agent",
+                Description = "Semantic Kernel-based travel agent providing comprehensive trip planning services including currency exchange and personalized activity planning.",
+                Version = "1.0.0",
+                DefaultInputModes = ["text"],
+                DefaultOutputModes = ["text"],
+                Capabilities = capabilities,
+                Skills = [skillTripPlanning],
+            };
+        }
     }
 
     #region private

--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -23,25 +23,6 @@ internal static class A2AHttpProcessor
     public static readonly ActivitySource ActivitySource = new("A2A.HttpProcessor", "1.0.0");
 
     /// <summary>
-    /// Processes a request to retrieve the agent card containing agent capabilities and metadata.
-    /// </summary>
-    /// <remarks>
-    /// Invokes the task manager's agent card query handler to get current agent information.
-    /// </remarks>
-    /// <param name="taskManager">The task manager instance containing the agent card query handler.</param>
-    /// <param name="logger">Logger instance for recording operation details and errors.</param>
-    /// <param name="agentUrl">The URL of the agent to retrieve the card for.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
-    /// <returns>An HTTP result containing the agent card JSON or an error response.</returns>
-    internal static Task<IResult> GetAgentCardAsync(ITaskManager taskManager, ILogger logger, string agentUrl, CancellationToken cancellationToken)
-        => WithExceptionHandlingAsync(logger, "GetAgentCard", async ct =>
-        {
-            var agentCard = await taskManager.OnAgentCardQuery(agentUrl, ct);
-
-            return Results.Ok(agentCard);
-        }, cancellationToken: cancellationToken);
-
-    /// <summary>
     /// Processes a request to retrieve a specific task by its ID.
     /// </summary>
     /// <remarks>

--- a/src/A2A/Models/AgentCapabilities.cs
+++ b/src/A2A/Models/AgentCapabilities.cs
@@ -8,6 +8,21 @@ namespace A2A;
 public sealed class AgentCapabilities
 {
     /// <summary>
+    /// Creates a new instance of the <see cref="AgentCapabilities"/> class.
+    /// </summary>
+    public AgentCapabilities()
+    {
+    }
+
+    internal AgentCapabilities(AgentCapabilities source)
+    {
+        Streaming = source.Streaming;
+        PushNotifications = source.PushNotifications;
+        StateTransitionHistory = source.StateTransitionHistory;
+        Extensions = [.. source.Extensions];
+    }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the agent supports SSE.
     /// </summary>
     [JsonPropertyName("streaming")]

--- a/src/A2A/Models/AgentCard.cs
+++ b/src/A2A/Models/AgentCard.cs
@@ -14,6 +14,35 @@ namespace A2A;
 public sealed class AgentCard
 {
     /// <summary>
+    /// Creates a new instance of the <see cref="AgentCard"/> class.
+    /// </summary>
+    public AgentCard()
+    {
+    }
+
+    // A constructor for cloning purposes.
+    internal AgentCard(AgentCard source)
+    {
+        Name = source.Name;
+        Description = source.Description;
+        Url = source.Url;
+        IconUrl = source.IconUrl;
+        Provider = source.Provider is null ? new AgentProvider() : new AgentProvider(source.Provider);
+        Version = source.Version;
+        ProtocolVersion = source.ProtocolVersion;
+        DocumentationUrl = source.DocumentationUrl;
+        Capabilities = source.Capabilities is null ? new AgentCapabilities() : new AgentCapabilities(source.Capabilities);
+        SecuritySchemes = source.SecuritySchemes is null ? null : new Dictionary<string, SecurityScheme>(source.SecuritySchemes, source.SecuritySchemes.Comparer);
+        Security = source.Security is not null ? new Dictionary<string, string[]>(source.Security) : null;
+        DefaultInputModes = [.. source.DefaultInputModes];
+        DefaultOutputModes = [.. source.DefaultOutputModes];
+        Skills = [.. source.Skills];
+        SupportsAuthenticatedExtendedCard = source.SupportsAuthenticatedExtendedCard;
+        AdditionalInterfaces = [.. source.AdditionalInterfaces];
+        PreferredTransport = source.PreferredTransport.HasValue ? new AgentTransport(source.PreferredTransport.Value) : null;
+    }
+
+    /// <summary>
     /// Gets or sets the human readable name of the agent.
     /// </summary>
     [JsonPropertyName("name")]

--- a/src/A2A/Models/AgentProvider.cs
+++ b/src/A2A/Models/AgentProvider.cs
@@ -8,6 +8,19 @@ namespace A2A;
 public sealed class AgentProvider
 {
     /// <summary>
+    /// Creates a new instance of the <see cref="AgentProvider"/> class.
+    /// </summary>
+    public AgentProvider()
+    {
+    }
+
+    internal AgentProvider(AgentProvider source)
+    {
+        Organization = source.Organization;
+        Url = source.Url;
+    }
+
+    /// <summary>
     /// Agent provider's organization name.
     /// </summary>
     [JsonPropertyName("organization")]

--- a/src/A2A/Models/AgentTransport.cs
+++ b/src/A2A/Models/AgentTransport.cs
@@ -31,6 +31,11 @@ public readonly struct AgentTransport : IEquatable<AgentTransport>
         this.Label = label;
     }
 
+    internal AgentTransport(AgentTransport source)
+    {
+        Label = source.Label;
+    }
+
     /// <summary>
     /// Determines whether two <see cref="AgentTransport"/> instances are equal.
     /// </summary>

--- a/src/A2A/Server/AgentCardProvider.cs
+++ b/src/A2A/Server/AgentCardProvider.cs
@@ -1,0 +1,77 @@
+﻿namespace A2A
+{
+    /// <summary>
+    /// Provides an agent card for a specific agent.
+    /// /// </summary>
+    public class AgentCardProvider
+    {
+        private readonly AgentCard _agentCard;
+
+        /// <summary>
+        /// Creates a new instance of the AgentCardProvider.
+        /// </summary>
+        /// <param name="agentCard">The valid agent card to initialize with.</param>
+        /// <exception cref="ArgumentNullException">Thrown when agentCard is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when any required property of agentCard is null or empty.</exception>
+        public AgentCardProvider(AgentCard agentCard)
+        {
+            if (agentCard is null)
+            {
+                throw new ArgumentNullException(nameof(agentCard));
+            }
+            else if (string.IsNullOrWhiteSpace(agentCard.Name))
+            {
+                throw new ArgumentException("Agent card must define a non-empty Name.", nameof(agentCard));
+            }
+            else if (string.IsNullOrWhiteSpace(agentCard.Description))
+            {
+                throw new ArgumentException("Agent card must define a non-empty Description.", nameof(agentCard));
+            }
+            else if (string.IsNullOrWhiteSpace(agentCard.Version))
+            {
+                throw new ArgumentException("Agent card must define a non-empty Version.", nameof(agentCard));
+            }
+            else if (string.IsNullOrWhiteSpace(agentCard.ProtocolVersion))
+            {
+                throw new ArgumentException("Agent card must define a non-empty ProtocolVersion.", nameof(agentCard));
+            }
+            else if (agentCard.Capabilities is null)
+            {
+                throw new ArgumentException("Agent card must define Capabilities.", nameof(agentCard));
+            }
+            else if (agentCard.DefaultInputModes is null || agentCard.DefaultInputModes.Count == 0)
+            {
+                throw new ArgumentException("Agent card must define DefaultInputModes with at least one mode.", nameof(agentCard));
+            }
+            else if (agentCard.DefaultOutputModes is null || agentCard.DefaultOutputModes.Count == 0)
+            {
+                throw new ArgumentException("Agent card must define DefaultOutputModes with at least one mode.", nameof(agentCard));
+            }
+
+            _agentCard = agentCard;
+        }
+
+        /// <summary>
+        /// Returns agent capability information for a given agent URL.
+        /// </summary>
+        /// <param name="agentUrl">The URL of the agent.</param>
+        /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+        /// <returns>A task representing the asynchronous operation, with the agent card as the result.</returns>
+        public virtual Task<AgentCard> GetAgentCardAsync(string agentUrl, CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<AgentCard>(cancellationToken);
+            }
+
+            if (string.IsNullOrWhiteSpace(agentUrl))
+            {
+                return Task.FromException<AgentCard>(new ArgumentNullException(nameof(agentUrl)));
+            }
+
+            // Ensure the agent card is cloned to avoid modifying the original instance
+            // or even worse, the same instance being modified by another thread with different agent URL.
+            return Task.FromResult(new AgentCard(_agentCard) { Url = agentUrl });
+        }
+    }
+}

--- a/src/A2A/Server/ITaskManager.cs
+++ b/src/A2A/Server/ITaskManager.cs
@@ -45,14 +45,6 @@ public interface ITaskManager
     Func<AgentTask, CancellationToken, Task> OnTaskUpdated { get; set; }
 
     /// <summary>
-    /// Gets or sets the handler for when an agent card is queried.
-    /// </summary>
-    /// <remarks>
-    /// Returns agent capability information for a given agent URL.
-    /// </remarks>
-    Func<string, CancellationToken, Task<AgentCard>> OnAgentCardQuery { get; set; }
-
-    /// <summary>
     /// Creates a new agent task with a unique ID and initial status.
     /// </summary>
     /// <remarks>

--- a/src/A2A/Server/TaskManager.cs
+++ b/src/A2A/Server/TaskManager.cs
@@ -35,12 +35,6 @@ public sealed class TaskManager : ITaskManager
     /// <inheritdoc />
     public Func<AgentTask, CancellationToken, Task> OnTaskUpdated { get; set; } = static (_, _) => Task.CompletedTask;
 
-    /// <inheritdoc />
-    public Func<string, CancellationToken, Task<AgentCard>> OnAgentCardQuery { get; set; }
-        = static (agentUrl, ct) => ct.IsCancellationRequested
-            ? Task.FromCanceled<AgentCard>(ct)
-            : Task.FromResult(new AgentCard() { Name = "Unknown", Url = agentUrl });
-
     /// <summary>
     /// Initializes a new instance of the TaskManager class.
     /// </summary>
@@ -154,7 +148,7 @@ public sealed class TaskManager : ITaskManager
         if (!string.IsNullOrWhiteSpace(messageSendParams.Message.TaskId))
         {
             activity?.SetTag("task.id", messageSendParams.Message.TaskId);
-            task = await _taskStore.GetTaskAsync(messageSendParams.Message.TaskId, cancellationToken).ConfigureAwait(false);
+            task = await _taskStore.GetTaskAsync(messageSendParams.Message.TaskId!, cancellationToken).ConfigureAwait(false);
             if (task == null)
             {
                 activity?.SetTag("task.found", false);
@@ -223,7 +217,7 @@ public sealed class TaskManager : ITaskManager
         if (!string.IsNullOrWhiteSpace(messageSendParams.Message.TaskId))
         {
             activity?.SetTag("task.id", messageSendParams.Message.TaskId);
-            agentTask = await _taskStore.GetTaskAsync(messageSendParams.Message.TaskId, cancellationToken).ConfigureAwait(false);
+            agentTask = await _taskStore.GetTaskAsync(messageSendParams.Message.TaskId!, cancellationToken).ConfigureAwait(false);
             if (agentTask == null)
             {
                 activity?.SetTag("task.found", false);

--- a/tests/A2A.AspNetCore.UnitTests/A2AEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AEndpointRouteBuilderExtensionsTests.cs
@@ -32,11 +32,12 @@ public class A2AEndpointRouteBuilderExtensionsTests
         var services = serviceCollection.BuildServiceProvider();
 
         var app = WebApplication.CreateBuilder().Build();
-        var taskManager = new TaskManager();
+        AgentCard agentCard = CreateValidAgentCard();
+        AgentCardProvider agentCardProvider = new(agentCard);
 
         // Act & Assert - Should not throw
-        var result = app.MapWellKnownAgentCard(taskManager, "/agent");
-        Assert.NotNull(result);
+        Assert.NotNull(app.MapWellKnownAgentCard(agentCard, "/agentCard"));
+        Assert.NotNull(app.MapWellKnownAgentCard(agentCardProvider, "/agentCardProvider"));
     }
 
     [Fact]
@@ -50,13 +51,17 @@ public class A2AEndpointRouteBuilderExtensionsTests
 
         var app = WebApplication.CreateBuilder().Build();
         var taskManager = new TaskManager();
+        AgentCard agentCard = CreateValidAgentCard();
+        AgentCardProvider agentCardProvider = new(agentCard);
 
         // Act & Assert - Should not throw when calling both
         var result1 = app.MapA2A(taskManager, "/agent");
-        var result2 = app.MapWellKnownAgentCard(taskManager, "/agent");
+        var result2 = app.MapWellKnownAgentCard(agentCard, "/agentCard");
+        var result3 = app.MapWellKnownAgentCard(agentCardProvider, "/agentCardProvider");
 
         Assert.NotNull(result1);
         Assert.NotNull(result2);
+        Assert.NotNull(result3);
     }
 
     [Theory]
@@ -86,16 +91,19 @@ public class A2AEndpointRouteBuilderExtensionsTests
     {
         // Arrange
         var app = WebApplication.CreateBuilder().Build();
-        var taskManager = new TaskManager();
+        AgentCard agentCard = CreateValidAgentCard();
+        AgentCardProvider agentCardProvider = new(agentCard);
 
         // Act & Assert
         if (agentPath == null)
         {
-            Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard(taskManager, agentPath!));
+            Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard(agentCard, agentPath!));
+            Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard(agentCardProvider, agentPath!));
         }
         else
         {
-            Assert.Throws<ArgumentException>(() => app.MapWellKnownAgentCard(taskManager, agentPath));
+            Assert.Throws<ArgumentException>(() => app.MapWellKnownAgentCard(agentCard, agentPath));
+            Assert.Throws<ArgumentException>(() => app.MapWellKnownAgentCard(agentCardProvider, agentPath));
         }
     }
 
@@ -116,6 +124,17 @@ public class A2AEndpointRouteBuilderExtensionsTests
         var app = WebApplication.CreateBuilder().Build();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard(null!, "/agent"));
+        Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard(agentCard: null!, "/agent"));
+        Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard(agentCardProvider: null!, "/agent"));
     }
+
+    private static AgentCard CreateValidAgentCard()
+        => new AgentCard
+        {
+            Name = "Test Agent",
+            Description = "A test agent for unit testing.",
+            Version = "1.0.0",
+            DefaultInputModes = [ "text" ],
+            DefaultOutputModes = ["text"]
+        };
 }

--- a/tests/A2A.AspNetCore.UnitTests/A2AHttpProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AHttpProcessorTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -11,23 +10,6 @@ namespace A2A.AspNetCore.Tests;
 
 public class A2AHttpProcessorTests
 {
-    [Fact]
-    public async Task GetAgentCard_ShouldReturnValidJsonResult()
-    {
-        // Arrange
-        var taskManager = new TaskManager();
-        var logger = NullLogger.Instance;
-
-        // Act
-        var result = await A2AHttpProcessor.GetAgentCardAsync(taskManager, logger, "http://example.com", CancellationToken.None);
-        (int statusCode, string? contentType, AgentCard agentCard) = await GetAgentCardResponse(result);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status200OK, statusCode);
-        Assert.Equal("application/json; charset=utf-8", contentType);
-        Assert.Equal("Unknown", agentCard.Name);
-    }
-
     [Fact]
     public async Task GetTask_ShouldReturnNotNull()
     {


### PR DESCRIPTION
This PR does the following:
- it removes `ITaskManager.OnAgentCardQuery` because `TaskManager` should not be responsible for Agent Cards and events should not be queries
- introduces `AgentCardProvider`:
    - allows for customization (the method is `virtual`)
    - allows for simple configuration: the user just needs to provide `AgentCard`. 
    - it enforces validation: all the `[JsonRequired]` fields are checked at creation time


So far `TaskManager` was by default returning an invalid `AgentCard`:

https://github.com/a2aproject/a2a-dotnet/blob/5b6cdd857e3b9b49ea7a764ae92e37051a062aba/src/A2A/Server/TaskManager.cs#L42

And the user had to find out how to configure it properly. Now I hope it's more intuitive and kind of obvious.

fixes #88