### PR TITLE
docs: rewrite migration guide and README to match v1 IAgentHandler API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,14 @@ This library contains the core A2A protocol implementation. It includes the foll
 - **`A2ACardResolver`**: Resolves agent card information from A2A-compatible endpoints to discover agent capabilities and metadata.
 
 ### Server Classes  
-- **`TaskManager`**: Manages the complete lifecycle of agent tasks including creation, updates, cancellation, and event streaming. Handles both message-based and task-based communication patterns.
-- **`ITaskStore`**: An interface for abstracting the storage of tasks.
-- **`InMemoryTaskStore`**: Simple in-memory implementation of `ITaskStore` suitable for development and testing scenarios.
+- **`A2AServer`**: Core server that handles A2A JSON-RPC requests, manages task lifecycle via `TaskProjection`, and coordinates streaming/non-streaming responses. Implements `IA2ARequestHandler`.
+- **`IAgentHandler`**: Interface that agents implement. Provides `ExecuteAsync()` for message handling and `CancelAsync()` for task cancellation.
+- **`TaskUpdater`**: Convenience API for emitting task lifecycle events (Submit, StartWork, AddArtifact, Complete, Fail, Cancel, RequireInput).
+- **`MessageResponder`**: Convenience API for stateless message replies without task lifecycle.
+- **`RequestContext`**: Pre-resolved context provided to agents, containing the incoming message, task ID, context ID, and helper properties like `UserText` and `IsContinuation`.
+- **`AgentEventQueue`**: Channel-backed queue that agents write events to. The SDK reads from it to build responses.
+- **`ITaskStore`**: Interface for task persistence with simple CRUD methods (Get, Save, Delete, List).
+- **`InMemoryTaskStore`**: In-memory implementation of `ITaskStore` suitable for development and testing.
 
 ### Core Models
 - **`AgentTask`**: Represents a task with its status, history, artifacts, and metadata.
@@ -63,7 +68,8 @@ This library contains the core A2A protocol implementation. It includes the foll
 This library provides ASP.NET Core integration for hosting A2A agents. It includes the following key classes:
 
 ### Extension Methods
-- **`A2ARouteBuilderExtensions`**: Provides `MapA2A()` and `MapHttpA2A()` extension methods for configuring A2A endpoints in ASP.NET Core applications.
+- **`A2AServiceCollectionExtensions`**: Provides `AddA2AAgent<THandler>()` for registering an agent, its card, and all A2A services with dependency injection.
+- **`A2ARouteBuilderExtensions`**: Provides `MapA2A()` for JSON-RPC endpoints, `MapHttpA2A()` for HTTP REST endpoints, and `MapWellKnownAgentCard()` for agent card discovery.
 
 ## Getting Started
 
@@ -74,51 +80,56 @@ using A2A;
 using A2A.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Register the echo agent with DI — this sets up A2AServer, ITaskStore, and all middleware
+builder.Services.AddA2AAgent<EchoAgent>(EchoAgent.GetAgentCard("http://localhost:5000/echo"));
+
 var app = builder.Build();
 
-var store = new InMemoryTaskStore();
-var taskManager = new TaskManager(store);
+// Map JSON-RPC endpoint for A2A communication
+app.MapA2A("/echo");
 
-taskManager.OnSendMessage = async (request, ct) =>
-{
-    var text = request.Message.Parts.FirstOrDefault()?.Text ?? "";
-    return new SendMessageResponse
-    {
-        Message = new Message
-        {
-            MessageId = Guid.NewGuid().ToString("N"),
-            Role = Role.Agent,
-            Parts = [Part.FromText($"Echo: {text}")]
-        }
-    };
-};
+// Map well-known agent card for discovery
+var card = app.Services.GetRequiredService<AgentCard>();
+app.MapWellKnownAgentCard(card);
 
