### PR TITLE
fix: accept spec-compliant lowercase enum values during deserialization

### DIFF
--- a/src/A2A/A2AEnumConverter.cs
+++ b/src/A2A/A2AEnumConverter.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace A2A;
+
+/// <summary>
+/// Base JSON converter for A2A enums that accepts both proto3-style SCREAMING_SNAKE_CASE
+/// names (e.g., "ROLE_USER") and spec-compliant lowercase names (e.g., "user") during
+/// deserialization. Serialization always produces proto3-style names.
+/// </summary>
+internal abstract class A2AEnumConverter<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
+{
+    private readonly Dictionary<string, TEnum> _readMap;
+    private readonly Dictionary<TEnum, string> _writeMap;
+
+    protected A2AEnumConverter((TEnum Value, string Proto3Name, string SpecName)[] mappings)
+    {
+        _readMap = new(mappings.Length * 2, StringComparer.OrdinalIgnoreCase);
+        _writeMap = new(mappings.Length);
+        foreach (var (value, proto3Name, specName) in mappings)
+        {
+            _readMap[proto3Name] = value;
+            _readMap[specName] = value;
+            _writeMap[value] = proto3Name;
+        }
+    }
+
+    public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException($"Expected string for {typeof(TEnum).Name}, got {reader.TokenType}.");
+        }
+
+        var value = reader.GetString()!;
+        if (_readMap.TryGetValue(value, out var result))
+        {
+            return result;
+        }
+
+        throw new JsonException($"Unable to convert \"{value}\" to {typeof(TEnum).Name}.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+    {
+        if (_writeMap.TryGetValue(value, out var name))
+        {
+            writer.WriteStringValue(name);
+            return;
+        }
+
+        throw new JsonException($"Unable to convert {typeof(TEnum).Name}.{value} to JSON.");
+    }
+}
+
+/// <summary>JSON converter for <see cref="Role"/> that accepts both proto3 and spec-compliant names.</summary>
+internal sealed class RoleConverter() : A2AEnumConverter<Role>(
+[
+    (Role.Unspecified, "ROLE_UNSPECIFIED", "unspecified"),
+    (Role.User, "ROLE_USER", "user"),
+    (Role.Agent, "ROLE_AGENT", "agent"),
+]);
+
+/// <summary>JSON converter for <see cref="TaskState"/> that accepts both proto3 and spec-compliant names.</summary>
+internal sealed class TaskStateConverter() : A2AEnumConverter<TaskState>(
+[
+    (TaskState.Unspecified, "TASK_STATE_UNSPECIFIED", "unspecified"),
+    (TaskState.Submitted, "TASK_STATE_SUBMITTED", "submitted"),
+    (TaskState.Working, "TASK_STATE_WORKING", "working"),
+    (TaskState.Completed, "TASK_STATE_COMPLETED", "completed"),
+    (TaskState.Failed, "TASK_STATE_FAILED", "failed"),
+    (TaskState.Canceled, "TASK_STATE_CANCELED", "canceled"),
+    (TaskState.InputRequired, "TASK_STATE_INPUT_REQUIRED", "input-required"),
+    (TaskState.Rejected, "TASK_STATE_REJECTED", "rejected"),
+    (TaskState.AuthRequired, "TASK_STATE_AUTH_REQUIRED", "auth-required"),
+]);

--- a/src/A2A/A2AEnumConverter.cs
+++ b/src/A2A/A2AEnumConverter.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -8,20 +10,37 @@ namespace A2A;
 /// names (e.g., "ROLE_USER") and spec-compliant lowercase names (e.g., "user") during
 /// deserialization. Serialization always produces proto3-style names.
 /// </summary>
