### PR TITLE
fix: return -32700 ParseError for malformed JSON instead of -32603

### DIFF
--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -54,6 +54,12 @@ public static class A2AJsonRpcProcessor
             var errorId = rpcRequest?.Id ?? new JsonRpcId(ex.GetRequestId());
             return new JsonRpcResponseResult(JsonRpcResponse.CreateJsonRpcErrorResponse(errorId, ex));
         }
+        catch (JsonException ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            var errorId = rpcRequest?.Id ?? new JsonRpcId((string?)null);
+            return new JsonRpcResponseResult(JsonRpcResponse.ParseErrorResponse(errorId, ex.Message));
+        }
         catch (Exception ex)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);

--- a/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
@@ -409,6 +409,30 @@ public class A2AJsonRpcProcessorTests
         Assert.Equal("Invalid parameters", BodyContent.Error.Message);
     }
 
+    [Theory]
+    [InlineData("{invalid json", "completely malformed JSON")]
+    [InlineData("not json at all", "plain text")]
+    [InlineData("{\"jsonrpc\": \"2.0\", \"method\":", "truncated JSON")]
+    public async Task ProcessRequestAsync_GivenInvalidJson_ReturnsParseError(string body, string scenario)
+    {
+        _ = scenario; // used only for test display name
+        // Arrange
+        var requestHandler = CreateTestServer();
+        var httpRequest = CreateHttpRequestFromJson(body);
+
+        // Act
+        var result = await A2AJsonRpcProcessor.ProcessRequestAsync(requestHandler, httpRequest, CancellationToken.None);
+
+        // Assert — should return -32700 (Parse error), not -32603 (Internal error)
+        var responseResult = Assert.IsType<JsonRpcResponseResult>(result);
+        var (StatusCode, ContentType, BodyContent) = await GetJsonRpcResponseHttpDetails<JsonRpcResponse>(responseResult);
+
+        Assert.Equal(StatusCodes.Status200OK, StatusCode);
+        Assert.Equal("application/json", ContentType);
+        Assert.NotNull(BodyContent.Error);
+        Assert.Equal(-32700, BodyContent.Error!.Code); // Parse error per JSON-RPC 2.0 spec
+    }
+
     /// <summary>Creates a test A2AServer with in-memory store and default callbacks.</summary>
     private static IA2ARequestHandler CreateTestServer()
     {


### PR DESCRIPTION
Closes #330

## Summary

Invalid JSON sent to the JSON-RPC endpoint now returns error code `-32700` (Parse error) per the JSON-RPC 2.0 specification, instead of `-32603` (Internal error).

## Root Cause

`JsonSerializer.DeserializeAsync` throws `JsonException` for completely malformed JSON (e.g., `{invalid json`). This fell through to the generic `catch (Exception)` which returned `-32603` (InternalError). The existing `JsonRpcRequestConverter` only handles `JsonException` for structurally valid JSON with invalid JSON-RPC fields — it never runs for truly broken input.

## Fix

Added `catch (JsonException)` between `catch (A2AException)` and `catch (Exception)` in `ProcessRequestAsync`, returning `JsonRpcResponse.ParseErrorResponse` with code `-32700`.

## Testing

- 3 new test cases: malformed JSON, plain text, truncated JSON
- All existing tests pass (net8.0 + net10.0)
