### PR TITLE
fix: align error handling with A2A spec PR #1627

### DIFF
--- a/src/A2A.AspNetCore/A2AErrorResult.cs
+++ b/src/A2A.AspNetCore/A2AErrorResult.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace A2A.AspNetCore;
+
+/// <summary>
+/// An <see cref="IResult"/> that writes a google.rpc.Status JSON error response
+/// per A2A spec Section 11.6.
+/// </summary>
+/// <param name="exception">The A2A exception to render as an error response.</param>
+internal sealed class A2AErrorResult(A2AException exception) : IResult, IStatusCodeHttpResult
+{
+    public int? StatusCode => A2AErrorCodeMapping.GetHttpStatusCode(exception.ErrorCode);
+
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        var errorCode = exception.ErrorCode;
+        var httpStatus = A2AErrorCodeMapping.GetHttpStatusCode(errorCode);
+
+        httpContext.Response.StatusCode = httpStatus;
+        httpContext.Response.ContentType = "application/json";
+
+        // Build JSON into a buffer first (Utf8JsonWriter on MemoryStream is synchronous-safe),
+        // then copy to the response body asynchronously to avoid AllowSynchronousIO violations.
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("error");
+            writer.WriteStartObject();
+            writer.WriteNumber("code", httpStatus);
+            writer.WriteString("status", A2AErrorCodeMapping.GetGrpcStatus(errorCode));
+            writer.WriteString("message", exception.Message);
+            writer.WritePropertyName("details");
+            writer.WriteStartArray();
+
+            if (A2AErrorCodeMapping.IsA2ASpecificError(errorCode))
+            {
+                var reason = A2AErrorCodeMapping.GetReasonString(errorCode);
+                if (reason is not null)
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("@type", "type.googleapis.com/google.rpc.ErrorInfo");
+                    writer.WriteString("reason", reason);
+                    writer.WriteString("domain", "a2a-protocol.org");
+                    writer.WriteEndObject();
+                }
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        buffer.Position = 0;
+        await buffer.CopyToAsync(httpContext.Response.Body);
+    }
+}

--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -74,7 +74,7 @@ internal static class A2AHttpProcessor
         catch (Exception ex)
         {
             logger.UnexpectedErrorInActivityName(ex, activityName);
-            return Results.Problem(detail: "An internal error occurred.", statusCode: StatusCodes.Status500InternalServerError);
+            return new A2AErrorResult(new A2AException("An internal error occurred.", A2AErrorCode.InternalError));
         }
     }
 
@@ -99,32 +99,12 @@ internal static class A2AHttpProcessor
         catch (Exception ex)
         {
             logger.UnexpectedErrorInActivityName(ex, activityName);
-            return Results.Problem(detail: "An internal error occurred.", statusCode: StatusCodes.Status500InternalServerError);
+            return new A2AErrorResult(new A2AException("An internal error occurred.", A2AErrorCode.InternalError));
         }
     }
 
-    private static IResult MapA2AExceptionToHttpResult(A2AException exception)
-    {
-        return exception.ErrorCode switch
-        {
-            A2AErrorCode.TaskNotFound or
-            A2AErrorCode.MethodNotFound => Results.NotFound(exception.Message),
-
-            A2AErrorCode.TaskNotCancelable or
-            A2AErrorCode.UnsupportedOperation or
-            A2AErrorCode.InvalidRequest or
-            A2AErrorCode.InvalidParams or
-            A2AErrorCode.ParseError => Results.Problem(detail: exception.Message, statusCode: StatusCodes.Status400BadRequest),
-
-            A2AErrorCode.PushNotificationNotSupported => Results.Problem(detail: exception.Message, statusCode: StatusCodes.Status400BadRequest),
-
-            A2AErrorCode.ContentTypeNotSupported => Results.Problem(detail: exception.Message, statusCode: StatusCodes.Status422UnprocessableEntity),
-
-            A2AErrorCode.InternalError => Results.Problem(detail: exception.Message, statusCode: StatusCodes.Status500InternalServerError),
-
-            _ => Results.Problem(detail: exception.Message, statusCode: StatusCodes.Status500InternalServerError)
-        };
-    }
+    private static A2AErrorResult MapA2AExceptionToHttpResult(A2AException exception) =>
+        new A2AErrorResult(exception);
 
     // ======= REST API handler methods =======
 

