### PR TITLE
sample: add multi-agent hosting sample with subdomain routing

### DIFF
--- a/A2A.slnx
+++ b/A2A.slnx
@@ -13,6 +13,8 @@
     <Project Path="samples/A2ACli/A2ACli.csproj" />
     <Project Path="samples/AgentClient/AgentClient.csproj" />
     <Project Path="samples/AgentServer/AgentServer.csproj" />
+    <Project Path="samples/MultiAgentClient/MultiAgentClient.csproj" />
+    <Project Path="samples/MultiAgentHost/MultiAgentHost.csproj" />
     <Project Path="samples/SemanticKernelAgent/SemanticKernelAgent.csproj" />
   </Folder>
   <Folder Name="/src/">

--- a/samples/MultiAgentClient/MultiAgentClient.csproj
+++ b/samples/MultiAgentClient/MultiAgentClient.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net10.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\A2A\A2A.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/samples/MultiAgentClient/Program.cs
+++ b/samples/MultiAgentClient/Program.cs
@@ -1,0 +1,149 @@
+// MultiAgentClient: Validates the multi-agent hosting sample by talking to two
+// agents hosted on the same server, each identified by its subdomain.
+//
+// Since local DNS doesn't resolve *.platform.local, the client uses a custom
+// HttpClient that sets the X-Agent-Subdomain header. In production with real
+// DNS, standard A2AClient and A2ACardResolver work out of the box.
+//
+// Usage:
+//   1. Start MultiAgentHost: cd ../MultiAgentHost && dotnet run
+//   2. Run this client:      dotnet run
+
+using A2A;
+using System.Text.Json;
+
+var baseUrl = "http://localhost:5060";
+var jsonOptions = new JsonSerializerOptions(A2AJsonUtilities.DefaultOptions) { WriteIndented = true };
+
+Console.WriteLine("╔══════════════════════════════════════════════════════════════╗");
+Console.WriteLine("║   Multi-Agent Hosting Demo — Client                        ║");
+Console.WriteLine("╚══════════════════════════════════════════════════════════════╝");
+Console.WriteLine();
+
+// ──── Helper: create an HttpClient that sends the subdomain header ────
+static HttpClient CreateSubdomainClient(string subdomain)
+{
+    var client = new HttpClient();
+    client.DefaultRequestHeaders.Add("X-Agent-Subdomain", subdomain);
+    return client;
+}
+
+// ──── 1. Discover agent cards for both agents ────
+Console.WriteLine("▶ Step 1: Discovering agent cards...");
+
+var schedulerCard = await DiscoverAgentCardAsync("scheduler");
+var researchCard = await DiscoverAgentCardAsync("research");
+
+// ──── 2. Send messages to each agent and verify isolation ────
+Console.WriteLine("▶ Step 2: Sending messages to each agent...");
+
+var schedulerClient = new A2AClient(new Uri(baseUrl), CreateSubdomainClient("scheduler"));
+var researchClient = new A2AClient(new Uri(baseUrl), CreateSubdomainClient("research"));
+
+var schedulerResponse = await SendAndPrintAsync(schedulerClient, "scheduler", "Book an appointment for Monday at 10am");
+var researchResponse = await SendAndPrintAsync(researchClient, "research", "Find patients eligible for trial NCT-2026-001");
+
+// ──── 3. Verify task isolation ────
+Console.WriteLine("▶ Step 3: Verifying task isolation...");
+
+var schedulerTasks = await schedulerClient.ListTasksAsync(new ListTasksRequest());
+var researchTasks = await researchClient.ListTasksAsync(new ListTasksRequest());
+
+Console.WriteLine($"  Scheduler agent tasks: {schedulerTasks.Tasks?.Count ?? 0}");
+Console.WriteLine($"  Research agent tasks:  {researchTasks.Tasks?.Count ?? 0}");
+
+// Each agent should only see its own task
+var schedulerTaskCount = schedulerTasks.Tasks?.Count ?? 0;
+var researchTaskCount = researchTasks.Tasks?.Count ?? 0;
+
+if (schedulerTaskCount >= 1 && researchTaskCount >= 1)
+    Console.WriteLine("  ✓ Task isolation confirmed — each agent only sees its own tasks.");
+else
+    Console.WriteLine("  ✗ Unexpected task counts — isolation may not be working.");
+
+// ──── 4. Verify cross-agent task lookup fails ────
+Console.WriteLine();
+Console.WriteLine("▶ Step 4: Verifying cross-agent access is blocked...");
+
+// Try to get a scheduler task from the research agent
+var schedulerTaskId = schedulerResponse.Task?.Id;
+if (schedulerTaskId is not null)
+{
+    try
+    {
+        await researchClient.GetTaskAsync(new GetTaskRequest { Id = schedulerTaskId });
+        Console.WriteLine("  ✗ Cross-agent access was NOT blocked — isolation failure!");
+    }
+    catch (A2AException ex) when (ex.ErrorCode == A2AErrorCode.TaskNotFound)
+    {
+        Console.WriteLine($"  ✓ Research agent cannot access scheduler's task {schedulerTaskId} — TaskNotFound.");
+    }
+}
+
+// ──── 5. Verify unknown subdomain returns error ────
+Console.WriteLine();
+Console.WriteLine("▶ Step 5: Verifying unknown agent returns error...");
+
+var unknownClient = new A2AClient(new Uri(baseUrl), CreateSubdomainClient("nonexistent"));
+try
+{
+    await unknownClient.SendMessageAsync(new SendMessageRequest
+    {
+        Message = new Message
+        {
+            Role = Role.User,
+            MessageId = Guid.NewGuid().ToString(),
+            Parts = [Part.FromText("Hello?")]
+        }
+    });
+    Console.WriteLine("  ✗ Unknown agent did NOT return an error!");
+}
+catch (A2AException ex)
+{
+    Console.WriteLine($"  ✓ Unknown agent returned error: {ex.Message}");
+}
+
+Console.WriteLine();
+Console.WriteLine("════════════════════════════════════════════════════════════════");
+Console.WriteLine("  Demo complete. All agents operated independently on one host.");
+Console.WriteLine("════════════════════════════════════════════════════════════════");
+
+// ── Helper methods ──
+
+async Task<AgentCard> DiscoverAgentCardAsync(string subdomain)
+{
+    using var http = CreateSubdomainClient(subdomain);
+    var json = await http.GetStringAsync($"{baseUrl}/.well-known/agent-card.json");
+    var card = JsonSerializer.Deserialize<AgentCard>(json, A2AJsonUtilities.DefaultOptions)
+        ?? throw new InvalidOperationException("Failed to deserialize agent card");
+
+    Console.WriteLine($"  [{subdomain}] Agent: {card.Name}");
+    Console.WriteLine($"           Description: {card.Description}");
+    Console.WriteLine($"           Skills: {string.Join(", ", card.Skills.Select(s => s.Name))}");
+    Console.WriteLine();
+
+    return card;
+}
+
+async Task<SendMessageResponse> SendAndPrintAsync(A2AClient client, string label, string text)
+{
+    var response = await client.SendMessageAsync(new SendMessageRequest
+    {
+        Message = new Message
+        {
+            Role = Role.User,
+            MessageId = Guid.NewGuid().ToString(),
+            Parts = [Part.FromText(text)]
+        }
+    });
+
+    var replyText = response.Task?.Artifacts?.LastOrDefault()?.Parts?.FirstOrDefault()?.Text
+        ?? response.Message?.Parts?.FirstOrDefault()?.Text
+        ?? "(no text response)";
+
+    Console.WriteLine($"  [{label}] Sent: \"{text}\"");
+    Console.WriteLine($"  [{label}] Reply: \"{replyText}\"");
+    Console.WriteLine();
+
+    return response;
+}

