### PR TITLE
fix: transition task to Failed when background handler throws

### DIFF
--- a/src/A2A/Log.cs
+++ b/src/A2A/Log.cs
@@ -19,5 +19,8 @@ namespace A2A
 
         [LoggerMessage(3, LogLevel.Error, "Background event processing failed for task {TaskId}")]
         internal static partial void BackgroundEventProcessingFailed(this ILogger logger, Exception exception, string TaskId);
+
+        [LoggerMessage(4, LogLevel.Error, "Failed to transition task {TaskId} to Failed state after background processing error")]
+        internal static partial void FailedToMarkTaskAsFailed(this ILogger logger, Exception exception, string TaskId);
     }
 }

--- a/src/A2A/Server/A2AServer.cs
+++ b/src/A2A/Server/A2AServer.cs
@@ -358,6 +358,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
                     catch (Exception ex)
                     {
                         _logger.BackgroundEventProcessingFailed(ex, capturedContext.TaskId);
+                        await TryTransitionToFailedAsync(capturedContext).ConfigureAwait(false);
                     }
                     finally
                     {
@@ -551,6 +552,40 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
 
     // ─── Private Helpers ───
 
+    /// <summary>
+    /// Attempts to transition a task to <see cref="TaskState.Failed"/> after a background
+    /// processing error. Guards against overwriting an already-terminal state.
+    /// </summary>
+    /// <param name="context">The request context identifying the task to transition.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    private async Task TryTransitionToFailedAsync(RequestContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var task = await _taskStore.GetTaskAsync(context.TaskId, cancellationToken).ConfigureAwait(false);
+            if (task is not null && !task.Status.State.IsTerminal())
+            {
+                await ApplyEventAsync(new StreamResponse
+                {
+                    StatusUpdate = new TaskStatusUpdateEvent
+                    {
+                        TaskId = context.TaskId,
+                        ContextId = context.ContextId,
+                        Status = new TaskStatus
+                        {
+                            State = TaskState.Failed,
+                            Timestamp = DateTimeOffset.UtcNow,
+                        },
+                    },
+                }, context, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception innerEx)
+        {
+            _logger.FailedToMarkTaskAsFailed(innerEx, context.TaskId);
+        }
+    }
+
     private async Task<RequestContext> ResolveContextAsync(
         SendMessageRequest request, bool streamingResponse, CancellationToken cancellationToken)
     {
@@ -684,6 +719,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
                 catch (Exception ex)
                 {
                     _logger.BackgroundEventProcessingFailed(ex, context.TaskId);
+                    await TryTransitionToFailedAsync(context).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/tests/A2A.UnitTests/Server/A2AServerTests.cs
+++ b/tests/A2A.UnitTests/Server/A2AServerTests.cs
@@ -831,6 +831,48 @@ public class A2AServerTests
     }
 
     [Fact]
+    public async Task GivenReturnImmediately_WhenHandlerThrows_ThenTaskTransitionsToFailed()
+    {
+        // Arrange — handler emits Submitted + Working then throws
+        var (server, store, handler) = CreateServer();
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        handler.OnExecute = async (ctx, eq, ct) =>
+        {
+            var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
+            await updater.SubmitAsync(ct);
+            await updater.StartWorkAsync(cancellationToken: ct);
+            handlerStarted.TrySetResult();
+
+            // Simulate unhandled failure in the handler
+            throw new InvalidOperationException("Simulated handler failure");
+        };
+
+        var request = new SendMessageRequest
+        {
+            Message = new Message { MessageId = "u1", Parts = [Part.FromText("Hello!")], Role = Role.User },
+            Configuration = new SendMessageConfiguration { ReturnImmediately = true },
+        };
+
+        // Act — send with return-immediately
+        var result = await server.SendMessageAsync(request);
+        Assert.NotNull(result.Task);
+        var taskId = result.Task!.Id;
+
+        // Wait for handler to have started (and thrown)
+        await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // DisposeAsync awaits all background drain tasks, guaranteeing the
+        // Failed transition has been applied before we read the store.
+        await server.DisposeAsync();
+
+        // Assert — task should have transitioned to Failed, not remain as Working (zombie)
+        var persisted = await store.GetTaskAsync(taskId);
+        Assert.NotNull(persisted);
+        Assert.Equal(TaskState.Failed, persisted!.Status.State);
+    }
+
+    [Fact]
     public async Task GivenReturnImmediately_WhenDispose_ThenBackgroundWorkIsCancelled()
     {
         // Arrange — handler blocks until cancelled


### PR DESCRIPTION
Closes #350

## Summary

When a handler throws during background processing (return-immediately or streaming disconnect drain), the task now transitions to \Failed\ instead of remaining stuck in a non-terminal state permanently.

## Root Cause

Both drain tasks' \catch (Exception)\ blocks only logged the error and never updated the task state, creating zombie tasks that clients polling via \GetTaskAsync\ would see as \Working\ forever.

## Changes

- **src/A2A/Server/A2AServer.cs**: Add \TryTransitionToFailedAsync\ helper that fetches the task, guards against already-terminal state, and applies a \Failed\ status update via \ApplyEventAsync\ (which persists and notifies SSE subscribers). Called from both drain catch blocks.
- **src/A2A/Log.cs**: Add \FailedToMarkTaskAsFailed\ log message (EventId 4) for the edge case where the transition itself fails.
- **tests/A2A.UnitTests/Server/A2AServerTests.cs**: Add \GivenReturnImmediately_WhenHandlerThrows_ThenTaskTransitionsToFailed\ test (no polling/Task.Delay — uses \DisposeAsync\ as deterministic sync point).

## Testing

- All 1,454 unit tests pass on Windows (net8.0 + net10.0)
- New test confirmed the bug before the fix (task stayed \Working\) and passes after (task transitions to \Failed\)