### PR TITLE
fix(test): use InvariantCulture for float formatting in ValidateIdField test

### DIFF
--- a/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 
@@ -19,11 +20,12 @@ public class A2AJsonRpcProcessorTests
     {
         // Arrange
         var requestHandler = CreateTestServer();
+        var idJson = Convert.ToString(idValue, CultureInfo.InvariantCulture);
         var jsonRequest = $$"""
         {
             "jsonrpc": "2.0",
             "method": "{{A2AMethods.SendMessage}}",
-            "id": {{idValue}},
+            "id": {{idJson}},
             "params": {
                 "message": {
                     "messageId": "test-message-id",


### PR DESCRIPTION
Closes #351

## Summary

`ValidateIdField_HandlesVariousIdTypes` test fails on non-English locales because `42.1.ToString()` produces `42,1` (comma) on French/German/Czech systems, generating invalid JSON.

## Fix

Use `Convert.ToString(idValue, CultureInfo.InvariantCulture)` before interpolating the value into the JSON string, ensuring `42.1` always uses a dot separator regardless of system locale.