--- a/samples/MultiAgentHost/A2AServerFactory.cs
+++ b/samples/MultiAgentHost/A2AServerFactory.cs
@@ -1,0 +1,89 @@
+using System.Collections.Concurrent;
+using A2A;
+using Microsoft.Extensions.Logging;
+
+namespace MultiAgentHost;
+
+/// <summary>
+/// Describes an agent hosted on the platform, identified by its subdomain.
+/// </summary>
+public sealed record AgentRegistration(string Subdomain, string AgentName, string Description, AgentSkill[] Skills);
+
+/// <summary>
+/// Factory that creates and caches <see cref="A2AServer"/> instances per subdomain.
+/// Each agent gets its own <see cref="InMemoryTaskStore"/> and <see cref="ChannelEventNotifier"/>,
+/// guaranteeing full task isolation between agents.
+/// </summary>
+public sealed class A2AServerFactory : IAsyncDisposable
+{
+    private readonly ConcurrentDictionary<string, AgentRegistration> _registrations = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, A2AServer> _servers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ILoggerFactory _loggerFactory;
+
+    public A2AServerFactory(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+    }
+
+    /// <summary>Registers an agent configuration for a given subdomain.</summary>
+    public void Register(AgentRegistration registration)
+    {
+        _registrations[registration.Subdomain] = registration;
+    }
+
+    /// <summary>Returns the registered subdomains.</summary>
+    public IEnumerable<string> Subdomains => _registrations.Keys;
+
+    /// <summary>Resolves or lazily creates the <see cref="A2AServer"/> for the given subdomain.</summary>
+    public A2AServer? GetServer(string subdomain)
+    {
+        if (!_registrations.TryGetValue(subdomain, out var reg))
+            return null;
+
+        return _servers.GetOrAdd(subdomain, _ =>
+        {
+            var store = new InMemoryTaskStore();
+            var notifier = new ChannelEventNotifier();
+            var handler = new NamedEchoAgent(reg.AgentName);
+            var logger = _loggerFactory.CreateLogger<A2AServer>();
+            return new A2AServer(handler, store, notifier, logger);
+        });
+    }
+
+    /// <summary>Builds an <see cref="AgentCard"/> for the given subdomain and base URL.</summary>
+    public AgentCard? GetAgentCard(string subdomain, string baseUrl)
+    {
+        if (!_registrations.TryGetValue(subdomain, out var reg))
+            return null;
+
+        return new AgentCard
+        {
+            Name = reg.AgentName,
+            Description = reg.Description,
+            Version = "1.0.0",
+            SupportedInterfaces =
+            [
+                new AgentInterface
+                {
+                    Url = baseUrl,
+                    ProtocolBinding = "JSONRPC",
+                    ProtocolVersion = "1.0",
+                }
+            ],
+            DefaultInputModes = ["text/plain"],
+            DefaultOutputModes = ["text/plain"],
+            Capabilities = new AgentCapabilities
+            {
+                Streaming = true,
+                PushNotifications = false,
+            },
+            Skills = [.. reg.Skills],
+        };
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var server in _servers.Values)
+            await server.DisposeAsync();
+    }
+}

