### PR TITLE
refactor: adopt immutable update pattern in TaskProjection

### DIFF
--- a/src/A2A/Server/TaskProjection.cs
+++ b/src/A2A/Server/TaskProjection.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace A2A;
 
 /// <summary>
@@ -5,9 +7,16 @@ namespace A2A;
 /// from a stream of <see cref="StreamResponse"/> events.
 /// </summary>
 /// <remarks>
-/// <see cref="A2AServer"/> uses <see cref="Apply"/> to mutate task state before
-/// persisting via <see cref="ITaskStore.SaveTaskAsync"/>. Store implementors do
-/// not need to call this directly.
+/// <para>
+/// <see cref="Apply"/> always returns a new <see cref="AgentTask"/> instance (or null).
+/// The incoming task is never mutated, making the projection inherently safe regardless
+/// of whether <see cref="ITaskStore"/> implementations clone on read.
+/// </para>
+/// <para>
+/// Sub-objects such as <see cref="Artifact"/> instances are also replaced rather than
+/// mutated in-place, so concurrent readers holding references to prior artifacts or
+/// history lists see consistent snapshots.
+/// </para>
 /// </remarks>
 public static class TaskProjection
 {
@@ -24,18 +33,34 @@ public static class TaskProjection
         if (current is null)
             return current;
 
+        // Shallow copy so the caller's AgentTask reference is never mutated.
+        // Artifacts list is copied because ApplyArtifact mutates it (Add/index-set).
+        // History is not copied — every branch that touches it replaces the reference entirely.
+        var result = new AgentTask
+        {
+            Id = current.Id,
+            ContextId = current.ContextId,
+            Status = current.Status,
+            History = current.History,
+            Artifacts = current.Artifacts is not null ? [.. current.Artifacts] : null,
+            Metadata = current.Metadata,
+        };
+
         if (streamEvent.StatusUpdate is { } su)
-            return ApplyStatus(current, su);
+            return ApplyStatus(result, su);
 
         if (streamEvent.ArtifactUpdate is { } au)
-            return ApplyArtifact(current, au);
+            return ApplyArtifact(result, au);
 
         if (streamEvent.Message is { } msg)
-        {
-            (current.History ??= []).Add(msg);
-            return current;
-        }
+            return ApplyMessage(result, msg);
 
+        return result;
+    }
+
+    private static AgentTask ApplyMessage(AgentTask current, Message msg)
+    {
+        current.History = [.. (current.History ?? []), msg];
         return current;
     }
 
@@ -44,7 +69,7 @@ public static class TaskProjection
         // Move superseded status.message to history (aligned with Python SDK behavior).
         if (current.Status.Message is not null)
         {
-            (current.History ??= []).Add(current.Status.Message);
+            current.History = [.. (current.History ?? []), current.Status.Message];
         }
         current.Status = su.Status;
         return current;
@@ -66,37 +91,23 @@ public static class TaskProjection
         }
         else
         {
-            // append=true: extend existing artifact's parts, metadata, extensions, name, description
+            // append=true: build new artifact with merged data — never mutate existing
             var existing = current.Artifacts.FirstOrDefault(a => a.ArtifactId == artifactId);
             if (existing is not null)
             {
-                // Parts: append
-                existing.Parts.AddRange(au.Artifact.Parts);
-
-                // Metadata: upsert
-                if (au.Artifact.Metadata is not null)
+                var merged = new Artifact
                 {
-                    existing.Metadata ??= new();
-                    foreach (var kvp in au.Artifact.Metadata)
-                        existing.Metadata[kvp.Key] = kvp.Value;
-                }
+                    ArtifactId = existing.ArtifactId,
+                    Name = !string.IsNullOrEmpty(au.Artifact.Name) ? au.Artifact.Name : existing.Name,
+                    Description = !string.IsNullOrEmpty(au.Artifact.Description)
+                        ? au.Artifact.Description : existing.Description,
+                    Parts = [.. existing.Parts, .. au.Artifact.Parts],
+                    Metadata = MergeMetadata(existing.Metadata, au.Artifact.Metadata),
+                    Extensions = MergeExtensions(existing.Extensions, au.Artifact.Extensions),
+                };
 
-                // Extensions: deduplicated append
-                if (au.Artifact.Extensions is not null)
-                {
-                    existing.Extensions ??= [];
-                    foreach (var ext in au.Artifact.Extensions)
-                    {
-                        if (!existing.Extensions.Contains(ext))
-                            existing.Extensions.Add(ext);
-                    }
-                }
-
-                // Name/Description: update if provided
-                if (!string.IsNullOrEmpty(au.Artifact.Name))
-                    existing.Name = au.Artifact.Name;
-                if (!string.IsNullOrEmpty(au.Artifact.Description))
-                    existing.Description = au.Artifact.Description;
+                var idx = current.Artifacts.IndexOf(existing);
+                current.Artifacts[idx] = merged;
             }
             else
             {
@@ -104,5 +115,29 @@ public static class TaskProjection
             }
         }
         return current;