-var agentCard = new AgentCard
-{
-    Name = "Echo Agent",
-    Description = "Echoes messages back to the user",
-    Version = "1.0.0",
-    SupportedInterfaces = [new AgentInterface
-    {
-        Url = "http://localhost:5000/echo",
-        ProtocolBinding = "JSONRPC",
-        ProtocolVersion = "1.0"
-    }],
-    DefaultInputModes = ["text/plain"],
-    DefaultOutputModes = ["text/plain"],
-    Capabilities = new AgentCapabilities { Streaming = false },
-    Skills = [new AgentSkill
-    {
-        Id = "echo",
-        Name = "Echo",
-        Description = "Echoes back user messages",
-        Tags = ["echo"]
-    }],
-};
-
-app.MapA2A(taskManager, "/echo");
-app.MapWellKnownAgentCard(agentCard);
 app.Run();
+
+// Define the agent — implement IAgentHandler
+public sealed class EchoAgent : IAgentHandler
+{
+    public async Task ExecuteAsync(
+        RequestContext context,
+        AgentEventQueue eventQueue,
+        CancellationToken cancellationToken)
+    {
+        var responder = new MessageResponder(eventQueue, context.ContextId);
+        await responder.ReplyAsync($"Echo: {context.UserText}", cancellationToken);
+    }
+
+    public static AgentCard GetAgentCard(string url) => new()
+    {
+        Name = "Echo Agent",
+        Description = "Echoes messages back to the user",
+        Version = "1.0.0",
+        SupportedInterfaces = [new AgentInterface
+        {
+            Url = url,
+            ProtocolBinding = "JSONRPC",
+            ProtocolVersion = "1.0"
+        }],
+        DefaultInputModes = ["text/plain"],
+        DefaultOutputModes = ["text/plain"],
+        Capabilities = new AgentCapabilities { Streaming = false },
+        Skills = [new AgentSkill
+        {
+            Id = "echo",
+            Name = "Echo",
+            Description = "Echoes back user messages",
+            Tags = ["echo"]
+        }],
+    };
+}
 ```
 
 ### 2. Connect with A2AClient

--- a/docs/taskmanager-migration-guide.md
+++ b/docs/taskmanager-migration-guide.md
@@ -5,23 +5,26 @@ This guide helps you migrate existing A2A agent implementations from the v0.3
 
 ## Overview of changes
 
-The v1 `TaskManager` is fundamentally simpler. Instead of four lifecycle
-callbacks and automatic task management, you get one main callback where you
-own the entire response.
+v1 replaces the `TaskManager` callback model with `IAgentHandler` — a single
+interface where your agent owns its execution logic. The SDK handles task
+lifecycle, persistence, and event streaming through `A2AServer` behind the scenes.
 
 | Aspect | v0.3 | v1 |
 |--------|------|-----|
-| Callbacks | `OnMessageReceived`, `OnTaskCreated`, `OnTaskCancelled`, `OnTaskUpdated` | `OnSendMessage`, `OnSendStreamingMessage`, `OnCancelTask` |
-| Task creation | Automatic (TaskManager creates tasks) | Manual (your code creates tasks via `ITaskStore`) |
-| Status updates | `taskManager.UpdateStatusAsync(taskId, state, message)` | `store.UpdateStatusAsync(taskId, status)` directly |
-| Artifacts | `taskManager.ReturnArtifactAsync(taskId, artifact)` | Set `task.Artifacts` before returning |
-| Agent card | `OnAgentCardQuery` callback | `MapWellKnownAgentCard()` extension method |
-| Constructor | `TaskManager(HttpClient?, ITaskStore?)` | `TaskManager(ITaskStore, ILogger<TaskManager>)` |
-| Return type | `A2AResponse` (polymorphic: cast to `AgentTask`, `TaskStatusUpdateEvent`, etc.) | `SendMessageResponse` (set `.Message` or `.Task`) |
+| Agent interface | Callback delegates (`OnMessageReceived`, `OnTaskCreated`, etc.) | `IAgentHandler.ExecuteAsync(RequestContext, AgentEventQueue, CancellationToken)` |
+| Task creation | Automatic (TaskManager creates tasks) | Agent controls via `TaskUpdater.SubmitAsync()` |
+| Status updates | `taskManager.UpdateStatusAsync(taskId, state, message)` | `TaskUpdater.StartWorkAsync()`, `CompleteAsync()`, `FailAsync()`, etc. |
+| Artifacts | `taskManager.ReturnArtifactAsync(taskId, artifact)` | `TaskUpdater.AddArtifactAsync(parts)` |
+| Agent card | `OnAgentCardQuery` callback | `MapWellKnownAgentCard(agentCard)` static registration |
+| DI registration | Manual: `new TaskManager()` + `agent.Attach(tm)` | `services.AddA2AAgent<T>(agentCard)` |
+| Endpoint mapping | `app.MapA2A(taskManager, "/agent")` | `app.MapA2A("/agent")` (DI-resolved) |
+| Store interface | 6 methods (mutations + push config) | 4 methods (Get, Save, Delete, List) |
+| Multi-turn routing | Separate `OnTaskCreated` (new) vs `OnTaskUpdated` (existing) | Single `ExecuteAsync` — check `context.IsContinuation` |
+| Streaming | Framework-managed (`TaskUpdateEventEnumerator`) | Agent-controlled (`AgentEventQueue` + `TaskUpdater`) |
 
 ## Step-by-step migration
 
-### Step 1: Update constructor and wiring
+### Step 1: Update DI registration and endpoint wiring
 
 **v0.3:**
 
@@ -34,18 +37,39 @@ app.MapA2A(taskManager, "/agent");
 **v1:**
 
 ```csharp
