### PR TITLE
fix: CancelTaskAsync does not update AgentTask.Status

### DIFF
--- a/src/A2A/Server/TaskManager.cs
+++ b/src/A2A/Server/TaskManager.cs
@@ -109,7 +109,7 @@ public sealed class TaskManager : ITaskManager
                 throw new A2AException("Task is in a terminal state and cannot be cancelled.", A2AErrorCode.TaskNotCancelable);
             }
 
-            await _taskStore.UpdateStatusAsync(task.Id, TaskState.Canceled, cancellationToken: cancellationToken).ConfigureAwait(false);
+            task.Status = await _taskStore.UpdateStatusAsync(task.Id, TaskState.Canceled, cancellationToken: cancellationToken).ConfigureAwait(false);
             await OnTaskCancelled(task, cancellationToken).ConfigureAwait(false);
             return task;
         }


### PR DESCRIPTION
## Summary

Fixes #277.

`CancelTaskAsync` was discarding the return value of `ITaskStore.UpdateStatusAsync`, causing the returned `AgentTask` to reflect the pre-cancellation status instead of `Canceled`.

- The bug was masked by `InMemoryTaskStore` because `GetTaskAsync` returns a reference to the cached object, which `UpdateStatusAsync` mutates in place
- Any external (non-memory) `ITaskStore` implementation would observe the bug: the store is updated correctly, but the returned `AgentTask.Status` is stale
- `OnTaskCancelled` was also receiving the task with the wrong status in those cases

**Fix:** assign the result of `UpdateStatusAsync` back to `task.Status` before returning.

```csharp
// before
await _taskStore.UpdateStatusAsync(task.Id, TaskState.Canceled, cancellationToken: cancellationToken).ConfigureAwait(false);

// after
task.Status = await _taskStore.UpdateStatusAsync(task.Id, TaskState.Canceled, cancellationToken: cancellationToken).ConfigureAwait(false);
```

## Test plan

- [ ] Verify existing tests pass
- [ ] Manually verify with a custom `ITaskStore` implementation that the returned `AgentTask.Status.State` equals `Canceled` after calling `CancelTaskAsync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)