-internal abstract class A2AEnumConverter<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
+/// <remarks>
+/// Proto3 names are read from <see cref="JsonStringEnumMemberNameAttribute"/> on each enum member.
+/// Spec-compliant names are derived by stripping the proto3 prefix from the proto3
+/// name, converting to lowercase, and replacing underscores with hyphens.
+/// </remarks>
+internal abstract class A2AEnumConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
 {
     private readonly Dictionary<string, TEnum> _readMap;
     private readonly Dictionary<TEnum, string> _writeMap;
 
-    protected A2AEnumConverter((TEnum Value, string Proto3Name, string SpecName)[] mappings)
+    protected A2AEnumConverter(string proto3Prefix)
     {
-        _readMap = new(mappings.Length * 2, StringComparer.OrdinalIgnoreCase);
-        _writeMap = new(mappings.Length);
-        foreach (var (value, proto3Name, specName) in mappings)
+        var fields = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static);
+        _readMap = new(fields.Length * 2, StringComparer.OrdinalIgnoreCase);
+        _writeMap = new(fields.Length);
+
+        foreach (var field in fields)
         {
+            var value = (TEnum)field.GetValue(null)!;
+            var attr = field.GetCustomAttribute<JsonStringEnumMemberNameAttribute>();
+            var proto3Name = attr?.Name ?? field.Name;
+
             _readMap[proto3Name] = value;
-            _readMap[specName] = value;
             _writeMap[value] = proto3Name;
+
+            // Derive spec name: strip prefix, lowercase, replace _ with -
+            var specName = proto3Name.StartsWith(proto3Prefix, StringComparison.Ordinal)
+                ? proto3Name[proto3Prefix.Length..]
+                : proto3Name;
+            specName = specName.ToLowerInvariant().Replace('_', '-');
+            _readMap[specName] = value;
         }
     }
 
@@ -54,23 +73,7 @@ internal abstract class A2AEnumConverter<TEnum> : JsonConverter<TEnum> where TEn
 }
 
 /// <summary>JSON converter for <see cref="Role"/> that accepts both proto3 and spec-compliant names.</summary>
-internal sealed class RoleConverter() : A2AEnumConverter<Role>(
-[
-    (Role.Unspecified, "ROLE_UNSPECIFIED", "unspecified"),
-    (Role.User, "ROLE_USER", "user"),
-    (Role.Agent, "ROLE_AGENT", "agent"),
-]);
+internal sealed class RoleConverter() : A2AEnumConverter<Role>("ROLE_");
 
 /// <summary>JSON converter for <see cref="TaskState"/> that accepts both proto3 and spec-compliant names.</summary>
-internal sealed class TaskStateConverter() : A2AEnumConverter<TaskState>(
-[
-    (TaskState.Unspecified, "TASK_STATE_UNSPECIFIED", "unspecified"),
-    (TaskState.Submitted, "TASK_STATE_SUBMITTED", "submitted"),
-    (TaskState.Working, "TASK_STATE_WORKING", "working"),
-    (TaskState.Completed, "TASK_STATE_COMPLETED", "completed"),
-    (TaskState.Failed, "TASK_STATE_FAILED", "failed"),
-    (TaskState.Canceled, "TASK_STATE_CANCELED", "canceled"),
-    (TaskState.InputRequired, "TASK_STATE_INPUT_REQUIRED", "input-required"),
-    (TaskState.Rejected, "TASK_STATE_REJECTED", "rejected"),
-    (TaskState.AuthRequired, "TASK_STATE_AUTH_REQUIRED", "auth-required"),
-]);
+internal sealed class TaskStateConverter() : A2AEnumConverter<TaskState>("TASK_STATE_");

