### PR TITLE
fix: Fix download of build artifacts on relese workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,6 +114,9 @@ jobs:
 
       - name: Download build artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: build-artifacts
+          path: ${{ github.workspace }}/build-artifacts
 
       - name: Authenticate to GitHub registry
         run: dotnet nuget add source
@@ -149,6 +152,9 @@ jobs:
 
       - name: Download build artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: build-artifacts
+          path: ${{ github.workspace }}/build-artifacts
 
       - name: Upload release asset
         run: gh release upload ${{ github.event.release.tag_name }}
@@ -174,6 +180,9 @@ jobs:
 
       - name: Download build artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: build-artifacts
+          path: ${{ github.workspace }}/build-artifacts
 
       - name: Publish to NuGet.org (Releases only)
         run: dotnet nuget push


### PR DESCRIPTION
After update, the `actions/download-artifact` do not place the downloaded artifacts to `build-artifacts` folder as before. This PR sets the location of the artifact explicitly. Furthermore, it requests only the `build-artifacts` artifact which removes warning.

Fix validated by https://github.com/Blackhex/a2a-dotnet/actions/runs/17468209270