-var store = new InMemoryTaskStore();
-var logger = loggerFactory.CreateLogger<TaskManager>();
-var taskManager = new TaskManager(store, logger);
-agent.Attach(taskManager, store);          // pass store to agent
-app.MapA2A(taskManager, "/agent");
-app.MapWellKnownAgentCard(agentCard);      // agent card served separately
+using A2A;
+using A2A.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Register the agent, its card, and all A2A services via DI
+builder.Services.AddA2AAgent<EchoAgent>(EchoAgent.GetAgentCard("http://localhost:5000/echo"));
+
+var app = builder.Build();
+
+// Map JSON-RPC endpoint
+app.MapA2A("/echo");
+
+// Map well-known agent card for discovery
+var card = app.Services.GetRequiredService<AgentCard>();
+app.MapWellKnownAgentCard(card);
+
+app.Run();
 ```
 
 Key differences:
-- `ITaskStore` and `ILogger` are required constructor parameters.
-- Your agent receives the `ITaskStore` so it can read/write tasks directly.
-- Agent card is no longer served via a callback; use `MapWellKnownAgentCard()`.
+
+- `AddA2AAgent<THandler>(agentCard)` registers `IAgentHandler`, `AgentCard`,
+  `A2AServerOptions`, `ChannelEventNotifier`, `ITaskStore` (defaults to
+  `InMemoryTaskStore`), and `IA2ARequestHandler` (as `A2AServer`).
+- Your agent implements `IAgentHandler` instead of attaching callbacks to
+  `TaskManager`.
+- `MapA2A(path)` resolves the handler from DI — no need to pass the handler
+  explicitly.
+- To use a custom `ITaskStore`, register it before calling
+  `AddA2AAgent<T>()` (uses `TryAddSingleton`).
+- Agent card is served at `.well-known/agent-card.json` via
+  `MapWellKnownAgentCard()`.
 
 ### Step 2: Replace OnAgentCardQuery
 
@@ -59,10 +83,11 @@ taskManager.OnAgentCardQuery = (url, ct) =>
 **v1:**
 
 ```csharp
