### PR TITLE
fix: Update A2A endpoint paths to use configuration values and have a…

### DIFF
--- a/samples/SemanticKernelAgent/Program.cs
+++ b/samples/SemanticKernelAgent/Program.cs
@@ -34,7 +34,8 @@ var logger = app.Logger;
 var agent = new SemanticKernelTravelAgent(configuration, httpClient, logger);
 var taskManager = new TaskManager();
 agent.Attach(taskManager);
-app.MapA2A(taskManager, string.Empty);
-app.MapWellKnownAgentCard(taskManager, string.Empty);
+string a2aPath = configuration["A2aPath"] ?? "/a2a";
+app.MapA2A(taskManager, a2aPath);
+app.MapWellKnownAgentCard(taskManager, a2aPath);
 
 await app.RunAsync();

--- a/samples/SemanticKernelAgent/Program.cs
+++ b/samples/SemanticKernelAgent/Program.cs
@@ -34,7 +34,7 @@ var logger = app.Logger;
 var agent = new SemanticKernelTravelAgent(configuration, httpClient, logger);
 var taskManager = new TaskManager();
 agent.Attach(taskManager);
-string a2aPath = configuration["A2aPath"] ?? "/a2a";
+string a2aPath = configuration["A2aPath"] ?? "/";
 app.MapA2A(taskManager, a2aPath);
 app.MapWellKnownAgentCard(taskManager, a2aPath);
 

--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -55,7 +55,7 @@ public static class A2ARouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(taskManager);
         ArgumentException.ThrowIfNullOrEmpty(agentPath);
 
-        var routeGroup = endpoints.MapGroup("");
+        var routeGroup = endpoints.MapGroup(agentPath);
 
         routeGroup.MapGet(".well-known/agent.json", async (HttpRequest request, CancellationToken cancellationToken) =>
         {

--- a/tests/A2A.AspNetCore.UnitTests/A2AEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AEndpointRouteBuilderExtensionsTests.cs
@@ -118,4 +118,36 @@ public class A2AEndpointRouteBuilderExtensionsTests
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard(null!, "/agent"));
     }
+
+    [Theory]
+    [InlineData("/agent")]
+    [InlineData("/my-api")]
+    [InlineData("/")]
+    [InlineData("/v1/agents/foo")]
+    public void MapWellKnownAgentCard_AcceptsDifferentPaths(string agentPath)
+    {
+        // Arrange
+        var app = WebApplication.CreateBuilder().Build();
+        var taskManager = new TaskManager();
+
+        // Act & Assert - Should not throw with different valid paths
+        var result = app.MapWellKnownAgentCard(taskManager, agentPath);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void MapWellKnownAgentCard_CanRegisterMultipleAgentsAtDifferentPaths()
+    {
+        // Arrange
+        var app = WebApplication.CreateBuilder().Build();
+        var taskManager1 = new TaskManager();
+        var taskManager2 = new TaskManager();
+
+        // Act & Assert - Should not throw when registering multiple agents
+        var result1 = app.MapWellKnownAgentCard(taskManager1, "/agent1");
+        var result2 = app.MapWellKnownAgentCard(taskManager2, "/agent2");
+
+        Assert.NotNull(result1);
+        Assert.NotNull(result2);
+    }
 }


### PR DESCRIPTION
Problem

The well-known agent card endpoint is currently always mapped at the root (/.well-known/agent.json) regardless of where the agent is hosted. This prevents hosting multiple agents on the same domain.

Solution

Modify MapWellKnownAgentCard to map the well-known endpoint relative to the agent's base path.

Changes Required

1. Update A2AEndpointRouteBuilderExtensions.cs:
  - Change line 58 from endpoints.MapGroup("") to endpoints.MapGroup(agentPath)
  - This will make the well-known endpoint relative to the agent path

Expected Behavior After Change

- Agent at /a2a → Well-known at /a2a/.well-known/agent.json
- Agent at /echo → Well-known at /echo/.well-known/agent.json
- Agent at / → Well-known at /.well-known/agent.json

Impact

- This is a breaking change for existing clients expecting the well-known endpoint at the root
- All samples in the repository will work correctly since they pass the same path to both methods
- The change aligns with the logical expectation that agent metadata should be discoverable relative to the agent's location