### PR TITLE
chore: Add workflow to prefix Dependabot PR titles

### DIFF
--- a/.github/workflows/prefix-dependabot-pr-titles.yml
+++ b/.github/workflows/prefix-dependabot-pr-titles.yml
@@ -2,23 +2,27 @@ name: Prefix Dependabot PR Titles
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
 
 jobs:
   prefix-title:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - uses: actions/github-script@v7
+      - name: Prefix PR title if needed
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        uses: actions/github-script@v7
         with:
           script: |
             const prefix = "chore: ";
             const title = github.context.payload.pull_request.title;
-            if (!title.startsWith("chore")) {
+            if (!title.startsWith(prefix)) {
               await github.rest.pulls.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                pull_number: github.context.payload.pull_request.number,
                 title: prefix + title
               });
             }


### PR DESCRIPTION
This workflow prefixes titles of pull requests created by Dependabot with 'chore: '.