### PR TITLE
fix(workflows): use correct context variable in github-script action

### DIFF
--- a/.github/workflows/prefix-dependabot-pr-titles.yml
+++ b/.github/workflows/prefix-dependabot-pr-titles.yml
@@ -17,12 +17,12 @@ jobs:
         with:
           script: |
             const prefix = "chore: ";
-            const title = github.context.payload.pull_request.title;
+            const title = context.payload.pull_request.title;
             if (!title.startsWith(prefix)) {
               await github.rest.pulls.update({
-                owner: github.context.repo.owner,
-                repo: github.context.repo.repo,
-                pull_number: github.context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
                 title: prefix + title
               });
             }


### PR DESCRIPTION
## Summary

Fixes `TypeError: Cannot read properties of undefined (reading 'payload')` in the Dependabot PR title prefixing workflow.

## Problem

The `prefix-dependabot-pr-titles.yml` workflow used `github.context.payload` and `github.context.repo` to access the GitHub Actions context. In `actions/github-script@v8`, `github` is the authenticated Octokit REST client and `context` is a separate top-level variable. Since `github` has no `.context` property, accessing it returned `undefined`, causing the runtime error.

## Fix

Replace all `github.context` references with `context`:
- `github.context.payload.pull_request.title` -> `context.payload.pull_request.title`
- `github.context.repo.owner` -> `context.repo.owner`
- `github.context.repo.repo` -> `context.repo.repo`
- `github.context.payload.pull_request.number` -> `context.payload.pull_request.number`