### PR TITLE
fix(build): bump version to 1.0.0-preview3

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <Version>1.0.0-preview2</Version>
+    <Version>1.0.0-preview3</Version>
     <Authors>Community Contributors</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/a2aproject/a2a-dotnet</PackageProjectUrl>


### PR DESCRIPTION
Bumps NuGet package version to `1.0.0-preview3` for the next release.