-// In Program.cs — static registration
+// Define the agent card (typically as a static method on the agent class)
 var card = new AgentCard
 {
     Name = "My Agent",
+    Description = "Agent description",
     Version = "1.0.0",
     SupportedInterfaces = [new AgentInterface
     {
@@ -75,6 +100,8 @@ var card = new AgentCard
     Capabilities = new AgentCapabilities { Streaming = false },
     Skills = [new AgentSkill { Id = "main", Name = "Main", Description = "...", Tags = ["main"] }],
 };
+
+// Register at startup
 app.MapWellKnownAgentCard(card);
 ```
 
@@ -102,31 +129,37 @@ taskManager.OnMessageReceived = async (msgParams, ct) =>
 **v1:**
 
 ```csharp
-taskManager.OnSendMessage = (request, ct) =>
+public sealed class EchoAgent : IAgentHandler
 {
-    var text = request.Message.Parts.FirstOrDefault(p => p.Text is not null)?.Text ?? "";
-    var response = new Message
+    public async Task ExecuteAsync(
+        RequestContext context,
+        AgentEventQueue eventQueue,
+        CancellationToken cancellationToken)
     {
-        Role = Role.Agent,
-        MessageId = Guid.NewGuid().ToString("N"),
-        ContextId = request.Message.ContextId,
-        Parts = [Part.FromText($"Echo: {text}")]
-    };
-    return Task.FromResult(new SendMessageResponse { Message = response });
-};
+        var responder = new MessageResponder(eventQueue, context.ContextId);
+        await responder.ReplyAsync($"Echo: {context.UserText}", cancellationToken);
+    }
+}
 ```
 
 What changed:
-- `MessageSendParams` → `SendMessageRequest`
-- `AgentMessage` → `Message`
-- `MessageRole.Agent` → `Role.Agent`
-- `TextPart { Text = ... }` → `Part.FromText(...)`
-- Return `SendMessageResponse { Message = ... }` instead of bare `AgentMessage`
+
+- Callback delegate → implement `IAgentHandler.ExecuteAsync()`
+- `MessageSendParams` → `RequestContext` (pre-resolved with `UserText`,
+  `ContextId`, etc.)
+- `AgentMessage` with manual field construction →
+  `MessageResponder.ReplyAsync()` (auto-generates `MessageId`, sets
+  `Role.Agent`)
+- `TextPart { Text = ... }` → `Part.FromText(...)` (handled internally by
+  `MessageResponder`)
+- No return value — agent writes to `AgentEventQueue` instead of returning a
+  response
 
 ### Step 4: Migrate task-based agents
 
-If your v0.3 agent used the automatic task lifecycle (OnTaskCreated, OnTaskUpdated,
-UpdateStatusAsync, ReturnArtifactAsync), you need to restructure.
+If your v0.3 agent used the automatic task lifecycle (`OnTaskCreated`,
+`OnTaskUpdated`, `UpdateStatusAsync`, `ReturnArtifactAsync`), you need to
+restructure.
 
 **v0.3:**
 
@@ -160,71 +193,61 @@ taskManager.OnTaskCancelled = async (task, ct) =>
 **v1:**
 
 ```csharp
-public void Attach(TaskManager taskManager, ITaskStore store)
+public sealed class MyAgent : IAgentHandler
 {
-    _store = store;
-    taskManager.OnSendMessage = OnSendMessageAsync;
-    taskManager.OnCancelTask = OnCancelTaskAsync;
-}
-
-private async Task<SendMessageResponse> OnSendMessageAsync(
-    SendMessageRequest request, CancellationToken ct)
-{
-    // You create the task yourself
-    var taskId = Guid.NewGuid().ToString("N");
-    var contextId = request.Message.ContextId ?? Guid.NewGuid().ToString("N");
-
-    // Do work...
-    var result = await DoWorkAsync(request, ct);
-
-    // Build the complete task with status, history, and artifacts
-    var task = new AgentTask
+    public async Task ExecuteAsync(
+        RequestContext context,
+        AgentEventQueue eventQueue,
+        CancellationToken cancellationToken)
     {
-        Id = taskId,
-        ContextId = contextId,
-        Status = new TaskStatus
-        {
-            State = TaskState.Completed,
-            Timestamp = DateTimeOffset.UtcNow,
-        },
-        History = [request.Message],
-        Artifacts =
-        [
-            new Artifact
-            {
-                ArtifactId = Guid.NewGuid().ToString("N"),
-                Parts = [Part.FromText(result)]
-            }
-        ],
-    };
+        var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
 
-    // Persist
-    await _store!.SetTaskAsync(task, ct);
+        // Signal task accepted
+        await updater.SubmitAsync(cancellationToken);
 
-    // Return the task directly
-    return new SendMessageResponse { Task = task };
-}
+        // Transition to working
+        await updater.StartWorkAsync(cancellationToken: cancellationToken);
 