--- a/samples/MultiAgentHost/A2AServerFactory.cs
+++ b/samples/MultiAgentHost/A2AServerFactory.cs
@@ -7,7 +7,7 @@ namespace MultiAgentHost;
 /// <summary>
 /// Describes an agent hosted on the platform, identified by its subdomain.
 /// </summary>
-public sealed record AgentRegistration(string Subdomain, string AgentName, string Description, AgentSkill[] Skills);
+public sealed record AgentRegistration(string Subdomain, string AgentName, string Description, AgentSkill[] Skills, IAgentHandler Handler);
 
 /// <summary>
 /// Factory that creates and caches <see cref="A2AServer"/> instances per subdomain.
@@ -44,9 +44,8 @@ public sealed class A2AServerFactory : IAsyncDisposable
         {
             var store = new InMemoryTaskStore();
             var notifier = new ChannelEventNotifier();
-            var handler = new NamedEchoAgent(reg.AgentName);
             var logger = _loggerFactory.CreateLogger<A2AServer>();
-            return new A2AServer(handler, store, notifier, logger);
+            return new A2AServer(reg.Handler, store, notifier, logger);
         });
     }
 

--- a/samples/MultiAgentHost/MultiAgentHandler.cs
+++ b/samples/MultiAgentHost/MultiAgentHandler.cs
@@ -1,0 +1,69 @@
+using A2A;
+
+namespace MultiAgentHost;
+
+/// <summary>
+/// Adapter <see cref="IA2ARequestHandler"/> that delegates every call to the
+/// subdomain-specific <see cref="A2AServer"/> resolved via <see cref="A2AServerFactory"/>.
+/// </summary>
+/// <remarks>
+/// The subdomain is extracted by <see cref="SubdomainMiddleware"/> and stored in the
+/// scoped <see cref="SubdomainContext"/>. This handler reads it via
+/// <see cref="IHttpContextAccessor"/> and resolves the correct <see cref="A2AServer"/>
+/// from the factory.
+/// <para>
+/// Each <see cref="A2AServer"/> has its own <see cref="InMemoryTaskStore"/> and
+/// <see cref="ChannelEventNotifier"/>, guaranteeing complete task isolation between agents.
+/// </para>
+/// </remarks>
+public sealed class MultiAgentHandler(
+    A2AServerFactory factory,
+    IHttpContextAccessor httpContextAccessor) : IA2ARequestHandler
+{
+    private A2AServer Resolve()
+    {
+        var ctx = httpContextAccessor.HttpContext
+            ?? throw new A2AException("No active HTTP request.", A2AErrorCode.InvalidRequest);
+
+        var subdomainCtx = ctx.RequestServices.GetRequiredService<SubdomainContext>();
+
+        if (string.IsNullOrEmpty(subdomainCtx.Subdomain))
+            throw new A2AException("Agent subdomain not resolved. Use a subdomain or set the X-Agent-Subdomain header.", A2AErrorCode.InvalidRequest);
+
+        return factory.GetServer(subdomainCtx.Subdomain)
+            ?? throw new A2AException($"Unknown agent subdomain: '{subdomainCtx.Subdomain}'.", A2AErrorCode.InvalidRequest);
+    }
+
+    public Task<SendMessageResponse> SendMessageAsync(SendMessageRequest request, CancellationToken cancellationToken)
+        => Resolve().SendMessageAsync(request, cancellationToken);
+
+    public IAsyncEnumerable<StreamResponse> SendStreamingMessageAsync(SendMessageRequest request, CancellationToken cancellationToken)
+        => Resolve().SendStreamingMessageAsync(request, cancellationToken);
+
+    public Task<AgentTask> GetTaskAsync(GetTaskRequest request, CancellationToken cancellationToken)
+        => Resolve().GetTaskAsync(request, cancellationToken);
+
+    public Task<ListTasksResponse> ListTasksAsync(ListTasksRequest request, CancellationToken cancellationToken)
+        => Resolve().ListTasksAsync(request, cancellationToken);
+
+    public Task<AgentTask> CancelTaskAsync(CancelTaskRequest request, CancellationToken cancellationToken)
+        => Resolve().CancelTaskAsync(request, cancellationToken);
+
+    public IAsyncEnumerable<StreamResponse> SubscribeToTaskAsync(SubscribeToTaskRequest request, CancellationToken cancellationToken)
+        => Resolve().SubscribeToTaskAsync(request, cancellationToken);
+
+    public Task<TaskPushNotificationConfig> CreateTaskPushNotificationConfigAsync(CreateTaskPushNotificationConfigRequest request, CancellationToken cancellationToken)
+        => Resolve().CreateTaskPushNotificationConfigAsync(request, cancellationToken);
+
+    public Task<TaskPushNotificationConfig> GetTaskPushNotificationConfigAsync(GetTaskPushNotificationConfigRequest request, CancellationToken cancellationToken)
+        => Resolve().GetTaskPushNotificationConfigAsync(request, cancellationToken);
+
+    public Task<ListTaskPushNotificationConfigResponse> ListTaskPushNotificationConfigAsync(ListTaskPushNotificationConfigRequest request, CancellationToken cancellationToken)
+        => Resolve().ListTaskPushNotificationConfigAsync(request, cancellationToken);
+
+    public Task DeleteTaskPushNotificationConfigAsync(DeleteTaskPushNotificationConfigRequest request, CancellationToken cancellationToken)
+        => Resolve().DeleteTaskPushNotificationConfigAsync(request, cancellationToken);
+
+    public Task<AgentCard> GetExtendedAgentCardAsync(GetExtendedAgentCardRequest request, CancellationToken cancellationToken)
+        => Resolve().GetExtendedAgentCardAsync(request, cancellationToken);
+}

