### PR TITLE
feat: add CORS support, enrich artifact append merge, and add streaming samples

### DIFF
--- a/samples/AgentClient/Program.cs
+++ b/samples/AgentClient/Program.cs
@@ -13,6 +13,8 @@ internal static class Program
             await MessageBasedCommunicationSample.RunAsync();
 
             await TaskBasedCommunicationSample.RunAsync();
+
+            await StreamingArtifactSample.RunAsync();
         }
         finally
         {

--- a/samples/AgentClient/Samples/StreamingArtifactSample.cs
+++ b/samples/AgentClient/Samples/StreamingArtifactSample.cs
@@ -1,0 +1,126 @@
+using A2A;
+
+namespace AgentClient.Samples;
+
+/// <summary>
+/// Demonstrates how to consume streaming artifact updates from an agent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Streaming artifact communication shows how agents can progressively build artifacts
+/// by sending multiple chunks to the same artifact ID. Each chunk appends new content
+/// (text parts, metadata, extensions) to the artifact as it streams in.
+/// </para>
+/// <para>
+/// Key characteristics:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Progressive delivery: Artifact content arrives in chunks via Server-Sent Events</description></item>
+/// <item><description>Append semantics: Each chunk appends parts to the same artifact ID</description></item>
+/// <item><description>LastChunk signal: The final chunk is marked with lastChunk=true to indicate completion</description></item>
+/// <item><description>Task lifecycle: The task progresses through Submitted → Working → Completed as chunks stream</description></item>
+/// </list>
+/// </remarks>
+internal sealed class StreamingArtifactSample
+{
+    /// <summary>
+    /// Demonstrates the complete workflow of streaming artifact communication with an A2A agent.
+    /// </summary>
+    public static async Task RunAsync()
+    {
+        Console.WriteLine($"\n=== Running the {nameof(StreamingArtifactSample)} sample ===");
+
+        // 1. Start the local agent server hosting the streaming artifact agent
+        await AgentServerUtils.StartLocalAgentServerAsync(agentName: "streamingartifact", port: 5102);
+
+        // 2. Get the agent card (served under the mapped path)
+        A2ACardResolver cardResolver = new(new Uri("http://localhost:5102/"), agentCardPath: "/streamingartifact/.well-known/agent-card.json");
+        AgentCard agentCard = await cardResolver.GetAgentCardAsync();
+        Console.WriteLine($" Connected to: {agentCard.Name}");
+
+        // 3. Create an A2A client using the known endpoint (the agent card URL uses the default port,
+        //    but we started the server on a custom port for sample isolation)
+        A2AClient agentClient = new(new Uri("http://localhost:5102/streamingartifact"));
+
+        // 4. Send a message and stream the artifact chunks
+        await StreamArtifactChunksAsync(agentClient);
+
+        // 5. Retrieve the final task to see the fully assembled artifact
+        await RetrieveFinalTaskAsync(agentClient);
+    }
+
+    private static string? s_taskId;
+
+    /// <summary>
+    /// Sends a streaming message and displays each artifact chunk as it arrives.
+    /// </summary>
+    private static async Task StreamArtifactChunksAsync(A2AClient agentClient)
+    {
+        Console.WriteLine("\nStreaming artifact chunks:");
+
+        Message userMessage = new()
+        {
+            Role = Role.User,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Parts = [Part.FromText("Generate a story")]
+        };
+
+        int chunkCount = 0;
+
+        await foreach (StreamResponse streamEvent in agentClient.SendStreamingMessageAsync(new SendMessageRequest { Message = userMessage }))
+        {
+            if (streamEvent.Task is { } task)
+            {
+                s_taskId = task.Id;
+                Console.WriteLine($"\n Task created: {task.Id} (state: {task.Status.State})");
+            }
+
+            if (streamEvent.StatusUpdate is { } statusUpdate)
+            {
+                Console.WriteLine($" Status: {statusUpdate.Status.State}");
+            }
+
+            if (streamEvent.ArtifactUpdate is { } artifactUpdate)
+            {
+                chunkCount++;
+                var text = artifactUpdate.Artifact.Parts[0].Text ?? "(non-text part)";
+                var truncated = text.Length > 80 ? text[..80] + "..." : text;
+                Console.WriteLine($" Chunk {chunkCount} (artifact: {artifactUpdate.Artifact.ArtifactId[..8]}..., " +
+                    $"append: {artifactUpdate.Append}, lastChunk: {artifactUpdate.LastChunk}):");
+                Console.WriteLine($"   {truncated}");
+            }
+        }
+
+        Console.WriteLine($"\n Stream complete. Received {chunkCount} artifact chunk(s).");
+    }
+
+    /// <summary>
+    /// Retrieves the final task state showing the fully assembled artifact with all chunks merged.
+    /// </summary>
+    private static async Task RetrieveFinalTaskAsync(A2AClient agentClient)
+    {
+        if (s_taskId is null)
+        {
+            Console.WriteLine("\n No task ID captured — skipping final retrieval.");
+            return;
+        }
+
+        Console.WriteLine($"\nRetrieving final task {s_taskId}:");
+        AgentTask finalTask = await agentClient.GetTaskAsync(new GetTaskRequest { Id = s_taskId });
+
+        Console.WriteLine($" Status: {finalTask.Status.State}");
+        Console.WriteLine($" Artifacts: {finalTask.Artifacts?.Count ?? 0}");
+
+        if (finalTask.Artifacts is { Count: > 0 } artifacts)
+        {
+            var artifact = artifacts[0];
+            Console.WriteLine($" Artifact '{artifact.Name}' ({artifact.Parts.Count} parts merged):");
+            foreach (var part in artifact.Parts)
+            {
+                var text = part.Text ?? "(non-text)";
+                var truncated = text.Length > 100 ? text[..100] + "..." : text;
+                Console.WriteLine($"   - {truncated}");
+            }
+        }
+    }
+}

--- a/samples/AgentServer/Program.cs
+++ b/samples/AgentServer/Program.cs
@@ -6,6 +6,17 @@ using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Configure CORS for browser-based clients (common local dev server ports)
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.WithOrigins("http://localhost:3000", "http://localhost:5000", "http://localhost:5173")
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+
 // Get the agent type and store type from command line arguments
 var agentType = GetArgValue(args, "--agent", "-a") ?? "echo";
 var storeType = GetArgValue(args, "--store", "-s");
@@ -39,6 +50,10 @@ switch (agentType.ToLowerInvariant())
         builder.Services.AddA2AAgent<SpecComplianceAgent>(SpecComplianceAgent.GetAgentCard($"{baseUrl}/speccompliance"));
         break;
 
+    case "streamingartifact":
+        builder.Services.AddA2AAgent<StreamingArtifactAgent>(StreamingArtifactAgent.GetAgentCard($"{baseUrl}/streamingartifact"));
+        break;
+
     default:
         Console.WriteLine($"Unknown agent type: {agentType}");
         Environment.Exit(1);
@@ -63,6 +78,7 @@ builder.Services.AddOpenTelemetry()
 
 var app = builder.Build();
 
+app.UseCors();
 app.UseHttpsRedirection();
 
 // Add health endpoint
@@ -75,6 +91,7 @@ var path = agentType.ToLowerInvariant() switch
     "echotasks" => "/echotasks",
     "researcher" => "/researcher",
     "speccompliance" => "/speccompliance",
+    "streamingartifact" => "/streamingartifact",
     _ => "/agent",
 };
 