-private async Task<AgentTask> OnCancelTaskAsync(
-    CancelTaskRequest request, CancellationToken ct)
-{
-    var task = await _store!.GetTaskAsync(request.Id, ct)
-        ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
+        // Do work...
+        var result = await DoWorkAsync(context, cancellationToken);
 
-    return await _store.UpdateStatusAsync(task.Id, new TaskStatus
+        // Add result artifact
+        await updater.AddArtifactAsync(
+            [Part.FromText(result)], cancellationToken: cancellationToken);
+
+        // Mark complete (also closes the event queue)
+        await updater.CompleteAsync(cancellationToken: cancellationToken);
+    }
+
+    // CancelAsync has a default implementation that transitions to Canceled.
+    // Override only if you need custom cleanup logic:
+    public async Task CancelAsync(
+        RequestContext context,
+        AgentEventQueue eventQueue,
+        CancellationToken cancellationToken)
     {
-        State = TaskState.Canceled,
-        Timestamp = DateTimeOffset.UtcNow,
-    }, ct);
+        // Custom cleanup...
+        var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
+        await updater.CancelAsync(cancellationToken);
+    }
 }
 ```
 
 What changed:
-- No more `OnTaskCreated`/`OnTaskUpdated` — everything happens in `OnSendMessage`
-- You create `AgentTask` objects directly instead of calling `taskManager.CreateTaskAsync()`
-- You set artifacts on the task object instead of calling `taskManager.ReturnArtifactAsync()`
-- You persist via `ITaskStore` directly instead of `taskManager.UpdateStatusAsync()`
-- `OnCancelTask` replaces `OnTaskCancelled` (note: different signature)
+
+- No more `OnTaskCreated`/`OnTaskUpdated` callbacks — the single
+  `ExecuteAsync` handles everything
+- `taskManager.UpdateStatusAsync(taskId, state, msg, final)` → `TaskUpdater`
+  methods: `SubmitAsync()`, `StartWorkAsync()`, `CompleteAsync()`,
+  `FailAsync()`, `CancelAsync()`, `RequireInputAsync()`, `RejectAsync()`
+- `taskManager.ReturnArtifactAsync(taskId, artifact)` →
+  `updater.AddArtifactAsync(parts)`
+- You don't create `AgentTask` objects directly — the SDK constructs them
+  from events via `TaskProjection.Apply`
+- `OnTaskCancelled` → `IAgentHandler.CancelAsync()` (has a sensible default
+  implementation)
+- The `TaskUpdater` manages task/context IDs — they come from
+  `RequestContext` which is pre-populated by `A2AServer`
 
 ### Step 5: Migrate multi-turn / stateful agents
 
@@ -245,52 +268,62 @@ taskManager.OnTaskUpdated = async (task, ct) =>
 **v1:**
 
 ```csharp
