### PR TITLE
fix: remove /card endpoint from HTTP+JSON binding

### DIFF
--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -26,7 +26,6 @@ public static class A2ARouteBuilderExtensions
         ArgumentException.ThrowIfNullOrEmpty(path);
 
         var handler = endpoints.ServiceProvider.GetRequiredService<IA2ARequestHandler>();
-        var agentCard = endpoints.ServiceProvider.GetRequiredService<AgentCard>();
 
         var routeGroup = endpoints.MapGroup("");
         routeGroup.MapPost(path, (HttpRequest request, CancellationToken cancellationToken)
@@ -84,22 +83,16 @@ public static class A2ARouteBuilderExtensions
     /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="requestHandler">The A2A request handler.</param>
-    /// <param name="agentCard">The agent card to serve at the /card endpoint.</param>
     /// <param name="path">The route prefix for all REST endpoints.</param>
     /// <returns>An endpoint convention builder for further configuration.</returns>
     public static IEndpointConventionBuilder MapHttpA2A(
-        this IEndpointRouteBuilder endpoints, IA2ARequestHandler requestHandler, AgentCard agentCard, [StringSyntax("Route")] string path = "")
+        this IEndpointRouteBuilder endpoints, IA2ARequestHandler requestHandler, [StringSyntax("Route")] string path = "")
     {
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(requestHandler);
-        ArgumentNullException.ThrowIfNull(agentCard);
 
         var routeGroup = endpoints.MapGroup(path);
         var logger = endpoints.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("A2A.REST");
-
-        // Agent card (SDK convenience endpoint, not part of the A2A spec Section 11.3)
-        routeGroup.MapGet("/card", (CancellationToken ct)
-            => A2AHttpProcessor.GetAgentCardRestAsync(requestHandler, logger, agentCard, ct));
 
         // Task operations
         routeGroup.MapGet("/tasks/{id}", (string id, [FromQuery] int? historyLength, CancellationToken ct)

--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -90,6 +90,7 @@ public static class A2ARouteBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(requestHandler);
+        ArgumentNullException.ThrowIfNull(path);
 
         var routeGroup = endpoints.MapGroup(path);
         var logger = endpoints.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("A2A.REST");

--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -128,12 +128,6 @@ internal static class A2AHttpProcessor
 
     // ======= REST API handler methods =======
 
-    // REST handler: Get agent card
-    internal static Task<IResult> GetAgentCardRestAsync(
-        IA2ARequestHandler requestHandler, ILogger logger, AgentCard agentCard, CancellationToken cancellationToken)
-        => WithExceptionHandlingAsync(logger, "REST.GetAgentCard", ct =>
-            Task.FromResult<IResult>(new A2AResponseResult(agentCard)), cancellationToken: cancellationToken);
-
     // REST handler: Get task by ID
     internal static Task<IResult> GetTaskRestAsync(
         IA2ARequestHandler requestHandler, ILogger logger, string id, int? historyLength, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

Remove the `GET /card` convenience endpoint from `MapHttpA2A` and the associated `agentCard` parameter. The endpoint was not part of the A2A specification, and requiring an `AgentCard` parameter made it impossible to use `MapHttpA2A` without providing a stub/fake agent card just to satisfy the parameter, even though the endpoint would never be called.

## Changes

- Remove the `agentCard` parameter from `MapHttpA2A`.
- Remove the `GET /card` route registration from `MapHttpA2A`.
- Remove `GetAgentCardRestAsync` from `A2AHttpProcessor`.
- Remove the unnecessary `AgentCard` DI resolution from the `MapA2A` overload that used DI-registered services (the resolved card was only needed for the now-removed `/card` endpoint).

Agent card discovery is still available via `MapWellKnownAgentCard` or the `.well-known/agent-card.json` endpoint.