### PR TITLE
fix: Change deser error handling to align wit JSON-RPC specs

### DIFF
--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -136,15 +136,16 @@ public static class A2AJsonRpcProcessor
         {
             parms = jsonParamValue.Deserialize(A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(T))) as T;
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            parms = null;
+            // Provide more specific error information about why parameter deserialization failed
+            throw new A2AException($"Invalid parameters for {typeof(T).Name}: {ex.Message}", ex, A2AErrorCode.InvalidParams);
         }
 
         switch (parms)
         {
             case null:
-                throw new A2AException("Invalid parameters", A2AErrorCode.InvalidParams);
+                throw new A2AException($"Failed to deserialize parameters as {typeof(T).Name}", A2AErrorCode.InvalidParams);
             case MessageSendParams messageSendParams when messageSendParams.Message.Parts.Count == 0:
                 throw new A2AException("Message parts cannot be empty", A2AErrorCode.InvalidParams);
             case TaskQueryParams taskQueryParams when taskQueryParams.HistoryLength < 0:

--- a/src/A2A/A2AJsonConverter.cs
+++ b/src/A2A/A2AJsonConverter.cs
@@ -49,15 +49,8 @@ namespace A2A
         public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             using var d = JsonDocument.ParseValue(ref reader);
-            try
-            {
-                var baseOptions = GetSafeOptions(options);
-                return d.Deserialize((JsonTypeInfo<T>)baseOptions.GetTypeInfo(typeToConvert));
-            }
-            catch (Exception e)
-            {
-                throw new A2AException($"Failed to deserialize {typeof(T).Name}: {e.Message}", e, A2AErrorCode.InvalidRequest);
-            }
+            var baseOptions = GetSafeOptions(options);
+            return d.Deserialize((JsonTypeInfo<T>)baseOptions.GetTypeInfo(typeToConvert));
         }
 
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)

--- a/tests/A2A.UnitTests/Models/MessageSendParamsTests.cs
+++ b/tests/A2A.UnitTests/Models/MessageSendParamsTests.cs
@@ -4,14 +4,16 @@ namespace A2A.UnitTests.Models
 {
     public sealed class MessageSendParamsTests
     {
-        [Fact]
-        public void MessageSendParams_Deserialize_NonMessageKind_Throws()
+        [Theory]
+        [InlineData("task")]
+        [InlineData("foo")]
+        public void MessageSendParams_Deserialize_InvalidKind_Throws(string invalidKind)
         {
             // Arrange
-            const string json = """
+            var json = $$"""
             {
                 "message": {
-                    "kind": "task",
+                    "kind": "{{invalidKind}}",
                     "id": "t-13",
                     "contextId": "c-13",
                     "status": { "state": "submitted" }
@@ -20,28 +22,7 @@ namespace A2A.UnitTests.Models
             """;
 
             // Act / Assert
-            var ex = Assert.Throws<A2AException>(() => JsonSerializer.Deserialize<MessageSendParams>(json, A2AJsonUtilities.DefaultOptions));
-            Assert.Equal(A2AErrorCode.InvalidRequest, ex.ErrorCode);
-        }
-
-        [Fact]
-        public void MessageSendParams_Deserialize_UnknownMessageKind_Throws()
-        {
-            // Arrange
-            const string json = """
-            {
-                "message": {
-                    "kind": "foo",
-                    "id": "t-13",
-                    "contextId": "c-13",
-                    "status": { "state": "submitted" }
-                }
-            }
-            """;
-
-            // Act / Assert
-            var ex = Assert.Throws<A2AException>(() => JsonSerializer.Deserialize<MessageSendParams>(json, A2AJsonUtilities.DefaultOptions));
-            Assert.Equal(A2AErrorCode.InvalidRequest, ex.ErrorCode);
+            var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MessageSendParams>(json, A2AJsonUtilities.DefaultOptions));
         }
 
         [Fact]


### PR DESCRIPTION
## Context
TCK tests was correctly identifying our wrong returning of error code `-32600 Invalid Request`
instead of correct `-32602 Invalid params` when message is invalid in params.

### Changes made
Remove JSON exception handling in JSON converters and let upper stack to properly do it as it already does for `JsonExceptions`

### Testing
After changes TCK mandatory tests no longer fails.
<img width="897" height="223" alt="image" src="https://github.com/user-attachments/assets/30131e6b-a2e4-41c4-9cc9-bd4f18e88b84" />