--- a/samples/MultiAgentHost/MultiAgentHost.csproj
+++ b/samples/MultiAgentHost/MultiAgentHost.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net10.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\A2A\A2A.csproj" />
+		<ProjectReference Include="..\..\src\A2A.AspNetCore\A2A.AspNetCore.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/samples/MultiAgentHost/NamedEchoAgent.cs
+++ b/samples/MultiAgentHost/NamedEchoAgent.cs
@@ -1,0 +1,19 @@
+using A2A;
+
+namespace MultiAgentHost;
+
+/// <summary>
+/// Simple echo agent that prefixes responses with the agent name.
+/// Uses task-based responses so tasks are persisted and isolation can be validated.
+/// </summary>
+public sealed class NamedEchoAgent(string agentName) : IAgentHandler
+{
+    public async Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+    {
+        var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
+        await updater.SubmitAsync(cancellationToken);
+        await updater.AddArtifactAsync(
+            [Part.FromText($"[{agentName}] Echo: {context.UserText}")], cancellationToken: cancellationToken);
+        await updater.CompleteAsync(cancellationToken: cancellationToken);
+    }
+}

--- a/samples/MultiAgentHost/Program.cs
+++ b/samples/MultiAgentHost/Program.cs
@@ -36,7 +36,8 @@ factory.Register(new AgentRegistration(
     [
         new AgentSkill { Id = "add-appointment", Name = "Add Appointment", Description = "Schedule a new appointment.", Tags = ["scheduling"] },
         new AgentSkill { Id = "cancel-appointment", Name = "Cancel Appointment", Description = "Cancel an existing appointment.", Tags = ["scheduling"] },
-    ]));
+    ],
+    Handler: new NamedEchoAgent("Scheduler Agent")));
 
 factory.Register(new AgentRegistration(
     Subdomain: "research",
@@ -46,7 +47,8 @@ factory.Register(new AgentRegistration(
     [
         new AgentSkill { Id = "match-trial", Name = "Match Trial", Description = "Match patients to clinical trials.", Tags = ["clinical", "research"] },
         new AgentSkill { Id = "read-patient", Name = "Read Patient Data", Description = "Read patient information.", Tags = ["clinical", "data"] },
-    ]));
+    ],
+    Handler: new NamedEchoAgent("Clinical Trials Agent")));
 
 // The base domain used to extract subdomains from Host header.
 // e.g., "scheduler.platform.local" with baseDomain ".platform.local" → "scheduler"

