### PR TITLE
feat: add per-request handler factory overloads for multi-agent hosting

### DIFF
--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -269,52 +269,86 @@ public static class A2ARouteBuilderExtensions
         var logger = endpoints.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("A2A.REST");
 
         // Agent card
-        routeGroup.MapGet("/card", (HttpContext httpContext, CancellationToken ct)
-            => A2AHttpProcessor.GetAgentCardRestAsync(handlerFactory(httpContext), logger, agentCardFactory(httpContext), ct));
+        routeGroup.MapGet("/card", async (HttpContext httpContext, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.GetAgentCardRestAsync(handlerFactory(httpContext), logger, agentCardFactory(httpContext), ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
         // Task operations
-        routeGroup.MapGet("/tasks/{id}", (HttpContext httpContext, string id, [FromQuery] int? historyLength, CancellationToken ct)
-            => A2AHttpProcessor.GetTaskRestAsync(handlerFactory(httpContext), logger, id, historyLength, ct));
+        routeGroup.MapGet("/tasks/{id}", async (HttpContext httpContext, string id, [FromQuery] int? historyLength, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.GetTaskRestAsync(handlerFactory(httpContext), logger, id, historyLength, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
-        routeGroup.MapPost("/tasks/{id}:cancel", (HttpContext httpContext, string id, CancellationToken ct)
-            => A2AHttpProcessor.CancelTaskRestAsync(handlerFactory(httpContext), logger, id, ct));
+        routeGroup.MapPost("/tasks/{id}:cancel", async (HttpContext httpContext, string id, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.CancelTaskRestAsync(handlerFactory(httpContext), logger, id, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
-        routeGroup.MapPost("/tasks/{id}:subscribe", (HttpContext httpContext, string id, CancellationToken ct)
-            => A2AHttpProcessor.SubscribeToTaskRest(handlerFactory(httpContext), logger, id, ct));
+        routeGroup.MapPost("/tasks/{id}:subscribe", (HttpContext httpContext, string id, CancellationToken ct) =>
+        {
+            try { return A2AHttpProcessor.SubscribeToTaskRest(handlerFactory(httpContext), logger, id, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
-        routeGroup.MapGet("/tasks", (HttpContext httpContext, [FromQuery] string? contextId, [FromQuery] string? status,
-            [FromQuery] int? pageSize, [FromQuery] string? pageToken, [FromQuery] int? historyLength,
-            CancellationToken ct)
-            => A2AHttpProcessor.ListTasksRestAsync(handlerFactory(httpContext), logger, contextId, status, pageSize, pageToken,
-                historyLength, ct));
+        routeGroup.MapGet("/tasks", async (HttpContext httpContext, [FromQuery] string? contextId, [FromQuery] string? status,
+            [FromQuery] int? pageSize, [FromQuery] string? pageToken, [FromQuery] int? historyLength, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.ListTasksRestAsync(handlerFactory(httpContext), logger, contextId, status, pageSize, pageToken, historyLength, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
         // Message operations
-        routeGroup.MapPost("/message:send", (HttpContext httpContext, [FromBody] SendMessageRequest request, CancellationToken ct)
-            => A2AHttpProcessor.SendMessageRestAsync(handlerFactory(httpContext), logger, request, ct));
+        routeGroup.MapPost("/message:send", async (HttpContext httpContext, [FromBody] SendMessageRequest request, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.SendMessageRestAsync(handlerFactory(httpContext), logger, request, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
-        routeGroup.MapPost("/message:stream", (HttpContext httpContext, [FromBody] SendMessageRequest request, CancellationToken ct)
-            => A2AHttpProcessor.SendMessageStreamRest(handlerFactory(httpContext), logger, request, ct));
+        routeGroup.MapPost("/message:stream", (HttpContext httpContext, [FromBody] SendMessageRequest request, CancellationToken ct) =>
+        {
+            try { return A2AHttpProcessor.SendMessageStreamRest(handlerFactory(httpContext), logger, request, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
         // Push notification config operations
         routeGroup.MapPost("/tasks/{id}/pushNotificationConfigs",
-            (HttpContext httpContext, string id, [FromBody] PushNotificationConfig config, CancellationToken ct)
-            => A2AHttpProcessor.CreatePushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, config, ct));
+            async (HttpContext httpContext, string id, [FromBody] PushNotificationConfig config, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.CreatePushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, config, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
         routeGroup.MapGet("/tasks/{id}/pushNotificationConfigs",
-            (HttpContext httpContext, string id, [FromQuery] int? pageSize, [FromQuery] string? pageToken, CancellationToken ct)
-            => A2AHttpProcessor.ListPushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, pageSize, pageToken, ct));
+            async (HttpContext httpContext, string id, [FromQuery] int? pageSize, [FromQuery] string? pageToken, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.ListPushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, pageSize, pageToken, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
         routeGroup.MapGet("/tasks/{id}/pushNotificationConfigs/{configId}",
-            (HttpContext httpContext, string id, string configId, CancellationToken ct)
-            => A2AHttpProcessor.GetPushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, configId, ct));
+            async (HttpContext httpContext, string id, string configId, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.GetPushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, configId, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
         routeGroup.MapDelete("/tasks/{id}/pushNotificationConfigs/{configId}",
-            (HttpContext httpContext, string id, string configId, CancellationToken ct)
-            => A2AHttpProcessor.DeletePushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, configId, ct));
+            async (HttpContext httpContext, string id, string configId, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.DeletePushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, configId, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
         // Extended agent card
-        routeGroup.MapGet("/extendedAgentCard", (HttpContext httpContext, CancellationToken ct)
-            => A2AHttpProcessor.GetExtendedAgentCardRestAsync(handlerFactory(httpContext), logger, ct));
+        routeGroup.MapGet("/extendedAgentCard", async (HttpContext httpContext, CancellationToken ct) =>
+        {
+            try { return await A2AHttpProcessor.GetExtendedAgentCardRestAsync(handlerFactory(httpContext), logger, ct); }
+            catch (A2AException ex) { return A2AHttpProcessor.MapA2AExceptionToHttpResult(ex); }
+        });
 
         return routeGroup;
     }

--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -53,6 +53,78 @@ public static class A2ARouteBuilderExtensions
         return routeGroup;
     }
 
+    /// <summary>Enables JSON-RPC A2A endpoints with per-request handler resolution.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="handlerFactory">Factory that resolves an <see cref="IA2ARequestHandler"/> per request from the <see cref="HttpContext"/>.</param>
+    /// <param name="path">The route path for the A2A endpoint.</param>
+    /// <returns>An endpoint convention builder for further configuration.</returns>
+    public static IEndpointConventionBuilder MapA2A(
+        this IEndpointRouteBuilder endpoints,
+        Func<HttpContext, IA2ARequestHandler> handlerFactory,
+        [StringSyntax("Route")] string path)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(handlerFactory);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        var routeGroup = endpoints.MapGroup("");
+        routeGroup.MapPost(path, async (HttpContext httpContext, CancellationToken cancellationToken) =>
+        {
+            IA2ARequestHandler handler;
+            try
+            {
+                handler = handlerFactory(httpContext);
+            }
+            catch (A2AException ex)
+            {
+                return new JsonRpcResponseResult(JsonRpcResponse.CreateJsonRpcErrorResponse(new JsonRpcId((string?)null), ex));
+            }
+
+            return await A2AJsonRpcProcessor.ProcessRequestAsync(handler, httpContext.Request, cancellationToken);
+        });
+
+        return routeGroup;
+    }
+
+    /// <summary>Enables JSON-RPC A2A endpoints and well-known agent card with per-request resolution.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="handlerFactory">Factory that resolves an <see cref="IA2ARequestHandler"/> per request from the <see cref="HttpContext"/>.</param>
+    /// <param name="agentCardFactory">Factory that resolves an <see cref="AgentCard"/> per request from the <see cref="HttpContext"/>.</param>
+    /// <param name="path">The route path for the A2A JSON-RPC endpoint.</param>
+    /// <returns>An endpoint convention builder for further configuration.</returns>
+    public static IEndpointConventionBuilder MapA2A(
+        this IEndpointRouteBuilder endpoints,
+        Func<HttpContext, IA2ARequestHandler> handlerFactory,
+        Func<HttpContext, AgentCard> agentCardFactory,
+        [StringSyntax("Route")] string path)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(handlerFactory);
+        ArgumentNullException.ThrowIfNull(agentCardFactory);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        var routeGroup = endpoints.MapGroup("");
+
+        routeGroup.MapPost(path, async (HttpContext httpContext, CancellationToken cancellationToken) =>
+        {
+            IA2ARequestHandler handler;
+            try
+            {
+                handler = handlerFactory(httpContext);
+            }
+            catch (A2AException ex)
+            {
+                return new JsonRpcResponseResult(JsonRpcResponse.CreateJsonRpcErrorResponse(new JsonRpcId((string?)null), ex));
+            }
+
+            return await A2AJsonRpcProcessor.ProcessRequestAsync(handler, httpContext.Request, cancellationToken);
+        });
+
+        routeGroup.MapGet(".well-known/agent-card.json", (HttpContext httpContext) => Results.Ok(agentCardFactory(httpContext)));
+
+        return routeGroup;
+    }
+
     /// <summary>Enables the well-known agent card endpoint for agent discovery.</summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="agentCard">The agent card to serve.</param>
@@ -66,6 +138,25 @@ public static class A2ARouteBuilderExtensions
         var routeGroup = endpoints.MapGroup(path);
 
         routeGroup.MapGet(".well-known/agent-card.json", () => Results.Ok(agentCard));
+
+        return routeGroup;
+    }
+
+    /// <summary>Enables the well-known agent card endpoint with per-request card resolution.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="agentCardFactory">Factory that resolves an <see cref="AgentCard"/> per request from the <see cref="HttpContext"/>.</param>
+    /// <param name="path">An optional route prefix.</param>
+    /// <returns>An endpoint convention builder for further configuration.</returns>
+    public static IEndpointConventionBuilder MapWellKnownAgentCard(
+        this IEndpointRouteBuilder endpoints,
+        Func<HttpContext, AgentCard> agentCardFactory,
+        [StringSyntax("Route")] string path = "")
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(agentCardFactory);
+
+        var routeGroup = endpoints.MapGroup(path);
+        routeGroup.MapGet(".well-known/agent-card.json", (HttpContext httpContext) => Results.Ok(agentCardFactory(httpContext)));
 
         return routeGroup;
     }
@@ -144,6 +235,86 @@ public static class A2ARouteBuilderExtensions
         // Extended agent card
         routeGroup.MapGet("/extendedAgentCard", (CancellationToken ct)
             => A2AHttpProcessor.GetExtendedAgentCardRestAsync(requestHandler, logger, ct));
+
+        return routeGroup;
+    }
+
+    /// <summary>
+    /// Maps HTTP+JSON REST API endpoints for A2A with per-request handler and agent card resolution.
+    /// </summary>
+    /// <remarks>
+    /// <para>Use this overload for multi-agent hosting scenarios where the handler and agent card
+    /// vary per request (e.g., based on subdomain, authentication, or tenant context).</para>
+    /// <para><strong>Limitation:</strong> Multi-tenant route variants
+    /// (<c>/{tenant}/tasks/{id}</c>) defined in the A2A specification are not currently
+    /// supported. The <c>Tenant</c> field on request types will always be <c>null</c>
+    /// for REST API calls.</para>
+    /// </remarks>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="handlerFactory">Factory that resolves an <see cref="IA2ARequestHandler"/> per request.</param>
+    /// <param name="agentCardFactory">Factory that resolves an <see cref="AgentCard"/> per request.</param>
+    /// <param name="path">The route prefix for all REST endpoints.</param>
+    /// <returns>An endpoint convention builder for further configuration.</returns>
+    public static IEndpointConventionBuilder MapHttpA2A(
+        this IEndpointRouteBuilder endpoints,
+        Func<HttpContext, IA2ARequestHandler> handlerFactory,
+        Func<HttpContext, AgentCard> agentCardFactory,
+        [StringSyntax("Route")] string path = "")
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(handlerFactory);
+        ArgumentNullException.ThrowIfNull(agentCardFactory);
+
+        var routeGroup = endpoints.MapGroup(path);
+        var logger = endpoints.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("A2A.REST");
+
+        // Agent card
+        routeGroup.MapGet("/card", (HttpContext httpContext, CancellationToken ct)
+            => A2AHttpProcessor.GetAgentCardRestAsync(handlerFactory(httpContext), logger, agentCardFactory(httpContext), ct));
+
+        // Task operations
+        routeGroup.MapGet("/tasks/{id}", (HttpContext httpContext, string id, [FromQuery] int? historyLength, CancellationToken ct)
+            => A2AHttpProcessor.GetTaskRestAsync(handlerFactory(httpContext), logger, id, historyLength, ct));
+
+        routeGroup.MapPost("/tasks/{id}:cancel", (HttpContext httpContext, string id, CancellationToken ct)
+            => A2AHttpProcessor.CancelTaskRestAsync(handlerFactory(httpContext), logger, id, ct));
+
+        routeGroup.MapPost("/tasks/{id}:subscribe", (HttpContext httpContext, string id, CancellationToken ct)
+            => A2AHttpProcessor.SubscribeToTaskRest(handlerFactory(httpContext), logger, id, ct));
+
+        routeGroup.MapGet("/tasks", (HttpContext httpContext, [FromQuery] string? contextId, [FromQuery] string? status,
+            [FromQuery] int? pageSize, [FromQuery] string? pageToken, [FromQuery] int? historyLength,
+            CancellationToken ct)
+            => A2AHttpProcessor.ListTasksRestAsync(handlerFactory(httpContext), logger, contextId, status, pageSize, pageToken,
+                historyLength, ct));
+
+        // Message operations
+        routeGroup.MapPost("/message:send", (HttpContext httpContext, [FromBody] SendMessageRequest request, CancellationToken ct)
+            => A2AHttpProcessor.SendMessageRestAsync(handlerFactory(httpContext), logger, request, ct));
+
+        routeGroup.MapPost("/message:stream", (HttpContext httpContext, [FromBody] SendMessageRequest request, CancellationToken ct)
+            => A2AHttpProcessor.SendMessageStreamRest(handlerFactory(httpContext), logger, request, ct));
+
+        // Push notification config operations
+        routeGroup.MapPost("/tasks/{id}/pushNotificationConfigs",
+            (HttpContext httpContext, string id, [FromBody] PushNotificationConfig config, CancellationToken ct)
+            => A2AHttpProcessor.CreatePushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, config, ct));
+
+        routeGroup.MapGet("/tasks/{id}/pushNotificationConfigs",
+            (HttpContext httpContext, string id, [FromQuery] int? pageSize, [FromQuery] string? pageToken, CancellationToken ct)
+            => A2AHttpProcessor.ListPushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, pageSize, pageToken, ct));
+
+        routeGroup.MapGet("/tasks/{id}/pushNotificationConfigs/{configId}",
+            (HttpContext httpContext, string id, string configId, CancellationToken ct)
+            => A2AHttpProcessor.GetPushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, configId, ct));
+
+        routeGroup.MapDelete("/tasks/{id}/pushNotificationConfigs/{configId}",
+            (HttpContext httpContext, string id, string configId, CancellationToken ct)
+            => A2AHttpProcessor.DeletePushNotificationConfigRestAsync(handlerFactory(httpContext), logger, id, configId, ct));
+
+        // Extended agent card
+        routeGroup.MapGet("/extendedAgentCard", (HttpContext httpContext, CancellationToken ct)
+            => A2AHttpProcessor.GetExtendedAgentCardRestAsync(handlerFactory(httpContext), logger, ct));
 
         return routeGroup;
     }

--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -103,7 +103,7 @@ internal static class A2AHttpProcessor
         }
     }
 
-    private static IResult MapA2AExceptionToHttpResult(A2AException exception)
+    internal static IResult MapA2AExceptionToHttpResult(A2AException exception)
     {
         return exception.ErrorCode switch
         {

--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -25,7 +25,18 @@ public static class A2AJsonRpcProcessor
         return null;
     }
 
-    internal static async Task<IResult> ProcessRequestAsync(IA2ARequestHandler requestHandler, HttpRequest request, CancellationToken cancellationToken)
+    /// <summary>
+    /// Processes an A2A JSON-RPC request, routing it to the appropriate handler method.
+    /// </summary>
+    /// <remarks>
+    /// Use this method directly for advanced scenarios such as custom per-request handler
+    /// routing or multi-agent middleware where the built-in <c>MapA2A</c> overloads are insufficient.
+    /// </remarks>
+    /// <param name="requestHandler">The handler to process the request.</param>
+    /// <param name="request">The incoming HTTP request containing the JSON-RPC payload.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>An <see cref="IResult"/> containing the JSON-RPC response.</returns>
+    public static async Task<IResult> ProcessRequestAsync(IA2ARequestHandler requestHandler, HttpRequest request, CancellationToken cancellationToken)
     {
         var preflightResult = CheckPreflight(request);
         if (preflightResult != null) return preflightResult;

--- a/tests/A2A.AspNetCore.UnitTests/A2AEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AEndpointRouteBuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Moq;
 
 namespace A2A.AspNetCore.Tests;
@@ -72,7 +73,7 @@ public class A2AEndpointRouteBuilderExtensionsTests
         var app = WebApplication.CreateBuilder().Build();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => app.MapA2A(null!, "/agent"));
+        Assert.Throws<ArgumentNullException>(() => app.MapA2A((IA2ARequestHandler)null!, "/agent"));
     }
 
     [Fact]
@@ -82,6 +83,93 @@ public class A2AEndpointRouteBuilderExtensionsTests
         var app = WebApplication.CreateBuilder().Build();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard(null!));
+        Assert.Throws<ArgumentNullException>(() => app.MapWellKnownAgentCard((AgentCard)null!));
+    }
+
+    // ── Factory overload tests ──
+
+    [Fact]
+    public void MapA2A_WithFactory_RegistersEndpoint()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Func<HttpContext, IA2ARequestHandler> factory = _ => new Mock<IA2ARequestHandler>().Object;
+        var result = app.MapA2A(factory, "/agent");
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void MapA2A_WithFactory_ThrowsArgumentNullException_WhenFactoryIsNull()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Assert.Throws<ArgumentNullException>(() =>
+            app.MapA2A((Func<HttpContext, IA2ARequestHandler>)null!, "/agent"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void MapA2A_WithFactory_ThrowsArgumentException_WhenPathIsNullOrEmpty(string? path)
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Func<HttpContext, IA2ARequestHandler> factory = _ => new Mock<IA2ARequestHandler>().Object;
+        if (path == null)
+            Assert.Throws<ArgumentNullException>(() => app.MapA2A(factory, path!));
+        else
+            Assert.Throws<ArgumentException>(() => app.MapA2A(factory, path));
+    }
+
+    [Fact]
+    public void MapA2A_WithHandlerAndCardFactories_RegistersEndpoint()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Func<HttpContext, IA2ARequestHandler> handlerFactory = _ => new Mock<IA2ARequestHandler>().Object;
+        Func<HttpContext, AgentCard> cardFactory = _ => new AgentCard { Name = "Test", Description = "Test" };
+        var result = app.MapA2A(handlerFactory, cardFactory, "/agent");
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void MapWellKnownAgentCard_WithFactory_RegistersEndpoint()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Func<HttpContext, AgentCard> factory = _ => new AgentCard { Name = "Test", Description = "Test" };
+        var result = app.MapWellKnownAgentCard(factory);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void MapWellKnownAgentCard_WithFactory_ThrowsArgumentNullException_WhenFactoryIsNull()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Assert.Throws<ArgumentNullException>(() =>
+            app.MapWellKnownAgentCard((Func<HttpContext, AgentCard>)null!));
+    }
+
+    [Fact]
+    public void MapHttpA2A_WithFactories_RegistersEndpoint()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Func<HttpContext, IA2ARequestHandler> handlerFactory = _ => new Mock<IA2ARequestHandler>().Object;
+        Func<HttpContext, AgentCard> cardFactory = _ => new AgentCard { Name = "Test", Description = "Test" };
+        var result = app.MapHttpA2A(handlerFactory, cardFactory);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void MapHttpA2A_WithFactories_ThrowsArgumentNullException_WhenHandlerFactoryIsNull()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Func<HttpContext, AgentCard> cardFactory = _ => new AgentCard { Name = "Test", Description = "Test" };
+        Assert.Throws<ArgumentNullException>(() =>
+            app.MapHttpA2A((Func<HttpContext, IA2ARequestHandler>)null!, cardFactory));
+    }
+
+    [Fact]
+    public void MapHttpA2A_WithFactories_ThrowsArgumentNullException_WhenCardFactoryIsNull()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+        Func<HttpContext, IA2ARequestHandler> handlerFactory = _ => new Mock<IA2ARequestHandler>().Object;
+        Assert.Throws<ArgumentNullException>(() =>
+            app.MapHttpA2A(handlerFactory, (Func<HttpContext, AgentCard>)null!));
     }
 }


### PR DESCRIPTION
## Summary

Addresses #353 — adds per-request `Func<HttpContext, T>` factory overloads to `MapA2A`, `MapWellKnownAgentCard`, and `MapHttpA2A`, enabling multi-agent hosting without adapter handler boilerplate. Also makes `ProcessRequestAsync` public for advanced custom middleware scenarios.

### Problem

The current `MapA2A`, `MapWellKnownAgentCard`, and `MapHttpA2A` all capture a single `IA2ARequestHandler` or `AgentCard` at startup. Enterprise platforms hosting many agents on one server (e.g., subdomain-per-user) had to implement a 70-line `IA2ARequestHandler` adapter that delegates all 11 interface methods to the correct handler per request.

### New overloads

| Overload | Purpose |
|----------|---------|
| `MapA2A(Func<HttpContext, IA2ARequestHandler>, path)` | JSON-RPC with per-request handler |
| `MapA2A(Func<HttpContext, IA2ARequestHandler>, Func<HttpContext, AgentCard>, path)` | JSON-RPC + well-known agent card |
| `MapWellKnownAgentCard(Func<HttpContext, AgentCard>, path)` | Dynamic agent card discovery |
| `MapHttpA2A(Func<HttpContext, IA2ARequestHandler>, Func<HttpContext, AgentCard>, path)` | REST binding with per-request handler + card |

### Usage

```csharp
// One call maps both JSON-RPC and agent card discovery
app.MapA2A(
    ctx => serverFactory.GetServer(ctx.GetSubdomain()),
    ctx => serverFactory.GetAgentCard(ctx.GetSubdomain()),
    "/");

// Optionally add REST binding too
app.MapHttpA2A(
    ctx => serverFactory.GetServer(ctx.GetSubdomain()),
    ctx => serverFactory.GetAgentCard(ctx.GetSubdomain()));
```

### Additional changes

- `A2AJsonRpcProcessor.ProcessRequestAsync` changed from `internal` to `public` with XML docs — enables custom routing middleware
- `MapA2A` factory overload wraps the factory call in try/catch so `A2AException` from the factory produces a proper JSON-RPC error response (not HTTP 500)

### Tests

- 10 new unit tests covering registration and null argument validation for all factory overloads
- 2 existing tests fixed with explicit casts to resolve overload ambiguity
- All 1,472 tests pass (78 AspNetCore × 2 TFMs + existing)

Relates to #353
