### PR TITLE
fix: Fix `release.yml` workflow failures on `ubuntu-latest`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,9 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: |
+          8.0.x
+          9.0.x
 
     - name: Build
       run: dotnet build --configuration ${{ matrix.configuration }}


### PR DESCRIPTION
Fixes failures of https://github.com/a2aproject/a2a-dotnet/blob/main/.github/workflows/release.yaml workflow on `ubuntu-latest` (e.g. https://github.com/a2aproject/a2a-dotnet/actions/runs/16985047713) by installing `8.0.x` version of .NET (together with the `9.0.x` version) using `actions/setup-dotnet` action.

Validated by https://github.com/Blackhex/a2a-dotnet/actions/runs/16988888966.