--- a/src/A2A/A2AErrorCodeMapping.cs
+++ b/src/A2A/A2AErrorCodeMapping.cs
@@ -1,0 +1,81 @@
+namespace A2A;
+
+/// <summary>
+/// Centralized mappings from <see cref="A2AErrorCode"/> to HTTP status codes,
+/// gRPC status strings, and UPPER_SNAKE_CASE reason strings per A2A spec Section 5.4.
+/// </summary>
+internal static class A2AErrorCodeMapping
+{
+    /// <summary>Returns the HTTP status code for the given error code per spec Section 5.4.</summary>
+    /// <param name="code">The A2A error code to map.</param>
+    public static int GetHttpStatusCode(A2AErrorCode code) => code switch
+    {
+        A2AErrorCode.TaskNotFound or
+        A2AErrorCode.MethodNotFound => 404,
+
+        A2AErrorCode.TaskNotCancelable or
+        A2AErrorCode.PushNotificationNotSupported or
+        A2AErrorCode.UnsupportedOperation or
+        A2AErrorCode.ContentTypeNotSupported or
+        A2AErrorCode.ExtendedAgentCardNotConfigured or
+        A2AErrorCode.ExtensionSupportRequired or
+        A2AErrorCode.VersionNotSupported or
+        A2AErrorCode.InvalidRequest or
+        A2AErrorCode.InvalidParams or
+        A2AErrorCode.ParseError => 400,
+
+        A2AErrorCode.InvalidAgentResponse or
+        A2AErrorCode.InternalError => 500,
+
+        _ => 500,
+    };
+
+    /// <summary>Returns the gRPC status string for the given error code per spec Section 5.4.</summary>
+    /// <param name="code">The A2A error code to map.</param>
+    public static string GetGrpcStatus(A2AErrorCode code) => code switch
+    {
+        A2AErrorCode.TaskNotFound or
+        A2AErrorCode.MethodNotFound => "NOT_FOUND",
+
+        A2AErrorCode.TaskNotCancelable or
+        A2AErrorCode.PushNotificationNotSupported or
+        A2AErrorCode.UnsupportedOperation or
+        A2AErrorCode.ExtendedAgentCardNotConfigured or
+        A2AErrorCode.ExtensionSupportRequired or
+        A2AErrorCode.VersionNotSupported => "FAILED_PRECONDITION",
+
+        A2AErrorCode.ContentTypeNotSupported or
+        A2AErrorCode.InvalidRequest or
+        A2AErrorCode.InvalidParams or
+        A2AErrorCode.ParseError => "INVALID_ARGUMENT",
+
+        A2AErrorCode.InvalidAgentResponse or
+        A2AErrorCode.InternalError => "INTERNAL",
+
+        _ => "INTERNAL",
+    };
+
+    /// <summary>
+    /// Returns the UPPER_SNAKE_CASE reason string for A2A-specific errors,
+    /// or <c>null</c> for standard JSON-RPC errors.
+    /// </summary>
+    /// <param name="code">The A2A error code to map.</param>
+    public static string? GetReasonString(A2AErrorCode code) => code switch
+    {
+        A2AErrorCode.TaskNotFound => "TASK_NOT_FOUND",
+        A2AErrorCode.TaskNotCancelable => "TASK_NOT_CANCELABLE",
+        A2AErrorCode.PushNotificationNotSupported => "PUSH_NOTIFICATION_NOT_SUPPORTED",
+        A2AErrorCode.UnsupportedOperation => "UNSUPPORTED_OPERATION",
+        A2AErrorCode.ContentTypeNotSupported => "CONTENT_TYPE_NOT_SUPPORTED",
+        A2AErrorCode.InvalidAgentResponse => "INVALID_AGENT_RESPONSE",
+        A2AErrorCode.ExtendedAgentCardNotConfigured => "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
+        A2AErrorCode.ExtensionSupportRequired => "EXTENSION_SUPPORT_REQUIRED",
+        A2AErrorCode.VersionNotSupported => "VERSION_NOT_SUPPORTED",
+        _ => null,
+    };
+
+    /// <summary>Returns <c>true</c> for A2A-specific error codes (-32001 to -32099).</summary>
+    /// <param name="code">The A2A error code to check.</param>
+    public static bool IsA2ASpecificError(A2AErrorCode code) =>
+        (int)code is >= -32099 and <= -32001;
+}