--- a/samples/MultiAgentHost/Program.cs
+++ b/samples/MultiAgentHost/Program.cs
@@ -1,0 +1,93 @@
+// MultiAgentHost: Demonstrates subdomain-based multi-agent hosting on a single server.
+//
+// Architecture:
+//   - Each agent is identified by a subdomain (e.g., scheduler.platform.local)
+//   - A2AServerFactory creates and caches an A2AServer per subdomain, each with its own InMemoryTaskStore
+//   - SubdomainMiddleware extracts the subdomain from the Host header (or X-Agent-Subdomain header for testing)
+//   - MultiAgentHandler delegates IA2ARequestHandler calls to the correct A2AServer
+//   - Agent cards are served dynamically per subdomain at /.well-known/agent-card.json
+//
+// For local testing without DNS, use the X-Agent-Subdomain header:
+//   curl -H "X-Agent-Subdomain: scheduler" http://localhost:5060/.well-known/agent-card.json
+//
+// Usage: dotnet run
+
+using A2A;
+using A2A.AspNetCore;
+using MultiAgentHost;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Register services
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<SubdomainContext>();
+builder.Services.AddSingleton<A2AServerFactory>();
+
+var app = builder.Build();
+
+// Configure agents in the factory
+var factory = app.Services.GetRequiredService<A2AServerFactory>();
+
+factory.Register(new AgentRegistration(
+    Subdomain: "scheduler",
+    AgentName: "Scheduler Agent",
+    Description: "Manages appointments for healthcare providers.",
+    Skills:
+    [
+        new AgentSkill { Id = "add-appointment", Name = "Add Appointment", Description = "Schedule a new appointment.", Tags = ["scheduling"] },
+        new AgentSkill { Id = "cancel-appointment", Name = "Cancel Appointment", Description = "Cancel an existing appointment.", Tags = ["scheduling"] },
+    ]));
+
+factory.Register(new AgentRegistration(
+    Subdomain: "research",
+    AgentName: "Clinical Trials Agent",
+    Description: "Finds patients matching clinical trial criteria.",
+    Skills:
+    [
+        new AgentSkill { Id = "match-trial", Name = "Match Trial", Description = "Match patients to clinical trials.", Tags = ["clinical", "research"] },
+        new AgentSkill { Id = "read-patient", Name = "Read Patient Data", Description = "Read patient information.", Tags = ["clinical", "data"] },
+    ]));
+
+// The base domain used to extract subdomains from Host header.
+// e.g., "scheduler.platform.local" with baseDomain ".platform.local" → "scheduler"
+var baseDomain = app.Configuration["BaseDomain"] ?? ".platform.local";
+
+// Subdomain extraction middleware — must run before routing
+app.UseMiddleware<SubdomainMiddleware>(baseDomain);
+
+// Dynamic agent card endpoint — returns per-subdomain agent card
+app.MapGet(".well-known/agent-card.json", (HttpContext ctx) =>
+{
+    var subdomainCtx = ctx.RequestServices.GetRequiredService<SubdomainContext>();
+    if (string.IsNullOrEmpty(subdomainCtx.Subdomain))
+        return Results.NotFound("No agent subdomain resolved. Use a subdomain or set the X-Agent-Subdomain header.");
+
+    var baseUrl = $"{ctx.Request.Scheme}://{ctx.Request.Host}";
+    var card = factory.GetAgentCard(subdomainCtx.Subdomain, baseUrl);
+    return card is not null ? Results.Ok(card) : Results.NotFound($"Unknown agent: '{subdomainCtx.Subdomain}'");
+});
+
+// A2A JSON-RPC endpoint — single path, routed to the correct agent by MultiAgentHandler
+var multiHandler = new MultiAgentHandler(
+    factory,
+    app.Services.GetRequiredService<IHttpContextAccessor>());
+
+app.MapA2A(multiHandler, "/");
+
+// Health check
+app.MapGet("/health", () => Results.Ok(new { Status = "Healthy", Agents = factory.Subdomains }));
+
+Console.WriteLine();
+Console.WriteLine("Multi-Agent Host started.");
+Console.WriteLine("Registered agents:");
+foreach (var subdomain in factory.Subdomains)
+{
+    Console.WriteLine($"  - {subdomain}.platform.local → http://localhost:5060 (use X-Agent-Subdomain: {subdomain})");
+}
+Console.WriteLine();
+Console.WriteLine("Test with:");
+Console.WriteLine("  curl -H \"X-Agent-Subdomain: scheduler\" http://localhost:5060/.well-known/agent-card.json");
+Console.WriteLine("  curl -H \"X-Agent-Subdomain: research\" http://localhost:5060/.well-known/agent-card.json");
+Console.WriteLine();
+
+app.Run();