--- a/src/A2A/A2AEnumConverter.cs
+++ b/src/A2A/A2AEnumConverter.cs
@@ -46,18 +46,26 @@ internal abstract class A2AEnumConverter<[DynamicallyAccessedMembers(Dynamically
 
     public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TokenType != JsonTokenType.String)
+        if (reader.TokenType == JsonTokenType.String)
         {
-            throw new JsonException($"Expected string for {typeof(TEnum).Name}, got {reader.TokenType}.");
+            var value = reader.GetString()!;
+            if (_readMap.TryGetValue(value, out var result))
+            {
+                return result;
+            }
+
+            throw new JsonException($"Unable to convert \"{value}\" to {typeof(TEnum).Name}.");
         }
 
-        var value = reader.GetString()!;
-        if (_readMap.TryGetValue(value, out var result))
+        if (reader.TokenType == JsonTokenType.Number)
         {
-            return result;
+            if (reader.TryGetInt32(out int intValue))
+            {
+                return (TEnum)Enum.ToObject(typeof(TEnum), intValue);
+            }
         }
 
-        throw new JsonException($"Unable to convert \"{value}\" to {typeof(TEnum).Name}.");
+        throw new JsonException($"Expected string or number for {typeof(TEnum).Name}, got {reader.TokenType}.");
     }
 
     public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)

--- a/src/A2A/Models/Role.cs
+++ b/src/A2A/Models/Role.cs
@@ -3,7 +3,7 @@ namespace A2A;
 using System.Text.Json.Serialization;
 
 /// <summary>Represents the role of a message sender in the A2A protocol.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<Role>))]
+[JsonConverter(typeof(RoleConverter))]
 public enum Role
 {
     /// <summary>Unspecified role.</summary>

--- a/src/A2A/Models/TaskState.cs
+++ b/src/A2A/Models/TaskState.cs
@@ -3,7 +3,7 @@ namespace A2A;
 using System.Text.Json.Serialization;
 
 /// <summary>Represents the state of a task in the A2A protocol.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<TaskState>))]
+[JsonConverter(typeof(TaskStateConverter))]
 public enum TaskState
 {
     /// <summary>Unspecified task state.</summary>

--- a/tests/A2A.UnitTests/Models/RoleTests.cs
+++ b/tests/A2A.UnitTests/Models/RoleTests.cs
@@ -50,6 +50,16 @@ public sealed class RoleTests
         Assert.Equal(expected, result);
     }
 
+    [Theory]
+    [InlineData(0, Role.Unspecified)]
+    [InlineData(1, Role.User)]
+    [InlineData(2, Role.Agent)]
+    public void Deserialize_NumericValues_ParsesCorrectly(int numeric, Role expected)
+    {
+        var result = JsonSerializer.Deserialize<Role>(numeric.ToString(System.Globalization.CultureInfo.InvariantCulture), A2AJsonUtilities.DefaultOptions);
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
     public void Deserialize_SpecCompliantMessage_ParsesRole()
     {

--- a/tests/A2A.UnitTests/Models/RoleTests.cs
+++ b/tests/A2A.UnitTests/Models/RoleTests.cs
@@ -39,4 +39,24 @@ public sealed class RoleTests
         Assert.Equal(Role.Agent, agent);
         Assert.Equal(Role.Unspecified, unspecified);
     }
+
+    [Theory]
+    [InlineData("\"user\"", Role.User)]
+    [InlineData("\"agent\"", Role.Agent)]
+    [InlineData("\"unspecified\"", Role.Unspecified)]
+    public void Deserialize_SpecCompliantNames_ParsesCorrectly(string json, Role expected)
+    {
+        var result = JsonSerializer.Deserialize<Role>(json, A2AJsonUtilities.DefaultOptions);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Deserialize_SpecCompliantMessage_ParsesRole()
+    {
+        const string json = """{"messageId":"123","role":"user","parts":[{"text":"hello"}]}""";
+        var message = JsonSerializer.Deserialize<Message>(json, A2AJsonUtilities.DefaultOptions);
+
+        Assert.NotNull(message);
+        Assert.Equal(Role.User, message.Role);
+    }
 }

--- a/tests/A2A.UnitTests/ParsingTests.cs
+++ b/tests/A2A.UnitTests/ParsingTests.cs
@@ -198,4 +198,40 @@ public class ParsingTests
         // Assert
         Assert.Contains("ROLE_USER", json);
     }
+
+    [Theory]
+    [InlineData("\"submitted\"", TaskState.Submitted)]
+    [InlineData("\"working\"", TaskState.Working)]
+    [InlineData("\"completed\"", TaskState.Completed)]
+    [InlineData("\"failed\"", TaskState.Failed)]
+    [InlineData("\"canceled\"", TaskState.Canceled)]
+    [InlineData("\"input-required\"", TaskState.InputRequired)]
+    [InlineData("\"rejected\"", TaskState.Rejected)]
+    [InlineData("\"auth-required\"", TaskState.AuthRequired)]
+    public void TaskState_DeserializesSpecCompliantNames(string json, TaskState expected)
+    {
+        var result = JsonSerializer.Deserialize<TaskState>(json, A2AJsonUtilities.DefaultOptions);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void SendMessageRequest_DeserializesWithSpecCompliantEnums()
+    {
+        const string json = """{"message":{"messageId":"123","role":"user","parts":[{"text":"hello"}]}}""";
+        var request = JsonSerializer.Deserialize<SendMessageRequest>(json, A2AJsonUtilities.DefaultOptions);
+
+        Assert.NotNull(request);
+        Assert.Equal(Role.User, request.Message.Role);
+        Assert.Equal("hello", request.Message.Parts[0].Text);
+    }
+
+    [Fact]
+    public void TaskStatus_DeserializesWithSpecCompliantState()
+    {
+        const string json = """{"state":"completed"}""";
+        var status = JsonSerializer.Deserialize<TaskStatus>(json, A2AJsonUtilities.DefaultOptions);
+
+        Assert.NotNull(status);
+        Assert.Equal(TaskState.Completed, status.State);
+    }
 }

--- a/tests/A2A.UnitTests/ParsingTests.cs
+++ b/tests/A2A.UnitTests/ParsingTests.cs
@@ -214,6 +214,21 @@ public class ParsingTests
         Assert.Equal(expected, result);
     }
 
