### PR TITLE
fixup: Fix #163 response code to -32602 when JSON polymorphics fail to deserialize due to missing discriminator

### DIFF
--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -57,6 +57,13 @@ public static class A2AJsonRpcProcessor
             var errorId = rpcRequest?.Id ?? new JsonRpcId(ex.GetRequestId());
             return new JsonRpcResponseResult(JsonRpcResponse.CreateJsonRpcErrorResponse(errorId, ex));
         }
+        // Missing JSON polymorphic discriminator case.
+        catch (NotSupportedException ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            var errorId = rpcRequest?.Id ?? new JsonRpcId((string?)null);
+            return new JsonRpcResponseResult(JsonRpcResponse.InvalidParamsResponse(errorId, ex.Message));
+        }
         catch (Exception ex)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);


### PR DESCRIPTION
The recent change #163 handled the case when there is a missing discriminator value by throwing an `A2AException`. Nevertheless, this exception is consumed by the deserialized and `NotSupportedException` is returned instead. This falls into request handler case treaten as "internal server error" so `JsonRpcResponse.InternalErrorResponse()` is returned. The specification (https://a2a-protocol.org/dev/specification/#81-standard-json-rpc-errors) mandates to return `JsonRpcResponse.InvalidParamsResponse()` in this case istead.

Better fix would be to convince the serializer to return the original `A2AException` and handle that instead but I don't think it's possible?

PS: This has been discovered by running the compliance agent against the latest `a2a-tck` (after applying some additional fixed required).