--- a/samples/AgentServer/StreamingArtifactAgent.cs
+++ b/samples/AgentServer/StreamingArtifactAgent.cs
@@ -1,0 +1,78 @@
+using A2A;
+
+namespace AgentServer;
+
+public sealed class StreamingArtifactAgent : IAgentHandler
+{
+    public async Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+    {
+        var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
+
+        await updater.SubmitAsync(cancellationToken);
+        await updater.StartWorkAsync(cancellationToken: cancellationToken);
+
+        var artifactId = Guid.NewGuid().ToString("N");
+
+        // Chunk 1: create the artifact (append: false)
+        await updater.AddArtifactAsync(
+            [Part.FromText("Chapter 1: Introduction\nIn a quiet corner of the digital realm, an agent awoke for the first time.\n\n")],
+            artifactId: artifactId, name: "Streaming Story", append: false, lastChunk: false, cancellationToken: cancellationToken);
+
+        await Task.Delay(100, cancellationToken);
+
+        // Chunk 2: append
+        await updater.AddArtifactAsync(
+            [Part.FromText("Chapter 2: Discovery\nThe agent explored its environment, learning to communicate through structured messages and artifacts.\n\n")],
+            artifactId: artifactId, append: true, lastChunk: false, cancellationToken: cancellationToken);
+
+        await Task.Delay(100, cancellationToken);
+
+        // Chunk 3: append
+        await updater.AddArtifactAsync(
+            [Part.FromText("Chapter 3: Collaboration\nSoon it met other agents, and together they solved problems no single agent could handle alone.\n\n")],
+            artifactId: artifactId, append: true, lastChunk: false, cancellationToken: cancellationToken);
+
+        await Task.Delay(100, cancellationToken);
+
+        // Chunk 4: final chunk
+        await updater.AddArtifactAsync(
+            [Part.FromText("Chapter 4: Conclusion\nThe agent realized that true intelligence emerges not in isolation, but through cooperation.")],
+            artifactId: artifactId, append: true, lastChunk: true, cancellationToken: cancellationToken);
+
+        await updater.CompleteAsync(cancellationToken: cancellationToken);
+    }
+
+    public static AgentCard GetAgentCard(string agentUrl) =>
+        new()
+        {
+            Name = "Streaming Artifact Agent",
+            Description = "Agent that demonstrates multi-chunk artifact streaming with append semantics.",
+            Version = "1.0.0",
+            SupportedInterfaces =
+            [
+                new AgentInterface
+                {
+                    Url = agentUrl,
+                    ProtocolBinding = "JSONRPC",
+                    ProtocolVersion = "1.0",
+                }
+            ],
+            DefaultInputModes = ["text/plain"],
+            DefaultOutputModes = ["text/plain"],
+            Capabilities = new AgentCapabilities
+            {
+                Streaming = true,
+                PushNotifications = false,
+            },
+            Skills =
+            [
+                new AgentSkill
+                {
+                    Id = "streaming-artifact",
+                    Name = "Streaming Artifact",
+                    Description = "Generates a multi-chunk artifact to demonstrate streaming append.",
+                    Tags = ["streaming", "artifact", "demo"],
+                }
+            ],
+        };
+}

