### PR TITLE
fix: use spec-compliant field names in FileContent

### DIFF
--- a/src/A2A/Extensions/AIContentExtensions.cs
+++ b/src/A2A/Extensions/AIContentExtensions.cs
@@ -84,13 +84,13 @@ public static class AIContentExtensions
                 break;
 
             case FilePart { File: { } file }:
-                if (file.Uri is not null)
+                if (file.FileWithUri is not null)
                 {
-                    content = new UriContent(file.Uri, file.MimeType ?? "application/octet-stream");
+                    content = new UriContent(file.FileWithUri, file.MediaType ?? "application/octet-stream");
                 }
-                else if (file.Bytes is not null)
+                else if (file.FileWithBytes is not null)
                 {
-                    content = new DataContent(Convert.FromBase64String(file.Bytes), file.MimeType ?? "application/octet-stream")
+                    content = new DataContent(Convert.FromBase64String(file.FileWithBytes), file.MediaType ?? "application/octet-stream")
                     {
                         Name = file.Name,
                     };
@@ -142,14 +142,14 @@ public static class AIContentExtensions
             case UriContent uriContent:
                 part = new FilePart
                 {
-                    File = new FileContent(uriContent.Uri) { MimeType = uriContent.MediaType },
+                    File = new FileContent(uriContent.Uri) { MediaType = uriContent.MediaType },
                 };
                 break;
 
             case DataContent dataContent:
                 part = new FilePart
                 {
-                    File = new FileContent(dataContent.Base64Data.ToString()) { MimeType = dataContent.MediaType },
+                    File = new FileContent(dataContent.Base64Data.ToString()) { MediaType = dataContent.MediaType },
                 };
                 break;
         }

--- a/src/A2A/Models/FileContent.cs
+++ b/src/A2A/Models/FileContent.cs
@@ -7,12 +7,12 @@ namespace A2A;
 /// <summary>
 /// Represents the base entity for FileParts.
 /// According to the A2A spec, FileContent types are distinguished by the presence
-/// of either "bytes" or "uri" properties, not by a discriminator.
+/// of either "fileWithBytes" or "fileWithUri" properties, not by a discriminator.
 /// </summary>
 public class FileContent
 {
-    private string? _bytes;
-    private Uri? _uri;
+    private string? _fileWithBytes;
+    private Uri? _fileWithUri;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FileContent"/> class.
@@ -32,7 +32,7 @@ public class FileContent
             throw new ArgumentNullException(nameof(bytes));
         }
 
-        _bytes = bytes;
+        _fileWithBytes = bytes;
     }
 
     /// <summary>
@@ -40,13 +40,13 @@ public class FileContent
     /// </summary>
     /// <param name="bytes">The byte sequence representing the file content.</param>
     /// <param name="encoding">The encoding to use for converting bytes to a string. Defaults to UTF-8 if not specified.</param>
-    public FileContent(IEnumerable<byte> bytes, Encoding? encoding = null) => _bytes = (encoding ?? Encoding.UTF8).GetString([.. bytes]);
+    public FileContent(IEnumerable<byte> bytes, Encoding? encoding = null) => _fileWithBytes = (encoding ?? Encoding.UTF8).GetString([.. bytes]);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FileContent"/> class with a URI reference.
     /// </summary>
     /// <param name="uri">The URI pointing to the file content.</param>
-    public FileContent(Uri uri) => _uri = uri;
+    public FileContent(Uri uri) => _fileWithUri = uri;
 
     /// <summary>
     /// Optional name for the file.
@@ -55,44 +55,44 @@ public class FileContent
     public string? Name { get; set; }
 
     /// <summary>
-    /// Optional mimeType for the file.
+    /// Optional media type for the file.
     /// </summary>
-    [JsonPropertyName("mimeType")]
-    public string? MimeType { get; set; }
+    [JsonPropertyName("mediaType")]
+    public string? MediaType { get; set; }
 
     /// <summary>
     /// base64 encoded content of the file.
     /// </summary>
-    [JsonPropertyName("bytes")]
-    public string? Bytes
+    [JsonPropertyName("fileWithBytes")]
+    public string? FileWithBytes
     {
-        get => _bytes;
+        get => _fileWithBytes;
         set
         {
-            if (!string.IsNullOrWhiteSpace(_uri?.ToString()))
+            if (!string.IsNullOrWhiteSpace(_fileWithUri?.ToString()))
             {
-                throw new A2AException("Only one of 'bytes' or 'uri' must be specified", A2AErrorCode.InvalidRequest);
+                throw new A2AException("Only one of 'fileWithBytes' or 'fileWithUri' must be specified", A2AErrorCode.InvalidRequest);
             }
 
-            _bytes = value;
+            _fileWithBytes = value;
         }
     }
 
     /// <summary>
     /// URL for the File content.
     /// </summary>