+    [Theory]
+    [InlineData(1, TaskState.Submitted)]
+    [InlineData(2, TaskState.Working)]
+    [InlineData(3, TaskState.Completed)]
+    [InlineData(4, TaskState.Failed)]
+    [InlineData(5, TaskState.Canceled)]
+    [InlineData(6, TaskState.InputRequired)]
+    [InlineData(7, TaskState.Rejected)]
+    [InlineData(8, TaskState.AuthRequired)]
+    public void TaskState_DeserializesNumericValues(int numeric, TaskState expected)
+    {
+        var result = JsonSerializer.Deserialize<TaskState>(numeric.ToString(System.Globalization.CultureInfo.InvariantCulture), A2AJsonUtilities.DefaultOptions);
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
     public void SendMessageRequest_DeserializesWithSpecCompliantEnums()
     {


### PR DESCRIPTION
## Summary

- Adds custom `A2AEnumConverter<TEnum>` that accepts both proto3-style SCREAMING_SNAKE_CASE names (e.g., `ROLE_USER`) and A2A spec-compliant lowercase names (e.g., `user`) during deserialization
- Applies the converter to `Role` and `TaskState` enums, replacing the default `JsonStringEnumConverter`
- Serialization continues to produce proto3-style names for backwards compatibility

This fixes interoperability with A2A implementations that send spec-compliant lowercase enum values (e.g., `"user"` instead of `"ROLE_USER"`), which currently fail to deserialize.

## Test plan

- [x] Unit tests for `Role` deserialization with spec-compliant names (`"user"`, `"agent"`, `"unspecified"`)
- [x] Unit tests for `TaskState` deserialization with spec-compliant names (`"submitted"`, `"working"`, `"input-required"`, etc.)
- [x] Integration-style tests deserializing full `Message` and `SendMessageRequest` JSON with lowercase enum values
- [x] Existing tests continue to pass (proto3-style names still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)