-private async Task<SendMessageResponse> OnSendMessageAsync(
-    SendMessageRequest request, CancellationToken ct)
+public sealed class ResearcherAgent : IAgentHandler
 {
-    // Check if this references an existing task
-    if (!string.IsNullOrEmpty(request.Message.TaskId))
+    public async Task ExecuteAsync(
+        RequestContext context,
+        AgentEventQueue eventQueue,
+        CancellationToken cancellationToken)
     {
-        var existing = await _store!.GetTaskAsync(request.Message.TaskId, ct);
-        if (existing is not null)
+        var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
+
+        if (!context.IsContinuation)
         {
-            // Append the new user message
-            await _store.AppendHistoryAsync(existing.Id, request.Message, ct);
+            // New task — initial processing
+            await updater.SubmitAsync(cancellationToken);
+            await updater.AddArtifactAsync(
+                [Part.FromText($"{context.UserText} received.")],
+                cancellationToken: cancellationToken);
 
-            // Process the follow-up...
-            var reply = new Message
+            // Ask the user for more input
+            await updater.RequireInputAsync(new Message
             {
-                MessageId = Guid.NewGuid().ToString("N"),
                 Role = Role.Agent,
-                TaskId = existing.Id,
-                ContextId = existing.ContextId,
-                Parts = [Part.FromText("Processed your follow-up.")],
-            };
-            await _store.AppendHistoryAsync(existing.Id, reply, ct);
-
-            // Update status
-            await _store.UpdateStatusAsync(existing.Id, new TaskStatus
-            {
-                State = TaskState.Completed,
-                Timestamp = DateTimeOffset.UtcNow,
-            }, ct);
-
-            var updated = await _store.GetTaskAsync(existing.Id, ct);
-            return new SendMessageResponse { Task = updated };
+                MessageId = Guid.NewGuid().ToString("N"),
+                ContextId = updater.ContextId,
+                Parts = [Part.FromText("When ready say go ahead")],
+            }, cancellationToken);
+            return;
         }
-    }
 
-    // New conversation — create initial task
-    var task = new AgentTask { /* ... */ };
-    await _store!.SetTaskAsync(task, ct);
-    return new SendMessageResponse { Task = task };
+        // Continuation — the user sent a follow-up message
+        await updater.StartWorkAsync(cancellationToken: cancellationToken);
+        await updater.AddArtifactAsync(
+            [Part.FromText($"{context.UserText} received.")],
+            cancellationToken: cancellationToken);
+        await updater.CompleteAsync(
+            new Message
+            {
+                Role = Role.Agent,
+                MessageId = Guid.NewGuid().ToString("N"),
+                Parts = [Part.FromText("Task completed successfully")],
+            },
+            cancellationToken);
+    }
 }
 ```
 
-Key insight: In v0.3, `TaskManager` routed messages to
-`OnTaskCreated` (new) or `OnTaskUpdated` (existing) for you. In v1, your
-single `OnSendMessage` callback handles both cases — check
-`request.Message.TaskId` to distinguish them.
+What changed:
+
+- v0.3 auto-routed new messages to `OnTaskCreated` and follow-ups to
+  `OnTaskUpdated`. In v1, the single `ExecuteAsync` callback handles both —
+  check `context.IsContinuation`.
+- `context.Task` contains the existing task (with history) when
+  `IsContinuation` is `true`.
+- `RequireInputAsync(message)` replaces manually setting `InputRequired`
+  state — it transitions the task and closes the event queue.
+- No manual `ITaskStore` interaction needed. The SDK automatically persists
+  state via `TaskProjection.Apply`.
 
 ### Step 6: Migrate streaming agents
 
@@ -312,81 +345,55 @@ taskManager.OnTaskCreated = async (task, ct) =>
 **v1:**
 
 ```csharp
