### PR TITLE
fix: change AgentCard's Security prop type to comply a2a spec

### DIFF
--- a/src/A2A/Models/AgentCard.cs
+++ b/src/A2A/Models/AgentCard.cs
@@ -91,7 +91,7 @@ public sealed class AgentCard
     /// Gets or sets the security requirements for contacting the agent.
     /// </summary>
     [JsonPropertyName("security")]
-    public Dictionary<string, string[]>? Security { get; set; }
+    public List<Dictionary<string, string[]>>? Security { get; set; }
 
     /// <summary>
     /// Gets or sets the set of interaction modes that the agent supports across all skills.

--- a/tests/A2A.UnitTests/Models/AgentCardTests.cs
+++ b/tests/A2A.UnitTests/Models/AgentCardTests.cs
@@ -30,9 +30,11 @@ public class AgentCardTests
               "in": "header"
             }
           },
-          "security": {
-            "apiKey": []
-          },
+          "security": [
+            {
+              "apiKey": []
+            }
+          ],
           "defaultInputModes": ["text", "image"],
           "defaultOutputModes": ["text", "json"],
           "skills": [
@@ -93,6 +95,10 @@ public class AgentCardTests
         Assert.False(string.IsNullOrWhiteSpace(apisec.KeyLocation));
         Assert.NotNull(deserializedCard.Security);
         Assert.Single(deserializedCard.Security);
+        Assert.NotNull(deserializedCard.Security[0]);
+        Assert.Single(deserializedCard.Security[0]);
+        Assert.True(deserializedCard.Security[0].ContainsKey("apiKey"));
+        Assert.Empty(deserializedCard.Security[0]["apiKey"]);
 
         // Input/Output modes
         Assert.Equal(new List<string> { "text", "image" }, deserializedCard.DefaultInputModes);
@@ -146,9 +152,12 @@ public class AgentCardTests
             {
                 ["apiKey"] = new ApiKeySecurityScheme("X-API-Key", "header")
             },
-            Security = new Dictionary<string, string[]>
+            Security = new List<Dictionary<string, string[]>>
             {
-                ["apiKey"] = []
+                new()
+                {
+                    ["apiKey"] = []
+                }
             },
             DefaultInputModes = ["text", "image"],
             DefaultOutputModes = ["text", "json"],

--- a/tests/A2A.UnitTests/Models/AgentCardTests.cs
+++ b/tests/A2A.UnitTests/Models/AgentCardTests.cs
@@ -93,12 +93,15 @@ public class AgentCardTests
         var apisec = Assert.IsType<ApiKeySecurityScheme>(deserializedCard.SecuritySchemes["apiKey"]);
         Assert.False(string.IsNullOrWhiteSpace(apisec.Name));
         Assert.False(string.IsNullOrWhiteSpace(apisec.KeyLocation));
+
         Assert.NotNull(deserializedCard.Security);
         Assert.Single(deserializedCard.Security);
-        Assert.NotNull(deserializedCard.Security[0]);
-        Assert.Single(deserializedCard.Security[0]);
-        Assert.True(deserializedCard.Security[0].ContainsKey("apiKey"));
-        Assert.Empty(deserializedCard.Security[0]["apiKey"]);
+
+        var securityRequirement = deserializedCard.Security[0];
+        Assert.NotNull(securityRequirement);
+        Assert.Single(securityRequirement);
+        Assert.True(securityRequirement.ContainsKey("apiKey"));
+        Assert.Empty(securityRequirement["apiKey"]);
 
         // Input/Output modes
         Assert.Equal(new List<string> { "text", "image" }, deserializedCard.DefaultInputModes);


### PR DESCRIPTION
Fixes #151 