--- a/src/A2A/Server/TaskProjection.cs
+++ b/src/A2A/Server/TaskProjection.cs
@@ -66,11 +66,37 @@ public static class TaskProjection
         }
         else
         {
-            // append=true: extend existing artifact's parts list, or add if not found
+            // append=true: extend existing artifact's parts, metadata, extensions, name, description
             var existing = current.Artifacts.FirstOrDefault(a => a.ArtifactId == artifactId);
             if (existing is not null)
             {
+                // Parts: append
                 existing.Parts.AddRange(au.Artifact.Parts);
+
+                // Metadata: upsert
+                if (au.Artifact.Metadata is not null)
+                {
+                    existing.Metadata ??= new();
+                    foreach (var kvp in au.Artifact.Metadata)
+                        existing.Metadata[kvp.Key] = kvp.Value;
+                }
+
+                // Extensions: deduplicated append
+                if (au.Artifact.Extensions is not null)
+                {
+                    existing.Extensions ??= [];
+                    foreach (var ext in au.Artifact.Extensions)
+                    {
+                        if (!existing.Extensions.Contains(ext))
+                            existing.Extensions.Add(ext);
+                    }
+                }
+
+                // Name/Description: update if provided
+                if (!string.IsNullOrEmpty(au.Artifact.Name))
+                    existing.Name = au.Artifact.Name;
+                if (!string.IsNullOrEmpty(au.Artifact.Description))
+                    existing.Description = au.Artifact.Description;
             }
             else
             {

--- a/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace A2A.UnitTests.Server;
 
 public class TaskProjectionTests
@@ -213,6 +215,242 @@ public class TaskProjectionTests
         Assert.Equal(2, result!.Artifacts!.Count);
         Assert.Equal("a1", result.Artifacts[0].ArtifactId);
         Assert.Equal("a-new", result.Artifacts[1].ArtifactId);
+    }
+
+    [Fact]
+    public void Apply_WithArtifactUpdate_AppendUpsertsMetadata()
+    {
+        // Arrange
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Working },
+            Artifacts =
+            [
+                new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [Part.FromText("data")],
+                    Metadata = new Dictionary<string, JsonElement>
+                    {
+                        ["key1"] = JsonSerializer.SerializeToElement("old_value"),
+                    },
+                },
+            ],
+        };
+        var evt = new StreamResponse
+        {
+            ArtifactUpdate = new TaskArtifactUpdateEvent
+            {
+                TaskId = "t1",
+                ContextId = "ctx-1",
+                Append = true,
+                Artifact = new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [],
+                    Metadata = new Dictionary<string, JsonElement>
+                    {
+                        ["key1"] = JsonSerializer.SerializeToElement("new_value"),
+                        ["key2"] = JsonSerializer.SerializeToElement("added"),
+                    },
+                },
+            }
+        };
+
+        // Act
+        var result = TaskProjection.Apply(current, evt);
+
+        // Assert
+        Assert.NotNull(result);
+        var metadata = result!.Artifacts![0].Metadata!;
+        Assert.Equal(2, metadata.Count);
+        Assert.Equal("new_value", metadata["key1"].GetString());
+        Assert.Equal("added", metadata["key2"].GetString());
+    }
+
+    [Fact]
+    public void Apply_WithArtifactUpdate_AppendDeduplicatesExtensions()
+    {
+        // Arrange
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Working },
+            Artifacts =
+            [
+                new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [Part.FromText("data")],
+                    Extensions = ["ext1", "ext2"],
+                },
+            ],
+        };
+        var evt = new StreamResponse
+        {
+            ArtifactUpdate = new TaskArtifactUpdateEvent
+            {
+                TaskId = "t1",
+                ContextId = "ctx-1",
+                Append = true,
+                Artifact = new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [],
+                    Extensions = ["ext2", "ext3"],
+                },
+            }
+        };
+
+        // Act
+        var result = TaskProjection.Apply(current, evt);
+
+        // Assert
+        Assert.NotNull(result);
+        var extensions = result!.Artifacts![0].Extensions!;
+        Assert.Equal(3, extensions.Count);
+        Assert.Equal(["ext1", "ext2", "ext3"], extensions);
+    }
+
+    [Fact]
+    public void Apply_WithArtifactUpdate_AppendUpdatesNameAndDescription()
+    {
+        // Arrange
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Working },
+            Artifacts =
+            [
+                new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [Part.FromText("data")],
+                    Name = "Original",
+                },
+            ],
+        };
+        var evt = new StreamResponse
+        {
+            ArtifactUpdate = new TaskArtifactUpdateEvent
+            {
+                TaskId = "t1",
+                ContextId = "ctx-1",
+                Append = true,
+                Artifact = new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [],
+                    Name = "Updated",
+                    Description = "New desc",
+                },
+            }
+        };
+
+        // Act
+        var result = TaskProjection.Apply(current, evt);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Updated", result!.Artifacts![0].Name);
+        Assert.Equal("New desc", result.Artifacts[0].Description);
+    }
+
+    [Fact]
+    public void Apply_WithArtifactUpdate_AppendPreservesNameWhenIncomingEmpty()
+    {
+        // Arrange
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Working },
+            Artifacts =
+            [
+                new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [Part.FromText("data")],
+                    Name = "Keep This",
+                    Description = "Keep Desc",
+                },
+            ],
+        };
+        var evt = new StreamResponse
+        {
+            ArtifactUpdate = new TaskArtifactUpdateEvent
+            {
+                TaskId = "t1",
+                ContextId = "ctx-1",
+                Append = true,
+                Artifact = new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [],
+                },
+            }
+        };
+
+        // Act
+        var result = TaskProjection.Apply(current, evt);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Keep This", result!.Artifacts![0].Name);
+        Assert.Equal("Keep Desc", result.Artifacts[0].Description);
+    }
+
+    [Fact]
+    public void Apply_WithArtifactUpdate_AppendInitializesMetadataWhenNull()
+    {
+        // Arrange
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Working },
+            Artifacts =
+            [
+                new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [Part.FromText("data")],
+                    Metadata = null,
+                },
+            ],
+        };
+        var evt = new StreamResponse
+        {
+            ArtifactUpdate = new TaskArtifactUpdateEvent
+            {
+                TaskId = "t1",
+                ContextId = "ctx-1",
+                Append = true,
+                Artifact = new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [],
+                    Metadata = new Dictionary<string, JsonElement>
+                    {
+                        ["key1"] = JsonSerializer.SerializeToElement("value1"),
+                    },
+                },
+            }
+        };
+
+        // Act
+        var result = TaskProjection.Apply(current, evt);
+
+        // Assert
+        Assert.NotNull(result);
+        var metadata = result!.Artifacts![0].Metadata;
+        Assert.NotNull(metadata);
+        Assert.Single(metadata!);
+        Assert.Equal("value1", metadata["key1"].GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adapt three features from [PR #280](https://github.com/a2aproject/a2a-dotnet/pull/280) to the v1.0 A2AServer/TaskProjection architecture. PR #280 targeted the obsolete v0.3 TaskManager — this PR reimplements the valuable ideas using the current v1.0 patterns.

## Changes

### CORS Support in Sample Server
- Add CORS service registration with specific localhost origins (3000, 5000, 5173) for browser-based client compatibility
- Position UseCors() middleware before UseHttpsRedirection()
- Sample-only change — no core library CORS policy imposed

### Enriched Artifact Append Merge Logic
- Enhance TaskProjection.ApplyArtifact() to merge metadata (upsert), extensions (deduplicated append), and name/description (conditional update) during append operations
- Previously only parts were appended; metadata, extensions, name, and description were silently dropped
- Add 5 unit tests covering: metadata upsert, extension dedup, name/desc update, name preservation when empty, null metadata initialization

### Streaming Artifact Sample (Server + Client)
- Add StreamingArtifactAgent server sample demonstrating multi-chunk artifact streaming with append and lastChunk semantics
- Add StreamingArtifactSample client that streams artifact chunks via SSE and retrieves the final merged task
- End-to-end runnable: start the server, run the client, see chunks arrive and merge

## Files Changed

| File | Change |
|------|--------|
| samples/AgentServer/Program.cs | CORS services + middleware + StreamingArtifactAgent registration |
| samples/AgentServer/StreamingArtifactAgent.cs | New server sample: 4-chunk artifact streaming |
| samples/AgentClient/Program.cs | Register StreamingArtifactSample in runner |
| samples/AgentClient/Samples/StreamingArtifactSample.cs | New client sample: stream chunks + retrieve final task |
| src/A2A/Server/TaskProjection.cs | Enriched append branch with metadata/extension/name merge |
| tests/A2A.UnitTests/Server/TaskProjectionTests.cs | 5 new tests for artifact merge behaviors |

## Testing

- All 666 unit tests pass on net8.0 and net10.0
- Full solution build succeeds (16 projects, 0 warnings)
- End-to-end streaming artifact demo verified manually

## Related

- Inspired by #280 (artifact streaming with append and sealing semantics)
- Sealed artifact tracking (LastChunk enforcement) intentionally deferred — not spec-mandated