-taskManager.OnSendStreamingMessage = (request, ct) =>
+public sealed class StreamingArtifactAgent : IAgentHandler
 {
-    return StreamWorkAsync(request, ct);
-};
-
-private async IAsyncEnumerable<StreamResponse> StreamWorkAsync(
-    SendMessageRequest request,
-    [EnumeratorCancellation] CancellationToken ct)
-{
-    var taskId = Guid.NewGuid().ToString("N");
-    var contextId = request.Message.ContextId ?? Guid.NewGuid().ToString("N");
-
-    // Create and persist the initial task
-    var task = new AgentTask
+    public async Task ExecuteAsync(
+        RequestContext context,
+        AgentEventQueue eventQueue,
+        CancellationToken cancellationToken)
     {
-        Id = taskId,
-        ContextId = contextId,
-        Status = new TaskStatus
-        {
-            State = TaskState.Working,
-            Timestamp = DateTimeOffset.UtcNow,
-        },
-        History = [request.Message],
-    };
-    await _store!.SetTaskAsync(task, ct);
+        var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
 
-    // Emit status update
-    yield return new StreamResponse
-    {
-        StatusUpdate = new TaskStatusUpdateEvent
-        {
-            TaskId = taskId,
-            ContextId = contextId,
-            Status = new TaskStatus { State = TaskState.Working }
-        }
-    };
+        await updater.SubmitAsync(cancellationToken);
+        await updater.StartWorkAsync(cancellationToken: cancellationToken);
 
-    // Do work and emit artifact chunks
-    var artifact = new Artifact
-    {
-        ArtifactId = Guid.NewGuid().ToString("N"),
-        Parts = [Part.FromText("Partial result...")]
-    };
-    yield return new StreamResponse
-    {
-        ArtifactUpdate = new TaskArtifactUpdateEvent
-        {
-            TaskId = taskId,
-            ContextId = contextId,
-            Artifact = artifact,
-            Append = true,
-            LastChunk = false
-        }
-    };
+        var artifactId = Guid.NewGuid().ToString("N");
 
-    // Persist final state with artifacts
-    task.Status = new TaskStatus
-    {
-        State = TaskState.Completed,
-        Timestamp = DateTimeOffset.UtcNow,
-    };
-    task.Artifacts = [artifact];
-    await _store.SetTaskAsync(task, ct);
+        // Chunk 1: create artifact (append: false)
+        await updater.AddArtifactAsync(
+            [Part.FromText("First chunk of content...")],
+            artifactId: artifactId, name: "Result",
+            append: false, lastChunk: false,
+            cancellationToken: cancellationToken);
 
-    // Emit final task
-    yield return new StreamResponse { Task = task };
+        // Chunk 2: append to same artifact
+        await updater.AddArtifactAsync(
+            [Part.FromText("More content...")],
+            artifactId: artifactId,
+            append: true, lastChunk: false,
+            cancellationToken: cancellationToken);
+
+        // Final chunk
+        await updater.AddArtifactAsync(
+            [Part.FromText("Final content.")],
+            artifactId: artifactId,
+            append: true, lastChunk: true,
+            cancellationToken: cancellationToken);
+
+        await updater.CompleteAsync(cancellationToken: cancellationToken);
+    }
 }
 ```
 
 What changed:
-- Instead of calling `UpdateStatusAsync`/`ReturnArtifactAsync` on
-  TaskManager, you `yield return` `StreamResponse` objects.
-- Each `StreamResponse` uses field-presence: set `.StatusUpdate`,
-  `.ArtifactUpdate`, `.Message`, or `.Task`.
-- You control the stream directly via `IAsyncEnumerable<StreamResponse>`.
+
+- No separate `OnSendStreamingMessage` callback — the same `ExecuteAsync`
+  handles both streaming and non-streaming. The SDK decides based on
+  `context.StreamingResponse` (set by the JSON-RPC method).
+- No `IAsyncEnumerable<StreamResponse>` — you write events to
+  `AgentEventQueue` via `TaskUpdater` methods. The SDK handles SSE framing.
+- Chunked artifacts use the `append` and `lastChunk` parameters on
+  `AddArtifactAsync`. Reuse the same `artifactId` across chunks.
 
 ## Type mapping quick reference
 
@@ -403,6 +410,12 @@ What changed:
 | `AgentTaskStatus` | `TaskStatus` |
 | `TaskIdParams` | `GetTaskRequest` or `CancelTaskRequest` |
 | `TaskQueryParams` | `GetTaskRequest` |
+| `TaskManager` | `A2AServer` + `IAgentHandler` |
+| `OnMessageReceived` / `OnTaskCreated` callbacks | `IAgentHandler.ExecuteAsync()` |
+| `OnTaskCancelled` callback | `IAgentHandler.CancelAsync()` |
+| `taskManager.UpdateStatusAsync()` | `TaskUpdater` methods (`SubmitAsync`, `StartWorkAsync`, `CompleteAsync`, etc.) |
+| `taskManager.ReturnArtifactAsync()` | `TaskUpdater.AddArtifactAsync()` |
+| `ITaskStore` (6 methods) | `ITaskStore` (4 methods: `GetTaskAsync`, `SaveTaskAsync`, `DeleteTaskAsync`, `ListTasksAsync`) |
 
 ## Common migration issues
 
@@ -412,13 +425,25 @@ What changed:
 2. **`Part` is no longer abstract** — Replace `switch (part) { case TextPart:
    ... }` with `switch (part.ContentCase) { case PartContentCase.Text: ... }`.
 
-3. **AgentCard has new required fields** — `Version`,
-   `SupportedInterfaces`, `Capabilities`, `Skills`,
-   `DefaultInputModes`, `DefaultOutputModes` are all required in v1.
+3. **AgentCard has new required fields** — `Name`, `Description`, `Version`,
+   `SupportedInterfaces`, `Capabilities`, `Skills`, `DefaultInputModes`,
+   `DefaultOutputModes` are all required in v1.
 
-4. **TaskManager constructor requires ITaskStore and ILogger** — Both are
-   mandatory. Use `InMemoryTaskStore` for simple cases.
+4. **`TaskManager` class removed** — v1 has no `TaskManager` class. Replace
+   `new TaskManager()` with `services.AddA2AAgent<T>(agentCard)` for DI
+   registration and implement `IAgentHandler` in your agent class.
 
-5. **No more `Final` flag on streaming** — v0.3 used
-   `UpdateStatusAsync(..., final: true)` to signal end of stream. In v1 the
-   stream ends when your `IAsyncEnumerable` completes.
+5. **Callback delegates removed** — `OnSendMessage`, `OnSendStreamingMessage`,
+   `OnCancelTask`, `OnMessageReceived`, `OnTaskCreated`, `OnTaskCancelled`, and
+   `OnTaskUpdated` do not exist in v1. All agent logic goes in
+   `IAgentHandler.ExecuteAsync()` and `CancelAsync()`.
+
+6. **`ITaskStore` simplified** — v1 `ITaskStore` has 4 methods (`GetTaskAsync`,
+   `SaveTaskAsync`, `DeleteTaskAsync`, `ListTasksAsync`). Methods like
+   `UpdateStatusAsync`, `AppendHistoryAsync`, and `SetTaskAsync` no longer
+   exist. The SDK manages task mutations internally via `TaskProjection.Apply`.
+
+7. **No more `Final` flag on streaming** — v0.3 used
+   `UpdateStatusAsync(..., final: true)` to signal end of stream. In v1, the
+   stream ends when the `AgentEventQueue` is completed (handled automatically
+   by `TaskUpdater.CompleteAsync()`, `FailAsync()`, etc.).


### PR DESCRIPTION
## Summary

Rewrite v1 code examples in `docs/taskmanager-migration-guide.md` and update `README.md` server-side sections to match the actual v1 API.

The previous documentation described a fabricated `TaskManager` class with `OnSendMessage`/`OnSendStreamingMessage`/`OnCancelTask` callback delegates that **does not exist in v1**. The actual v1 server pattern uses `IAgentHandler` + `A2AServer` + `TaskUpdater`/`MessageResponder` + DI registration via `AddA2AAgent<T>()`.

## Changes

### `docs/taskmanager-migration-guide.md`
### `README.md`

## Verification

- All v1 code examples cross-referenced against source files in `src/A2A/Server/` and `samples/AgentServer/`
- Zero remaining references to fabricated types (`OnSendMessage` callback, `ITaskEventStore`, `InMemoryEventStore`)
- `dotnet build A2A.slnx` passes with 0 warnings, 0 errors
- Client-side examples unchanged (already correct)
- v0.3 examples preserved as-is
