### PR TITLE
fix: surface handler exceptions instead of generic 'no events' error

### DIFF
--- a/src/A2A/Server/A2AServer.cs
+++ b/src/A2A/Server/A2AServer.cs
@@ -165,7 +165,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
                     backgroundCts, executionCancellationToken, cancellationToken).ConfigureAwait(false);
             }
 
-            var result = await MaterializeResponseAsync(eventQueue, context, cancellationToken).ConfigureAwait(false);
+            var result = await MaterializeResponseAsync(eventQueue, agentTask, context, cancellationToken).ConfigureAwait(false);
             await agentTask.ConfigureAwait(false); // surface handler exceptions
 
             return result;
@@ -724,7 +724,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
     }
 
     private async Task<SendMessageResponse> MaterializeResponseAsync(
-        AgentEventQueue eventQueue, RequestContext context, CancellationToken cancellationToken)
+        AgentEventQueue eventQueue, Task agentTask, RequestContext context, CancellationToken cancellationToken)
     {
         SendMessageResponse? result = null;
 
@@ -754,7 +754,18 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
                 ?? throw new A2AException($"Task '{context.TaskId}' not found after processing.", A2AErrorCode.TaskNotFound);
         }
 
-        return result ?? throw new A2AException(
+        if (result is not null)
+        {
+            return result;
+        }
+
+        // No events were produced. Await the handler first so its exception
+        // (if any) propagates instead of the generic "no events" error.
+#pragma warning disable VSTHRD003 // Intentional: agentTask runs the agent handler on a background thread
+        await agentTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+
+        throw new A2AException(
             "Agent handler did not produce any response events.",
             A2AErrorCode.InvalidAgentResponse);
     }

--- a/tests/A2A.UnitTests/Server/A2AServerTests.cs
+++ b/tests/A2A.UnitTests/Server/A2AServerTests.cs
@@ -878,6 +878,27 @@ public class A2AServerTests
     }
 
     [Fact]
+    public async Task GivenBlockingMode_WhenHandlerThrowsWithoutEvents_ThenOriginalExceptionSurfaces()
+    {
+        // Arrange — handler throws immediately without emitting any events
+        var (server, _, handler) = CreateServer();
+
+        handler.OnExecute = (ctx, eq, ct) =>
+            throw new InvalidOperationException("External API unavailable");
+
+        var request = new SendMessageRequest
+        {
+            Message = new Message { MessageId = "u1", Parts = [Part.FromText("Hello!")], Role = Role.User },
+        };
+
+        // Act & Assert — the handler's original exception should propagate,
+        // not a generic "Agent handler did not produce any response events."
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => server.SendMessageAsync(request));
+        Assert.Equal("External API unavailable", ex.Message);
+    }
+
+    [Fact]
     public async Task GivenStreamDisconnect_WhenReconnectWithSubscribe_ThenReceivesRemainingEvents()
     {
         // Arrange — handler waits for a signal before completing, so we control timing precisely


### PR DESCRIPTION
Closes #355

## Summary

When a handler throws an exception without emitting any events (e.g., early failure connecting to an external API), the original exception now propagates to the caller instead of being swallowed and replaced with a generic `A2AException: Agent handler did not produce any response events.`

## Root Cause

In the blocking `SendMessageAsync` path, `MaterializeResponseAsync` throws the generic error when no events are in the queue, but this happens **before** `await agentTask` on the next line, so the handler's exception never surfaces.

## Fix

Pass `agentTask` into `MaterializeResponseAsync`. When no events were produced, await `agentTask` first — if it faulted, its exception propagates naturally. The generic error is only thrown if the handler completed successfully without producing events.

## Testing

- All 1,454 unit tests pass (net8.0 + net10.0)
- New test confirms handler's `InvalidOperationException` surfaces instead of the generic `A2AException`
