### PR TITLE
Fix A2A unnecessary dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,18 +5,18 @@
     </PropertyGroup>
     <ItemGroup>
         <!-- Product dependencies netstandard -->
-        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.9" />
         <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
         <PackageVersion Include="Microsoft.Extensions.ExtraAnalyzers" Version="8.0.0-rc.2.23510.2" />
-        <PackageVersion Include="System.Text.Json" Version="9.0.8" />
+        <PackageVersion Include="System.Text.Json" Version="9.0.9" />
         <!-- Product dependencies shared -->
-        <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.0-preview.5.25277.114" />
-        <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0-preview.5.25277.114" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+        <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" />
+        <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.0-rc.1.25451.107" />
         <!-- Testing / samples dependencies -->
         <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
         <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.1" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
         <PackageVersion Include="Microsoft.SemanticKernel.Agents.Core" Version="1.59.0" />
         <PackageVersion Include="Microsoft.SemanticKernel.Agents.OpenAI" Version="1.59.0-preview" />
         <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.59.0" />
@@ -33,7 +33,7 @@
         <!-- Build / infrastructure dependencies -->
         <PackageVersion Include="coverlet.collector" Version="6.0.4" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageVersion Include="System.Threading.Channels" Version="9.0.7" />
+        <PackageVersion Include="System.Threading.Channels" Version="9.0.9" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
         <!-- Code analyzers -->

--- a/src/A2A/A2A.csproj
+++ b/src/A2A/A2A.csproj
@@ -29,13 +29,12 @@
     <ItemGroup>
         <InternalsVisibleTo Include="A2A.AspNetCore" Key="0024000004800000940000000602000000240000525341310004000001000100fdff21bdfb01242cffd857fcfe4fd1048248b80c2d5779adf1916ba0f2fdfb7d9f780ba2c7eb359d8b2c40be090f54d99f29ada7769f3b50d5db1e92e645577abc702cb53a9ccdae1ff5aaf4c413f9ba4fd26f298f8756d38d0c4c9c813b39dd6f760f29ed0094f55af0dd698df03c714dace31a70362a2970fd0fa5a5dc5ec1" />
         <InternalsVisibleTo Include="A2A.UnitTests" Key="0024000004800000940000000602000000240000525341310004000001000100fdff21bdfb01242cffd857fcfe4fd1048248b80c2d5779adf1916ba0f2fdfb7d9f780ba2c7eb359d8b2c40be090f54d99f29ada7769f3b50d5db1e92e645577abc702cb53a9ccdae1ff5aaf4c413f9ba4fd26f298f8756d38d0c4c9c813b39dd6f760f29ed0094f55af0dd698df03c714dace31a70362a2970fd0fa5a5dc5ec1" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.ExtraAnalyzers">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
-        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="System.Linq.AsyncEnumerable" />
         <PackageReference Include="System.Net.ServerSentEvents" />
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">

--- a/src/A2A/A2AJsonUtilities.cs
+++ b/src/A2A/A2AJsonUtilities.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Options;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Text.Json;


### PR DESCRIPTION
The A2A project had dependencies on Microsoft.Extensions.Caching.Abstractions, which it didn't use at all, and Microsoft.Extensions.Logging, which it only needed for the Microsoft.Extensions.Logging.Abstractions dependency.