-    [JsonPropertyName("uri")]
-    public Uri? Uri
+    [JsonPropertyName("fileWithUri")]
+    public Uri? FileWithUri
     {
-        get => _uri;
+        get => _fileWithUri;
         set
         {
-            if (!string.IsNullOrWhiteSpace(_bytes))
+            if (!string.IsNullOrWhiteSpace(_fileWithBytes))
             {
-                throw new A2AException("Only one of 'bytes' or 'uri' must be specified", A2AErrorCode.InvalidRequest);
+                throw new A2AException("Only one of 'fileWithBytes' or 'fileWithUri' must be specified", A2AErrorCode.InvalidRequest);
             }
 
-            _uri = value;
+            _fileWithUri = value;
         }
     }
 
@@ -103,14 +103,14 @@ public class FileContent
             var root = document.RootElement;
 
             // Determine type based on presence of required properties
-            bool hasBytes = root.TryGetProperty("bytes", out var bytesProperty) &&
+            bool hasBytes = root.TryGetProperty("fileWithBytes", out var bytesProperty) &&
                            bytesProperty.ValueKind == JsonValueKind.String;
-            bool hasUri = root.TryGetProperty("uri", out var uriProperty) &&
+            bool hasUri = root.TryGetProperty("fileWithUri", out var uriProperty) &&
                          uriProperty.ValueKind == JsonValueKind.String;
 
             if (!hasBytes && !hasUri)
             {
-                throw new A2AException("FileContent must have either 'bytes' or 'uri' property", A2AErrorCode.InvalidRequest);
+                throw new A2AException("FileContent must have either 'fileWithBytes' or 'fileWithUri' property", A2AErrorCode.InvalidRequest);
             }
 
             return base.DeserializeImpl(typeof(FileContent), options, document);

--- a/tests/A2A.UnitTests/Models/AIContentExtensionsTests.cs
+++ b/tests/A2A.UnitTests/Models/AIContentExtensionsTests.cs
@@ -15,9 +15,9 @@ namespace A2A.UnitTests.Models
         public void ToChatMessage_ConvertsAgentRoleAndParts()
         {
             var text = new TextPart { Text = "hello" };
-            var file = new FilePart { File = new FileContent(new Uri("https://example.com")) { MimeType = "text/plain" } };
+            var file = new FilePart { File = new FileContent(new Uri("https://example.com")) { MediaType = "text/plain" } };
             var bytes = new byte[] { 1, 2, 3 };
-            var fileBytes = new FilePart { File = new FileContent(Convert.ToBase64String(bytes)) { MimeType = "application/octet-stream", Name = "b.bin" } };
+            var fileBytes = new FilePart { File = new FileContent(Convert.ToBase64String(bytes)) { MediaType = "application/octet-stream", Name = "b.bin" } };
             var data = new DataPart { Data = new Dictionary<string, JsonElement> { ["k"] = JsonSerializer.SerializeToElement("v") } };
             var agent = new AgentMessage
             {
@@ -135,7 +135,7 @@ namespace A2A.UnitTests.Models
         public void ToAIContent_ConvertsFilePartWithUri()
         {
             var uri = new Uri("https://example.com/data.json");
-            var part = new FilePart { File = new FileContent(uri) { MimeType = "application/json" } };
+            var part = new FilePart { File = new FileContent(uri) { MediaType = "application/json" } };
             var content = part.ToAIContent();
             var uc = Assert.IsType<UriContent>(content);
             Assert.Equal(uri, uc.Uri);
@@ -147,7 +147,7 @@ namespace A2A.UnitTests.Models
         {
             var raw = new byte[] { 10, 20, 30 };
             var b64 = Convert.ToBase64String(raw);
-            var part = new FilePart { File = new FileContent(b64) { MimeType = null, Name = "r.bin" } };
+            var part = new FilePart { File = new FileContent(b64) { MediaType = null, Name = "r.bin" } };
             var content = part.ToAIContent();
             var dc = Assert.IsType<DataContent>(content);
             Assert.Equal(raw, dc.Data);
@@ -208,9 +208,9 @@ namespace A2A.UnitTests.Models
             var content = new UriContent(uri, "text/plain");
             var part = content.ToPart();
             var fp = Assert.IsType<FilePart>(part);
-            Assert.NotNull(fp.File.Uri);
-            Assert.Equal(uri, fp.File.Uri);
-            Assert.Equal("text/plain", fp.File.MimeType);
+            Assert.NotNull(fp.File.FileWithUri);
+            Assert.Equal(uri, fp.File.FileWithUri);
+            Assert.Equal("text/plain", fp.File.MediaType);
         }
 
         [Fact]
@@ -220,9 +220,9 @@ namespace A2A.UnitTests.Models
             var content = new DataContent(payload, "application/custom");
             var part = content.ToPart();
             var fp = Assert.IsType<FilePart>(part);
-            Assert.NotNull(fp.File.Bytes);
-            Assert.Equal(new byte[] { 1, 2, 3, 4 }, Convert.FromBase64String(fp.File.Bytes));
-            Assert.Equal("application/custom", fp.File.MimeType);
+            Assert.NotNull(fp.File.FileWithBytes);
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, Convert.FromBase64String(fp.File.FileWithBytes));
+            Assert.Equal("application/custom", fp.File.MediaType);
         }
 
         [Fact]

--- a/tests/A2A.UnitTests/Models/FileContentSpecComplianceTests.cs
+++ b/tests/A2A.UnitTests/Models/FileContentSpecComplianceTests.cs
@@ -11,8 +11,8 @@ public class FileContentSpecComplianceTests
         const string json = """
         {
             "name": "example.txt",
-            "mimeType": "text/plain",
-            "bytes": "SGVsbG8gV29ybGQ="
+            "mediaType": "text/plain",
+            "fileWithBytes": "SGVsbG8gV29ybGQ="
         }
         """;
 
@@ -21,8 +21,8 @@ public class FileContentSpecComplianceTests
 
         Assert.NotNull(fileContent);
         Assert.Equal("example.txt", fileContent.Name);
-        Assert.Equal("text/plain", fileContent.MimeType);
-        Assert.Equal("SGVsbG8gV29ybGQ=", fileContent.Bytes);
+        Assert.Equal("text/plain", fileContent.MediaType);
+        Assert.Equal("SGVsbG8gV29ybGQ=", fileContent.FileWithBytes);
     }
 
     [Fact]