--- a/samples/MultiAgentHost/Properties/launchSettings.json
+++ b/samples/MultiAgentHost/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "MultiAgentHost": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5060",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/MultiAgentHost/README.md
+++ b/samples/MultiAgentHost/README.md
@@ -1,0 +1,103 @@
+# Multi-Agent Hosting Sample
+
+Demonstrates hosting multiple A2A agents on a single ASP.NET Core server with subdomain-based routing. Each agent gets its own `A2AServer` instance with isolated task storage.
+
+This sample addresses the scenario described in [#353](https://github.com/a2aproject/a2a-dotnet/issues/353): an enterprise platform where each customer gets a subdomain and deploys their own agents.
+
+## Architecture
+
+```text
+                ┌─────────────────────────────────────────────────┐
+                │            ASP.NET Core Server                  │
+                │                                                 │
+  Request ──►   │  SubdomainMiddleware                            │
+                │    ├─ Extracts subdomain from Host header       │
+                │    └─ Or from X-Agent-Subdomain header (dev)    │
+                │                                                 │
+                │  MultiAgentHandler (IA2ARequestHandler)         │
+                │    ├─ Reads SubdomainContext                    │
+                │    └─ Delegates to A2AServerFactory             │
+                │                                                 │
+                │  A2AServerFactory                               │
+                │    ├─ scheduler ──► A2AServer + InMemoryStore   │
+                │    ├─ research  ──► A2AServer + InMemoryStore   │
+                │    └─ (more...)                                 │
+                └─────────────────────────────────────────────────┘
+```
+
+Key design decisions:
+
+- **Task isolation by construction**: each agent gets its own `InMemoryTaskStore`, so no task data leaks between agents.
+- **Dynamic agent cards**: `/.well-known/agent-card.json` returns a different `AgentCard` per subdomain.
+- **Lazy server creation**: `A2AServer` instances are created on first request and cached.
+- **Single `MapA2A` call**: one `IA2ARequestHandler` adapter routes all requests.
+
+## Running the Sample
+
+### 1. Start the server
+
+```bash
+cd samples/MultiAgentHost
+dotnet run --urls http://localhost:5060
+```
+
+### 2. Run the client (in another terminal)
+
+```bash
+cd samples/MultiAgentClient
+dotnet run
+```
+
+The client validates:
+1. Agent card discovery per subdomain
+2. Message routing to the correct agent
+3. Task isolation between agents
+4. Cross-agent task access is blocked
+5. Unknown agent subdomains return errors
+
+### Testing Without DNS
+
+The sample supports an `X-Agent-Subdomain` header for local testing without configuring DNS or `/etc/hosts`:
+
+```bash
+# Get the scheduler agent's card
+curl -H "X-Agent-Subdomain: scheduler" http://localhost:5060/.well-known/agent-card.json
+
+# Get the research agent's card
+curl -H "X-Agent-Subdomain: research" http://localhost:5060/.well-known/agent-card.json
+```
+
+### Testing With Real Subdomains
+
+Add to your hosts file (`C:\Windows\System32\drivers\etc\hosts` or `/etc/hosts`):
+
+```text
+127.0.0.1 scheduler.platform.local
+127.0.0.1 research.platform.local
+```
+
+Then:
+
+```bash
+curl http://scheduler.platform.local:5060/.well-known/agent-card.json
+curl http://research.platform.local:5060/.well-known/agent-card.json
+```
+
+## Project Structure
+
+| File | Purpose |
+|------|---------|
+| `Program.cs` | Wires up middleware, registers agents, maps endpoints |
+| `A2AServerFactory.cs` | Creates/caches `A2AServer` instances per subdomain |
+| `MultiAgentHandler.cs` | `IA2ARequestHandler` adapter that delegates per subdomain |
+| `SubdomainMiddleware.cs` | Extracts subdomain from Host header into scoped context |
+| `SubdomainContext.cs` | Scoped service holding the resolved subdomain |
+| `NamedEchoAgent.cs` | Simple echo `IAgentHandler` that prefixes with agent name |
+
+## Adapting for Production
+
+- Replace `AgentRegistration` data with a database or configuration service.
+- Replace `InMemoryTaskStore` with a persistent `ITaskStore` implementation.
+- Add authentication/authorization middleware.
+- Configure a reverse proxy (nginx, YARP) for TLS termination if needed; Kestrel handles subdomain routing natively.
+- Consider handler eviction from `A2AServerFactory` for very large numbers of tenants.

--- a/samples/MultiAgentHost/SubdomainContext.cs
+++ b/samples/MultiAgentHost/SubdomainContext.cs
@@ -1,0 +1,10 @@
+namespace MultiAgentHost;
+
+/// <summary>
+/// Scoped service that holds the resolved subdomain (tenant) for the current request.
+/// Set by <see cref="SubdomainMiddleware"/>, consumed by <see cref="MultiAgentHandler"/>.
+/// </summary>
+public sealed class SubdomainContext
+{
+    public string? Subdomain { get; set; }
+}

--- a/samples/MultiAgentHost/SubdomainMiddleware.cs
+++ b/samples/MultiAgentHost/SubdomainMiddleware.cs
@@ -1,0 +1,40 @@
+namespace MultiAgentHost;
+
+/// <summary>
+/// Middleware that extracts the subdomain from the Host header and stores it
+/// in the scoped <see cref="SubdomainContext"/> for downstream handlers.
+/// </summary>
+/// <remarks>
+/// Supports two modes:
+/// <list type="bullet">
+///   <item>Real subdomains: <c>scheduler.platform.local</c> → subdomain = "scheduler"</item>
+///   <item>Port-based dev fallback: <c>X-Agent-Subdomain</c> header for testing without DNS</item>
+/// </list>
+/// </remarks>
+public sealed class SubdomainMiddleware(RequestDelegate next, string baseDomain)
+{
+    public Task InvokeAsync(HttpContext context)
+    {
+        var subdomainCtx = context.RequestServices.GetRequiredService<SubdomainContext>();
+
+        // Priority 1: X-Agent-Subdomain header (for easy local testing without DNS)
+        var headerValue = context.Request.Headers["X-Agent-Subdomain"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(headerValue))
+        {
+            subdomainCtx.Subdomain = headerValue;
+            return next(context);
+        }
+
+        // Priority 2: Extract subdomain from Host header
+        var host = context.Request.Host.Host;
+        if (host.EndsWith(baseDomain, StringComparison.OrdinalIgnoreCase) && host.Length > baseDomain.Length)
+        {
+            // "scheduler.platform.local" with baseDomain ".platform.local" → "scheduler"
+            var subdomain = host[..^baseDomain.Length];
+            // Strip trailing dot if present
+            subdomainCtx.Subdomain = subdomain.TrimEnd('.');
+        }
+
+        return next(context);
+    }
+}


### PR DESCRIPTION
## Multi-Agent Hosting Sample

Demonstrates how to host multiple A2A agents on a single ASP.NET Core server with subdomain-based routing, addressing the scenario described in #353.

### Problem

Enterprise platforms need to host hundreds or thousands of agents on a single server, each identified by a subdomain (e.g., `scheduler.platform.com`, `research.platform.com`). The current SDK's `AddA2AAgent<T>` registers a single agent per DI container.

### Solution

This sample shows a pattern that works **today with zero SDK changes**:

- **`A2AServerFactory`** — creates and caches an `A2AServer` instance per subdomain, each with its own `InMemoryTaskStore` and `ChannelEventNotifier`
- **`SubdomainMiddleware`** — extracts the subdomain from the `Host` header (or `X-Agent-Subdomain` header for local testing)
- **`MultiAgentHandler`** — adapter `IA2ARequestHandler` that delegates all calls to the correct `A2AServer` via `IHttpContextAccessor`
- **Dynamic agent cards** — custom `MapGet(".well-known/agent-card.json")` returns per-subdomain cards
- **Single `MapA2A` call** — one endpoint, routing handled internally

### What the client validates

1. ✅ Agent card discovery per subdomain (different name, description, skills)
2. ✅ Message routing to the correct agent (response prefixed with agent name)
3. ✅ Task isolation (each agent only sees its own tasks)
4. ✅ Cross-agent task access blocked (`TaskNotFound`)
5. ✅ Unknown subdomain returns error

### Architecture

```
Request → SubdomainMiddleware → MultiAgentHandler → A2AServerFactory
                                                        ├─ scheduler → A2AServer + InMemoryStore
                                                        └─ research  → A2AServer + InMemoryStore
```

### How to run

```bash
# Terminal 1: Start the server
cd samples/MultiAgentHost
dotnet run --urls http://localhost:5060

# Terminal 2: Run the client
cd samples/MultiAgentClient
dotnet run
```

### Relates to

- Closes #353
- Related: #368 (tenant routing)
