### PR TITLE
chore: Match package version with v0.3.0 of the specification

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <Version>0.1.0-preview.3</Version>
+    <Version>0.3.1-preview</Version>
     <Authors>Community Contributors</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/a2aproject/a2a-dotnet</PackageProjectUrl>


### PR DESCRIPTION
Since we are aligning library version to specification version, the package version needs to be updated before release as well.

We are switching to versioning schema where major and minor version will be aligned with the protocol version and patch version will be incremented with each release starting from 1.