+    }
+
+    private static Dictionary<string, JsonElement>? MergeMetadata(
+        Dictionary<string, JsonElement>? existing, Dictionary<string, JsonElement>? incoming)
+    {
+        if (incoming is null) return existing;
+        var result = existing is not null ? new Dictionary<string, JsonElement>(existing) : new();
+        foreach (var kvp in incoming)
+            result[kvp.Key] = kvp.Value;
+        return result;
+    }
+
+    private static List<string>? MergeExtensions(List<string>? existing, List<string>? incoming)
+    {
+        if (incoming is null) return existing;
+        if (existing is null) return [.. incoming];
+        var seen = new HashSet<string>(existing);
+        var result = new List<string>(existing);
+        foreach (var ext in incoming)
+        {
+            if (seen.Add(ext))
+                result.Add(ext);
+        }
+        return result;
     }
 }

--- a/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
@@ -480,4 +480,169 @@ public class TaskProjectionTests
         Assert.Single(result.History);
         Assert.Equal("m1", result.History[0].MessageId);
     }
+
+    [Fact]
+    public void Apply_WithArtifactAppend_DoesNotMutateOriginalArtifact()
+    {
+        // Arrange
+        var originalParts = new List<Part> { Part.FromText("original") };
+        var originalMetadata = new Dictionary<string, JsonElement>
+        {
+            ["key"] = JsonSerializer.SerializeToElement("val")
+        };
+        var original = new Artifact
+        {
+            ArtifactId = "a1",
+            Parts = originalParts,
+            Metadata = originalMetadata,
+            Extensions = ["ext1"]
+        };
+        var task = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "c1",
+            Status = new TaskStatus { State = TaskState.Working },
+            Artifacts = [original]
+        };
+
+        var partsCount = original.Parts.Count;
+        var metaCount = original.Metadata.Count;
+        var extCount = original.Extensions!.Count;
+
+        // Act
+        var result = TaskProjection.Apply(task, new StreamResponse
+        {
+            ArtifactUpdate = new TaskArtifactUpdateEvent
+            {
+                Artifact = new Artifact
+                {
+                    ArtifactId = "a1",
+                    Parts = [Part.FromText("appended")],
+                    Metadata = new() { ["new"] = JsonSerializer.SerializeToElement("new-val") },
+                    Extensions = ["ext2"]
+                },
+                Append = true
+            }
+        });
+
+        // Assert — original artifact object is untouched
+        Assert.Equal(partsCount, original.Parts.Count);
+        Assert.Equal(metaCount, original.Metadata.Count);
+        Assert.Equal(extCount, original.Extensions!.Count);
+
+        // Assert — merged artifact is a new instance with combined data
+        var merged = result!.Artifacts![0];
+        Assert.NotSame(original, merged);
+        Assert.Equal(2, merged.Parts.Count);
+        Assert.Equal(2, merged.Metadata!.Count);
+        Assert.Equal(2, merged.Extensions!.Count);
+    }
+
+    [Fact]
+    public void Apply_WithStatusUpdate_DoesNotMutateOriginalHistory()
+    {
+        // Arrange
+        var originalHistory = new List<Message>
+        {
+            new() { Role = Role.Agent, Parts = [Part.FromText("old")] }
+        };
+        var task = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "c1",
+            Status = new TaskStatus
+            {
+                State = TaskState.Working,
+                Message = new Message { Role = Role.Agent, Parts = [Part.FromText("superseded")] }
+            },
+            History = originalHistory
+        };
+
+        var historyCount = originalHistory.Count;
+
+        // Act
+        var result = TaskProjection.Apply(task, new StreamResponse
+        {
+            StatusUpdate = new TaskStatusUpdateEvent
+            {
+                Status = new TaskStatus { State = TaskState.Completed }
+            }
+        });
+
+        // Assert — original history list is unchanged
+        Assert.Equal(historyCount, originalHistory.Count);
+        // Assert — result has new history with superseded message appended
+        Assert.NotSame(originalHistory, result!.History);
+        Assert.Equal(historyCount + 1, result.History!.Count);
+    }
+
+    [Fact]
+    public void Apply_WithMessage_DoesNotMutateOriginalHistory()
+    {
+        // Arrange
+        var originalHistory = new List<Message>
+        {
+            new() { Role = Role.Agent, Parts = [Part.FromText("existing")] }
+        };
+        var task = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "c1",
+            Status = new TaskStatus { State = TaskState.Working },
+            History = originalHistory
+        };
+
+        var historyCount = originalHistory.Count;
+
+        // Act
+        var result = TaskProjection.Apply(task, new StreamResponse
+        {
+            Message = new Message { Role = Role.Agent, Parts = [Part.FromText("new message")] }
+        });
+
+        // Assert — original history list is unchanged
+        Assert.Equal(historyCount, originalHistory.Count);
+        // Assert — result has new history with message appended
+        Assert.NotSame(originalHistory, result!.History);
+        Assert.Equal(historyCount + 1, result.History!.Count);
+    }
+
+    [Fact]
+    public void Apply_ReturnsNewAgentTaskInstance_OriginalUnmutated()
+    {
+        // Arrange
+        var original = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "c1",
+            Status = new TaskStatus { State = TaskState.Working },
+            History = [new Message { Role = Role.Agent, Parts = [Part.FromText("old")] }],
+            Artifacts = [new Artifact { ArtifactId = "a1", Parts = [Part.FromText("part")] }],
+        };
+
+        var originalStatus = original.Status;
+        var originalHistory = original.History;
+        var originalArtifacts = original.Artifacts;
+
+        // Act
+        var result = TaskProjection.Apply(original, new StreamResponse
+        {
+            StatusUpdate = new TaskStatusUpdateEvent
+            {
+                Status = new TaskStatus { State = TaskState.Completed }
+            }
+        });
+
+        // Assert — result is a different AgentTask instance
+        Assert.NotSame(original, result);
+
+        // Assert — original AgentTask is completely untouched
+        Assert.Same(originalStatus, original.Status);
+        Assert.Same(originalHistory, original.History);
+        Assert.Same(originalArtifacts, original.Artifacts);
+        Assert.Equal(TaskState.Working, original.Status.State);
+
+        // Assert — result has the updated state
+        Assert.Equal(TaskState.Completed, result!.Status.State);
+    }
 }