@@ -32,8 +32,8 @@ public class FileContentSpecComplianceTests
         const string json = """
         {
             "name": "example.txt",
-            "mimeType": "text/plain",
-            "uri": "https://example.com/file.txt"
+            "mediaType": "text/plain",
+            "fileWithUri": "https://example.com/file.txt"
         }
         """;
 
@@ -42,9 +42,9 @@ public class FileContentSpecComplianceTests
 
         Assert.NotNull(fileContent);
         Assert.Equal("example.txt", fileContent.Name);
-        Assert.Equal("text/plain", fileContent.MimeType);
-        Assert.NotNull(fileContent.Uri);
-        Assert.Equal("https://example.com/file.txt", fileContent.Uri.ToString());
+        Assert.Equal("text/plain", fileContent.MediaType);
+        Assert.NotNull(fileContent.FileWithUri);
+        Assert.Equal("https://example.com/file.txt", fileContent.FileWithUri.ToString());
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class FileContentSpecComplianceTests
         var fileWithBytes = new FileContent("SGVsbG8=")
         {
             Name = "test.txt",
-            MimeType = "text/plain",
+            MediaType = "text/plain",
         };
 
         // Act
@@ -62,9 +62,9 @@ public class FileContentSpecComplianceTests
 
         // Assert: Should not contain "kind" property
         Assert.DoesNotContain("\"kind\"", json);
-        Assert.Contains("\"bytes\"", json);
+        Assert.Contains("\"fileWithBytes\"", json);
         Assert.Contains("\"name\"", json);
-        Assert.Contains("\"mimeType\"", json);
+        Assert.Contains("\"mediaType\"", json);
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class FileContentSpecComplianceTests
         var fileWithUri = new FileContent(new Uri("https://example.com/test.txt"))
         {
             Name = "test.txt",
-            MimeType = "text/plain",
+            MediaType = "text/plain",
         };
 
         // Act
@@ -82,21 +82,21 @@ public class FileContentSpecComplianceTests
 
         // Assert: Should not contain "kind" property
         Assert.DoesNotContain("\"kind\"", json);
-        Assert.Contains("\"uri\"", json);
+        Assert.Contains("\"fileWithUri\"", json);
         Assert.Contains("\"name\"", json);