--- a/src/A2A/JsonRpc/JsonRpcResponse.cs
+++ b/src/A2A/JsonRpc/JsonRpcResponse.cs
@@ -61,6 +61,17 @@ public sealed class JsonRpcResponse
     /// <returns>A JSON-RPC error response.</returns>
     public static JsonRpcResponse CreateJsonRpcErrorResponse(JsonRpcId requestId, A2AException exception)
     {
+        JsonElement? data = null;
+
+        if (A2AErrorCodeMapping.IsA2ASpecificError(exception.ErrorCode))
+        {
+            var reason = A2AErrorCodeMapping.GetReasonString(exception.ErrorCode);
+            if (reason is not null)
+            {
+                data = CreateErrorInfoData(reason);
+            }
+        }
+
         return new JsonRpcResponse()
         {
             Id = requestId,
@@ -68,8 +79,27 @@ public sealed class JsonRpcResponse
             {
                 Code = (int)exception.ErrorCode,
                 Message = exception.Message,
+                Data = data,
             }
         };
+    }
+
+    private static JsonElement CreateErrorInfoData(string reason)
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            writer.WriteStartObject();
+            writer.WriteString("@type", "type.googleapis.com/google.rpc.ErrorInfo");
+            writer.WriteString("reason", reason);
+            writer.WriteString("domain", "a2a-protocol.org");
+            writer.WriteEndObject();
+            writer.WriteEndArray();
+        }
+
+        using var doc = JsonDocument.Parse(buffer.ToArray());
+        return doc.RootElement.Clone();
     }
 
     /// <summary>
@@ -117,6 +147,7 @@ public sealed class JsonRpcResponse
         {
             Code = (int)A2AErrorCode.TaskNotFound,
             Message = message ?? "Task not found",
+            Data = CreateErrorInfoData("TASK_NOT_FOUND"),
         },
     };
 
@@ -133,6 +164,7 @@ public sealed class JsonRpcResponse
         {
             Code = (int)A2AErrorCode.TaskNotCancelable,
             Message = message ?? "Task cannot be canceled",
+            Data = CreateErrorInfoData("TASK_NOT_CANCELABLE"),
         },
     };
 
@@ -165,6 +197,7 @@ public sealed class JsonRpcResponse
         {
             Code = (int)A2AErrorCode.PushNotificationNotSupported,
             Message = message ?? "Push notification not supported",
+            Data = CreateErrorInfoData("PUSH_NOTIFICATION_NOT_SUPPORTED"),
         },
     };
 
@@ -213,6 +246,7 @@ public sealed class JsonRpcResponse
         {
             Code = (int)A2AErrorCode.UnsupportedOperation,
             Message = message ?? "Unsupported operation",
+            Data = CreateErrorInfoData("UNSUPPORTED_OPERATION"),
         },
     };
 
@@ -229,6 +263,7 @@ public sealed class JsonRpcResponse
         {
             Code = (int)A2AErrorCode.ContentTypeNotSupported,
             Message = message ?? "Content type not supported",
+            Data = CreateErrorInfoData("CONTENT_TYPE_NOT_SUPPORTED"),
         },
     };
 }