### PR DESCRIPTION
## Summary

Addresses #348 — TaskProjection.Apply now returns a **new AgentTask instance** instead of mutating the input, and all sub-object updates (artifacts, history lists, metadata) use copy-and-replace. This makes TaskProjection inherently safe for concurrent readers without requiring ITaskStore implementations to clone on read.

### Problem

TaskProjection.Apply mutated the incoming AgentTask in-place — swapping .Status, .History, .Artifacts and mutating individual Artifact objects (appending to Parts, upserting Metadata, etc.). This created two hazards:

1. **Shared reference mutation**: ResolveContextAsync stores the AgentTask in context.Task, which the handler reads concurrently. If ITaskStore.GetTaskAsync returns the same reference, ApplyEventAsync would mutate the handler's live context.
2. **Sub-object mutation**: Custom ITaskStore implementations that don't deep-clone on read would expose in-flight mutations to concurrent GetTaskAsync callers.

### Changes

**src/A2A/Server/TaskProjection.cs** (107 → ~140 lines):

- Apply now creates a **shallow copy** of the AgentTask before dispatching to sub-methods — the original is never touched
- ApplyArtifact append mode builds a **new Artifact** with merged data instead of mutating the existing one
- ApplyStatus and ApplyMessage replace the History reference with a new list via collection expressions
- Added MergeMetadata (copy + upsert) and MergeExtensions (copy + deduplicated append with HashSet) private helpers
- Extracted ApplyMessage for consistent abstraction level in Apply

**	ests/A2A.UnitTests/Server/TaskProjectionTests.cs** (+4 tests):

- Apply_ReturnsNewAgentTaskInstance_OriginalUnmutated — verifies original AgentTask properties unchanged
- Apply_WithArtifactAppend_DoesNotMutateOriginalArtifact — verifies original artifact's Parts/Metadata/Extensions unchanged
- Apply_WithStatusUpdate_DoesNotMutateOriginalHistory — verifies original History list unchanged
- Apply_WithMessage_DoesNotMutateOriginalHistory — verifies original History list unchanged

### Safety model after this PR

| Layer | Behavior |
|-------|----------|
| AgentTask | **New instance** returned — original untouched |
| Artifacts list | **Copied** — original list untouched |
| Individual Artifact (append) | **New instance** with merged collections |
| History list | **New list** via collection expressions |
| Metadata, Status | Assigned on the **new copy** only |

### Validation

- `dotnet build A2A.slnx` — 20 projects succeeded (net8.0 + net10.0)
- `dotnet test` — all 1458+ tests pass, 0 failures

Closes #348