-        Assert.Contains("\"mimeType\"", json);
+        Assert.Contains("\"mediaType\"", json);
     }
 
     [Fact]
     public void FileContent_Deserialize_WithBothBytesAndUri_ShouldThrow()
     {
-        // Arrange: Invalid JSON with both bytes and uri
+        // Arrange: Invalid JSON with both fileWithBytes and fileWithUri
         const string json = """
         {
             "name": "example.txt",
-            "mimeType": "text/plain",
-            "bytes": "SGVsbG8=",
-            "uri": "https://example.com/file.txt"
+            "mediaType": "text/plain",
+            "fileWithBytes": "SGVsbG8=",
+            "fileWithUri": "https://example.com/file.txt"
         }
         """;
 
@@ -105,17 +105,17 @@ public class FileContentSpecComplianceTests
             JsonSerializer.Deserialize<FileContent>(json, A2AJsonUtilities.DefaultOptions));
 
         Assert.Equal(A2AErrorCode.InvalidRequest, ex.ErrorCode);
-        Assert.Contains("Only one of 'bytes' or 'uri' must be specified", ex.Message);
+        Assert.Contains("Only one of 'fileWithBytes' or 'fileWithUri' must be specified", ex.Message);
     }
 
     [Fact]
     public void FileContent_Deserialize_WithNeitherBytesNorUri_ShouldThrow()
     {
-        // Arrange: Invalid JSON with neither bytes nor uri
+        // Arrange: Invalid JSON with neither fileWithBytes nor fileWithUri
         const string json = """
         {
             "name": "example.txt",
-            "mimeType": "text/plain"
+            "mediaType": "text/plain"
         }
         """;
 
@@ -124,7 +124,7 @@ public class FileContentSpecComplianceTests
             JsonSerializer.Deserialize<FileContent>(json, A2AJsonUtilities.DefaultOptions));
 
         Assert.Equal(A2AErrorCode.InvalidRequest, ex.ErrorCode);
-        Assert.Contains("must have either 'bytes' or 'uri'", ex.Message);
+        Assert.Contains("must have either 'fileWithBytes' or 'fileWithUri'", ex.Message);
     }
 
     [Fact]
@@ -134,7 +134,7 @@ public class FileContentSpecComplianceTests
         var original = new FileContent("SGVsbG8gV29ybGQ=")
         {
             Name = "test.txt",
-            MimeType = "text/plain",
+            MediaType = "text/plain",
         };
 
         // Act: Serialize and deserialize
@@ -144,8 +144,8 @@ public class FileContentSpecComplianceTests
         // Assert
         Assert.NotNull(deserialized);
         Assert.Equal(original.Name, deserialized.Name);
-        Assert.Equal(original.MimeType, deserialized.MimeType);
-        Assert.Equal(original.Bytes, deserialized.Bytes);
+        Assert.Equal(original.MediaType, deserialized.MediaType);
+        Assert.Equal(original.FileWithBytes, deserialized.FileWithBytes);
     }
 
     [Fact]
@@ -155,7 +155,7 @@ public class FileContentSpecComplianceTests
         var original = new FileContent(new Uri("https://example.com/test.txt"))
         {
             Name = "test.txt",
-            MimeType = "text/plain",
+            MediaType = "text/plain",
         };
 
         // Act: Serialize and deserialize
@@ -165,7 +165,7 @@ public class FileContentSpecComplianceTests
         // Assert
         Assert.NotNull(deserialized);
         Assert.Equal(original.Name, deserialized.Name);
-        Assert.Equal(original.MimeType, deserialized.MimeType);
-        Assert.Equal(original.Uri, deserialized.Uri);
+        Assert.Equal(original.MediaType, deserialized.MediaType);
+        Assert.Equal(original.FileWithUri, deserialized.FileWithUri);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #269

Renames `FileContent` properties and their JSON serialization names to match the A2A protocol specification (Section 4.1.7. FilePart):

| Before | After |
|--------|-------|
| `MimeType` / `"mimeType"` | `MediaType` / `"mediaType"` |
| `Bytes` / `"bytes"` | `FileWithBytes` / `"fileWithBytes"` |
| `Uri` / `"uri"` | `FileWithUri` / `"fileWithUri"` |

Also updates the `Converter` property lookups and error messages, all call sites in `AIContentExtensions`, and all tests.

## Test plan

- [x] All 255 existing unit tests pass on both net8.0 and net9.0
- [x] `FileContentSpecComplianceTests` updated to assert correct spec field names in serialized JSON
- [x] `AIContentExtensionsTests` updated to use renamed properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)