### PR TITLE
fix: Agent card PreferredTransport MUST list supported transports

### DIFF
--- a/src/A2A/Models/AgentCard.cs
+++ b/src/A2A/Models/AgentCard.cs
@@ -139,10 +139,11 @@ public sealed class AgentCard
     /// The transport of the preferred endpoint.
     /// </summary>
     /// <remarks>
-    /// If empty, defaults to JSONRPC.
+    /// Defaults to JSONRPC transport when not explicitly specified.
     /// </remarks>
     [JsonPropertyName("preferredTransport")]
-    public AgentTransport? PreferredTransport { get; set; }
+    [JsonRequired]
+    public AgentTransport PreferredTransport { get; set; } = AgentTransport.JsonRpc;
 
     /// <summary>
     /// JSON Web Signatures computed for this AgentCard.

--- a/src/A2A/Models/AgentCard.cs
+++ b/src/A2A/Models/AgentCard.cs
@@ -139,7 +139,7 @@ public sealed class AgentCard
     /// The transport of the preferred endpoint.
     /// </summary>
     /// <remarks>
-    /// Defaults to JSONRPC transport when not explicitly specified.
+    /// This property is required. It defaults to <see cref="AgentTransport.JsonRpc"/> when an <see cref="AgentCard"/> is instantiated in code.
     /// </remarks>
     [JsonPropertyName("preferredTransport")]
     [JsonRequired]

--- a/tests/A2A.UnitTests/Models/AgentCardTests.cs
+++ b/tests/A2A.UnitTests/Models/AgentCardTests.cs
@@ -138,8 +138,7 @@ public class AgentCardTests
         Assert.Equal(["read"], skillSecurityRequirement["oauth"]);
 
         // Transport properties
-        Assert.NotNull(deserializedCard.PreferredTransport);
-        Assert.Equal("GRPC", deserializedCard.PreferredTransport.Value.Label);
+        Assert.Equal("GRPC", deserializedCard.PreferredTransport.Label);
         Assert.NotNull(deserializedCard.AdditionalInterfaces);
         Assert.Single(deserializedCard.AdditionalInterfaces);
         Assert.Equal("JSONRPC", deserializedCard.AdditionalInterfaces[0].Transport.Label);
@@ -287,7 +286,7 @@ public class AgentCardTests
         }
 
         // Transport properties
-        Assert.Equal(expectedCard.PreferredTransport?.Label, actualCard.PreferredTransport?.Label);
+        Assert.Equal(expectedCard.PreferredTransport.Label, actualCard.PreferredTransport.Label);
         Assert.Equal(expectedCard.AdditionalInterfaces?.Count, actualCard.AdditionalInterfaces?.Count);
         if (expectedCard.AdditionalInterfaces?.Count > 0 && actualCard.AdditionalInterfaces?.Count > 0)
         {


### PR DESCRIPTION
Many TCK tests failing for

> 3.4.2. Transport Selection and Negotiation[¶](https://a2a-protocol.org/dev/specification/#342-transport-selection-and-negotiation)
Agent Declaration: Agents MUST declare all supported transports in their AgentCard using the preferredTransport and additionalInterfaces fields.

Specification Reference: A2A Protocol v0.3.0 §3.4.2 - Transport Selection and Negotiation