--- a/tests/A2A.AspNetCore.UnitTests/A2AErrorResultTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AErrorResultTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.AspNetCore.Http;
+using System.Text.Json;
+
+namespace A2A.AspNetCore.Tests;
+
+public class A2AErrorResultTests
+{
+    private static async Task<(int statusCode, JsonDocument body)> ExecuteResultAsync(A2AErrorResult result)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+
+        await result.ExecuteAsync(httpContext);
+
+        httpContext.Response.Body.Position = 0;
+        var doc = await JsonDocument.ParseAsync(httpContext.Response.Body);
+        return (httpContext.Response.StatusCode, doc);
+    }
+
+    [Fact]
+    public async Task TaskNotFound_ReturnsGoogleRpcStatusWithErrorInfo()
+    {
+        var result = new A2AErrorResult(new A2AException("Task not found", A2AErrorCode.TaskNotFound));
+
+        var (statusCode, doc) = await ExecuteResultAsync(result);
+        var error = doc.RootElement.GetProperty("error");
+
+        Assert.Equal(404, statusCode);
+        Assert.Equal(404, error.GetProperty("code").GetInt32());
+        Assert.Equal("NOT_FOUND", error.GetProperty("status").GetString());
+        Assert.Equal("Task not found", error.GetProperty("message").GetString());
+
+        var details = error.GetProperty("details");
+        Assert.Equal(JsonValueKind.Array, details.ValueKind);
+        Assert.Equal(1, details.GetArrayLength());
+
+        var detail = details[0];
+        Assert.Equal("type.googleapis.com/google.rpc.ErrorInfo", detail.GetProperty("@type").GetString());
+        Assert.Equal("TASK_NOT_FOUND", detail.GetProperty("reason").GetString());
+        Assert.Equal("a2a-protocol.org", detail.GetProperty("domain").GetString());
+    }
+
+    [Fact]
+    public async Task ContentTypeNotSupported_Returns400()
+    {
+        var result = new A2AErrorResult(new A2AException("Unsupported content type", A2AErrorCode.ContentTypeNotSupported));
+
+        var (statusCode, doc) = await ExecuteResultAsync(result);
+        var error = doc.RootElement.GetProperty("error");
+
+        Assert.Equal(400, statusCode);
+        Assert.Equal(400, error.GetProperty("code").GetInt32());
+        Assert.Equal("INVALID_ARGUMENT", error.GetProperty("status").GetString());
+        Assert.Equal("CONTENT_TYPE_NOT_SUPPORTED", error.GetProperty("details")[0].GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public async Task InternalError_ReturnsEmptyDetailsArray()
+    {
+        var result = new A2AErrorResult(new A2AException("Something broke", A2AErrorCode.InternalError));
+
+        var (statusCode, doc) = await ExecuteResultAsync(result);
+        var error = doc.RootElement.GetProperty("error");
+
+        Assert.Equal(500, statusCode);
+        Assert.Equal(500, error.GetProperty("code").GetInt32());
+        Assert.Equal("INTERNAL", error.GetProperty("status").GetString());
+        Assert.Equal("Something broke", error.GetProperty("message").GetString());
+        Assert.Equal(0, error.GetProperty("details").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ParseError_ReturnsEmptyDetailsArray()
+    {
+        var result = new A2AErrorResult(new A2AException("Parse failed", A2AErrorCode.ParseError));
+
+        var (statusCode, doc) = await ExecuteResultAsync(result);
+        var error = doc.RootElement.GetProperty("error");
+
+        Assert.Equal(400, statusCode);
+        Assert.Equal("INVALID_ARGUMENT", error.GetProperty("status").GetString());
+        Assert.Equal(0, error.GetProperty("details").GetArrayLength());
+    }
+
+    [Theory]
+    [InlineData(A2AErrorCode.TaskNotCancelable, "TASK_NOT_CANCELABLE")]
+    [InlineData(A2AErrorCode.PushNotificationNotSupported, "PUSH_NOTIFICATION_NOT_SUPPORTED")]
+    [InlineData(A2AErrorCode.UnsupportedOperation, "UNSUPPORTED_OPERATION")]
+    [InlineData(A2AErrorCode.InvalidAgentResponse, "INVALID_AGENT_RESPONSE")]
+    [InlineData(A2AErrorCode.ExtendedAgentCardNotConfigured, "EXTENDED_AGENT_CARD_NOT_CONFIGURED")]
+    [InlineData(A2AErrorCode.ExtensionSupportRequired, "EXTENSION_SUPPORT_REQUIRED")]
+    [InlineData(A2AErrorCode.VersionNotSupported, "VERSION_NOT_SUPPORTED")]
+    public async Task A2ASpecificErrors_IncludeErrorInfoInDetails(A2AErrorCode errorCode, string expectedReason)
+    {
+        var result = new A2AErrorResult(new A2AException("test", errorCode));
+
+        var (_, doc) = await ExecuteResultAsync(result);
+        var details = doc.RootElement.GetProperty("error").GetProperty("details");
+
+        Assert.Equal(1, details.GetArrayLength());
+        Assert.Equal("type.googleapis.com/google.rpc.ErrorInfo", details[0].GetProperty("@type").GetString());
+        Assert.Equal(expectedReason, details[0].GetProperty("reason").GetString());
+        Assert.Equal("a2a-protocol.org", details[0].GetProperty("domain").GetString());
+    }
+
+    [Fact]
+    public async Task ResponseContentType_IsApplicationJson()
+    {
+        var result = new A2AErrorResult(new A2AException("test", A2AErrorCode.InternalError));
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+
+        await result.ExecuteAsync(httpContext);
+
+        Assert.Equal("application/json", httpContext.Response.ContentType);
+    }
+
+    [Fact]
+    public void StatusCode_MatchesMappedHttpStatus()
+    {
+        var result = new A2AErrorResult(new A2AException("test", A2AErrorCode.TaskNotFound));
+        Assert.Equal(404, ((IStatusCodeHttpResult)result).StatusCode);
+
+        var result2 = new A2AErrorResult(new A2AException("test", A2AErrorCode.InternalError));
+        Assert.Equal(500, ((IStatusCodeHttpResult)result2).StatusCode);
+    }
+}

--- a/tests/A2A.AspNetCore.UnitTests/A2AHttpProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AHttpProcessorTests.cs
@@ -129,7 +129,11 @@ public class A2AHttpProcessorTests
     [InlineData(A2AErrorCode.UnsupportedOperation, StatusCodes.Status400BadRequest)]
     [InlineData(A2AErrorCode.ParseError, StatusCodes.Status400BadRequest)]
     [InlineData(A2AErrorCode.PushNotificationNotSupported, StatusCodes.Status400BadRequest)]
-    [InlineData(A2AErrorCode.ContentTypeNotSupported, StatusCodes.Status422UnprocessableEntity)]
+    [InlineData(A2AErrorCode.ContentTypeNotSupported, StatusCodes.Status400BadRequest)]
+    [InlineData(A2AErrorCode.ExtendedAgentCardNotConfigured, StatusCodes.Status400BadRequest)]
+    [InlineData(A2AErrorCode.ExtensionSupportRequired, StatusCodes.Status400BadRequest)]
+    [InlineData(A2AErrorCode.VersionNotSupported, StatusCodes.Status400BadRequest)]
+    [InlineData(A2AErrorCode.InvalidAgentResponse, StatusCodes.Status500InternalServerError)]
     [InlineData(A2AErrorCode.InternalError, StatusCodes.Status500InternalServerError)]
     public async Task GetTask_WithA2AException_ShouldMapToCorrectHttpStatusCode(A2AErrorCode errorCode, int expectedStatusCode)
     {

--- a/tests/A2A.UnitTests/A2AErrorCodeMappingTests.cs
+++ b/tests/A2A.UnitTests/A2AErrorCodeMappingTests.cs
@@ -1,0 +1,90 @@
+namespace A2A.UnitTests;
+
+public class A2AErrorCodeMappingTests
+{
+    [Theory]
+    [InlineData(A2AErrorCode.TaskNotFound, 404)]
+    [InlineData(A2AErrorCode.TaskNotCancelable, 400)]
+    [InlineData(A2AErrorCode.PushNotificationNotSupported, 400)]
+    [InlineData(A2AErrorCode.UnsupportedOperation, 400)]
+    [InlineData(A2AErrorCode.ContentTypeNotSupported, 400)]
+    [InlineData(A2AErrorCode.InvalidAgentResponse, 500)]
+    [InlineData(A2AErrorCode.ExtendedAgentCardNotConfigured, 400)]
+    [InlineData(A2AErrorCode.ExtensionSupportRequired, 400)]
+    [InlineData(A2AErrorCode.VersionNotSupported, 400)]
+    [InlineData(A2AErrorCode.InvalidRequest, 400)]
+    [InlineData(A2AErrorCode.MethodNotFound, 404)]
+    [InlineData(A2AErrorCode.InvalidParams, 400)]
+    [InlineData(A2AErrorCode.InternalError, 500)]
+    [InlineData(A2AErrorCode.ParseError, 400)]
+    public void GetHttpStatusCode_ReturnsCorrectStatus(A2AErrorCode code, int expected)
+    {
+        Assert.Equal(expected, A2AErrorCodeMapping.GetHttpStatusCode(code));
+    }
+
+    [Theory]
+    [InlineData(A2AErrorCode.TaskNotFound, "NOT_FOUND")]
+    [InlineData(A2AErrorCode.TaskNotCancelable, "FAILED_PRECONDITION")]
+    [InlineData(A2AErrorCode.PushNotificationNotSupported, "FAILED_PRECONDITION")]
+    [InlineData(A2AErrorCode.UnsupportedOperation, "FAILED_PRECONDITION")]
+    [InlineData(A2AErrorCode.ContentTypeNotSupported, "INVALID_ARGUMENT")]
+    [InlineData(A2AErrorCode.InvalidAgentResponse, "INTERNAL")]
+    [InlineData(A2AErrorCode.ExtendedAgentCardNotConfigured, "FAILED_PRECONDITION")]
+    [InlineData(A2AErrorCode.ExtensionSupportRequired, "FAILED_PRECONDITION")]
+    [InlineData(A2AErrorCode.VersionNotSupported, "FAILED_PRECONDITION")]
+    [InlineData(A2AErrorCode.InvalidRequest, "INVALID_ARGUMENT")]
+    [InlineData(A2AErrorCode.MethodNotFound, "NOT_FOUND")]
+    [InlineData(A2AErrorCode.InvalidParams, "INVALID_ARGUMENT")]
+    [InlineData(A2AErrorCode.InternalError, "INTERNAL")]
+    [InlineData(A2AErrorCode.ParseError, "INVALID_ARGUMENT")]
+    public void GetGrpcStatus_ReturnsCorrectStatus(A2AErrorCode code, string expected)
+    {
+        Assert.Equal(expected, A2AErrorCodeMapping.GetGrpcStatus(code));
+    }
+
+    [Theory]
+    [InlineData(A2AErrorCode.TaskNotFound, "TASK_NOT_FOUND")]
+    [InlineData(A2AErrorCode.TaskNotCancelable, "TASK_NOT_CANCELABLE")]
+    [InlineData(A2AErrorCode.PushNotificationNotSupported, "PUSH_NOTIFICATION_NOT_SUPPORTED")]
+    [InlineData(A2AErrorCode.UnsupportedOperation, "UNSUPPORTED_OPERATION")]
+    [InlineData(A2AErrorCode.ContentTypeNotSupported, "CONTENT_TYPE_NOT_SUPPORTED")]
+    [InlineData(A2AErrorCode.InvalidAgentResponse, "INVALID_AGENT_RESPONSE")]
+    [InlineData(A2AErrorCode.ExtendedAgentCardNotConfigured, "EXTENDED_AGENT_CARD_NOT_CONFIGURED")]
+    [InlineData(A2AErrorCode.ExtensionSupportRequired, "EXTENSION_SUPPORT_REQUIRED")]
+    [InlineData(A2AErrorCode.VersionNotSupported, "VERSION_NOT_SUPPORTED")]
+    public void GetReasonString_ReturnsCorrectReason_ForA2ASpecificCodes(A2AErrorCode code, string expected)
+    {
+        Assert.Equal(expected, A2AErrorCodeMapping.GetReasonString(code));
+    }
+
+    [Theory]
+    [InlineData(A2AErrorCode.InvalidRequest)]
+    [InlineData(A2AErrorCode.MethodNotFound)]
+    [InlineData(A2AErrorCode.InvalidParams)]
+    [InlineData(A2AErrorCode.InternalError)]
+    [InlineData(A2AErrorCode.ParseError)]
+    public void GetReasonString_ReturnsNull_ForStandardJsonRpcCodes(A2AErrorCode code)
+    {
+        Assert.Null(A2AErrorCodeMapping.GetReasonString(code));
+    }
+
+    [Theory]
+    [InlineData(A2AErrorCode.TaskNotFound, true)]
+    [InlineData(A2AErrorCode.TaskNotCancelable, true)]
+    [InlineData(A2AErrorCode.PushNotificationNotSupported, true)]
+    [InlineData(A2AErrorCode.UnsupportedOperation, true)]
+    [InlineData(A2AErrorCode.ContentTypeNotSupported, true)]
+    [InlineData(A2AErrorCode.InvalidAgentResponse, true)]
+    [InlineData(A2AErrorCode.ExtendedAgentCardNotConfigured, true)]
+    [InlineData(A2AErrorCode.ExtensionSupportRequired, true)]
+    [InlineData(A2AErrorCode.VersionNotSupported, true)]
+    [InlineData(A2AErrorCode.InvalidRequest, false)]
+    [InlineData(A2AErrorCode.MethodNotFound, false)]
+    [InlineData(A2AErrorCode.InvalidParams, false)]
+    [InlineData(A2AErrorCode.InternalError, false)]
+    [InlineData(A2AErrorCode.ParseError, false)]
+    public void IsA2ASpecificError_ReturnsCorrectResult(A2AErrorCode code, bool expected)
+    {
+        Assert.Equal(expected, A2AErrorCodeMapping.IsA2ASpecificError(code));
+    }
+}

--- a/tests/A2A.UnitTests/JsonRpc/JsonRpcErrorResponseTests.cs
+++ b/tests/A2A.UnitTests/JsonRpc/JsonRpcErrorResponseTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace A2A.UnitTests.JsonRpc;
@@ -56,6 +57,65 @@ public class JsonRpcErrorResponseTests
         Assert.NotNull(response.Error);
         Assert.Equal((int)errorCode, response.Error.Code);
         Assert.Equal(errorMessage, response.Error.Message);
+        Assert.Null(response.Error.Data);
+    }
+
+    [Fact]
+    public void CreateJsonRpcErrorResponse_WithA2ASpecificError_PopulatesDataWithErrorInfo()
+    {
+        // Arrange
+        const string requestId = "test-request-456";
+        const string errorMessage = "Task not found";
+        const A2AErrorCode errorCode = A2AErrorCode.TaskNotFound;
+        var exception = new A2AException(errorMessage, errorCode);
+
+        // Act
+        var response = JsonRpcResponse.CreateJsonRpcErrorResponse(requestId, exception);
+
+        // Assert
+        Assert.NotNull(response.Error);
+        Assert.NotNull(response.Error.Data);
+        AssertErrorInfoData(response.Error.Data.Value, "TASK_NOT_FOUND");
+    }
+
+    [Fact]
+    public void CreateJsonRpcErrorResponse_WithStandardError_LeavesDataNull()
+    {
+        // Arrange
+        const string requestId = "test-request-789";
+        const string errorMessage = "Internal error";
+        const A2AErrorCode errorCode = A2AErrorCode.InternalError;
+        var exception = new A2AException(errorMessage, errorCode);
+
+        // Act
+        var response = JsonRpcResponse.CreateJsonRpcErrorResponse(requestId, exception);
+
+        // Assert
+        Assert.NotNull(response.Error);
+        Assert.Null(response.Error.Data);
+    }
+
+    [Fact]
+    public void TaskNotFoundResponse_PopulatesDataWithErrorInfo()
+    {
+        // Act
+        var response = JsonRpcResponse.TaskNotFoundResponse("req-1");
+
+        // Assert
+        Assert.NotNull(response.Error);
+        Assert.NotNull(response.Error.Data);
+        AssertErrorInfoData(response.Error.Data.Value, "TASK_NOT_FOUND");
+    }
+
+    [Fact]
+    public void InternalErrorResponse_LeavesDataNull()
+    {
+        // Act
+        var response = JsonRpcResponse.InternalErrorResponse("req-2");
+
+        // Assert
+        Assert.NotNull(response.Error);
+        Assert.Null(response.Error.Data);
     }
 
     [Fact]
@@ -76,5 +136,16 @@ public class JsonRpcErrorResponseTests
         Assert.NotNull(response.Error);
         Assert.Equal((int)errorCode, response.Error.Code);
         Assert.Equal(errorMessage, response.Error.Message);
+    }
+
+    private static void AssertErrorInfoData(JsonElement data, string expectedReason)
+    {
+        Assert.Equal(JsonValueKind.Array, data.ValueKind);
+        Assert.Equal(1, data.GetArrayLength());
+
+        var element = data[0];
+        Assert.Equal("type.googleapis.com/google.rpc.ErrorInfo", element.GetProperty("@type").GetString());
+        Assert.Equal(expectedReason, element.GetProperty("reason").GetString());
+        Assert.Equal("a2a-protocol.org", element.GetProperty("domain").GetString());
     }
 }


### PR DESCRIPTION
## Summary

Align error handling with the updated A2A specification ([PR #1627](https://github.com/a2aproject/A2A/pull/1627), merged 2026-04-14) which fixes error code mappings and error detail format.

## Changes

### HTTP Status Code Fixes (spec Section 5.4)
- `ContentTypeNotSupported`: 422 → **400 Bad Request**
- `ExtendedAgentCardNotConfigured`: 500 (default) → **400 Bad Request**
- `ExtensionSupportRequired`: 500 (default) → **400 Bad Request**
- `VersionNotSupported`: 500 (default) → **400 Bad Request**
- `InvalidAgentResponse`: 500 (default) → **500** (now explicit)

### REST Error Response Format (spec Section 11.6)
- Replaced RFC 7807 ProblemDetails (`Results.Problem()`) with **google.rpc.Status** format
- A2A-specific errors include `google.rpc.ErrorInfo` in `details` array with `@type`, `reason`, `domain`
- Standard errors return empty `details` array
- Generic exception handlers also produce google.rpc.Status format

### JSON-RPC Error Data (spec Section 10.3)
- `error.data` populated as array with `@type`-keyed `ErrorInfo` for A2A-specific errors (-32001 to -32009)
- Standard JSON-RPC errors (-32600 to -32700) leave `data` as null per SHOULD semantics
- Updated 5 convenience factory methods: `TaskNotFoundResponse`, `TaskNotCancelableResponse`, `PushNotificationNotSupportedResponse`, `UnsupportedOperationResponse`, `ContentTypeNotSupportedResponse`

### New Files
- `src/A2A/A2AErrorCodeMapping.cs` — Centralized error code → HTTP status, gRPC status, reason string mappings
- `src/A2A.AspNetCore/A2AErrorResult.cs` — Custom `IResult` producing google.rpc.Status JSON via `Utf8JsonWriter`

## Testing
- 56 new parameterized tests for `A2AErrorCodeMapping` (all 14 enum values × 4 methods)
- 10 new tests for `A2AErrorResult` (format verification, all error codes, content-type)
- 4 new tests for JSON-RPC error data population
- All 1,606 existing tests pass (0 failures, net8.0 + net10.0)

## Notes
- One `Results.Problem()` call remains in `ListTasksRestAsync` for invalid status filter validation (tracked for follow-up)
- Client-side fallback mappings (409/415/502) retained for backward compatibility with older servers
