### PR TITLE
refactor: Add metadata parameters to TaskUpdater and MessageResponder methods

### DIFF
--- a/samples/AgentServer/EchoAgent.cs
+++ b/samples/AgentServer/EchoAgent.cs
@@ -7,7 +7,7 @@ public sealed class EchoAgent : IAgentHandler
     public async Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
     {
         var responder = new MessageResponder(eventQueue, context.ContextId);
-        await responder.ReplyAsync($"Echo: {context.UserText}", cancellationToken);
+        await responder.ReplyAsync($"Echo: {context.UserText}", cancellationToken: cancellationToken);
     }
 
     public static AgentCard GetAgentCard(string agentUrl) =>

--- a/samples/AgentServer/EchoAgentWithTasks.cs
+++ b/samples/AgentServer/EchoAgentWithTasks.cs
@@ -10,7 +10,7 @@ public sealed class EchoAgentWithTasks : IAgentHandler
         var targetState = GetTargetStateFromMetadata(context.Message.Metadata);
         var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
 
-        await updater.SubmitAsync(cancellationToken);
+        await updater.SubmitAsync(cancellationToken: cancellationToken);
 
         // When the client requests return-immediately, simulate slow work so
         // the server returns the in-progress task before processing completes.
@@ -33,12 +33,12 @@ public sealed class EchoAgentWithTasks : IAgentHandler
                 await updater.FailAsync(cancellationToken: cancellationToken);
                 break;
             case TaskState.Canceled:
-                await updater.CancelAsync(cancellationToken);
+                await updater.CancelAsync(cancellationToken: cancellationToken);
                 break;
             case TaskState.InputRequired:
                 await updater.RequireInputAsync(
                     new Message { Role = Role.Agent, MessageId = Guid.NewGuid().ToString("N"), Parts = [Part.FromText("Need input")] },
-                    cancellationToken);
+                    cancellationToken: cancellationToken);
                 break;
             default:
                 await updater.CompleteAsync(cancellationToken: cancellationToken);

--- a/samples/AgentServer/ResearcherAgent.cs
+++ b/samples/AgentServer/ResearcherAgent.cs
@@ -11,7 +11,7 @@ public sealed class ResearcherAgent : IAgentHandler
         if (!context.IsContinuation)
         {
             // New task: planning phase — ask for confirmation
-            await updater.SubmitAsync(cancellationToken);
+            await updater.SubmitAsync(cancellationToken: cancellationToken);
             await updater.AddArtifactAsync(
                 [Part.FromText($"{context.UserText} received.")],
                 cancellationToken: cancellationToken);
@@ -24,7 +24,7 @@ public sealed class ResearcherAgent : IAgentHandler
                 MessageId = Guid.NewGuid().ToString("N"),
                 ContextId = updater.ContextId,
                 Parts = [Part.FromText("When ready say go ahead")],
-            }, cancellationToken);
+            }, cancellationToken: cancellationToken);
             return;
         }
 
@@ -43,7 +43,7 @@ public sealed class ResearcherAgent : IAgentHandler
                     MessageId = Guid.NewGuid().ToString("N"),
                     Parts = [Part.FromText("Task completed successfully")],
                 },
-                cancellationToken);
+                cancellationToken: cancellationToken);
         }
         else
         {
@@ -58,7 +58,7 @@ public sealed class ResearcherAgent : IAgentHandler
                 MessageId = Guid.NewGuid().ToString("N"),
                 ContextId = updater.ContextId,
                 Parts = [Part.FromText("When ready say go ahead")],
-            }, cancellationToken);
+            }, cancellationToken: cancellationToken);
         }
     }
 

--- a/samples/AgentServer/StreamingArtifactAgent.cs
+++ b/samples/AgentServer/StreamingArtifactAgent.cs
@@ -8,7 +8,7 @@ public sealed class StreamingArtifactAgent : IAgentHandler
     {
         var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
 
-        await updater.SubmitAsync(cancellationToken);
+        await updater.SubmitAsync(cancellationToken: cancellationToken);
         await updater.StartWorkAsync(cancellationToken: cancellationToken);
 
         var artifactId = Guid.NewGuid().ToString("N");

--- a/samples/FileStoreDemo/Program.cs
+++ b/samples/FileStoreDemo/Program.cs
@@ -242,13 +242,13 @@ file sealed class DemoAgent : IAgentHandler
     public async Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken ct)
     {
         var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
-        await updater.SubmitAsync(ct);
+        await updater.SubmitAsync(cancellationToken: ct);
         await updater.StartWorkAsync(cancellationToken: ct);
 
         // Echo back with a response
         var userText = context.Message.Parts?.FirstOrDefault()?.Text ?? "no input";
         var responder = new MessageResponder(eventQueue, updater.ContextId);
-        await responder.ReplyAsync($"Acknowledged: {userText}", ct);
+        await responder.ReplyAsync($"Acknowledged: {userText}", cancellationToken: ct);
 
         await updater.CompleteAsync(cancellationToken: ct);
     }
@@ -256,6 +256,6 @@ file sealed class DemoAgent : IAgentHandler
     public async Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken ct)
     {
         var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
-        await updater.CancelAsync(ct);
+        await updater.CancelAsync(cancellationToken: ct);
     }
 }

--- a/samples/SemanticKernelAgent/SemanticKernelTravelAgent.cs
+++ b/samples/SemanticKernelAgent/SemanticKernelTravelAgent.cs
@@ -135,7 +135,7 @@ public sealed class SemanticKernelTravelAgent : IAgentHandler, IDisposable
     public async Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
     {
         var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
-        await updater.SubmitAsync(cancellationToken);
+        await updater.SubmitAsync(cancellationToken: cancellationToken);
         await updater.StartWorkAsync(cancellationToken: cancellationToken);
 
         // Get the response from the Semantic Kernel agent

--- a/src/A2A/Server/IAgentHandler.cs
+++ b/src/A2A/Server/IAgentHandler.cs
@@ -28,6 +28,6 @@ public interface IAgentHandler
     async Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
     {
         var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
-        await updater.CancelAsync(cancellationToken);
+        await updater.CancelAsync(cancellationToken: cancellationToken);
     }
 }

--- a/src/A2A/Server/MessageResponder.cs
+++ b/src/A2A/Server/MessageResponder.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace A2A;
 
 /// <summary>
@@ -13,19 +15,22 @@ public sealed class MessageResponder(AgentEventQueue eventQueue, string contextI
 
     /// <summary>Send a text reply.</summary>
     /// <param name="text">The text content of the reply.</param>
+    /// <param name="metadata">Optional metadata to attach to the message.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public ValueTask ReplyAsync(string text, CancellationToken cancellationToken = default)
-        => ReplyAsync([Part.FromText(text)], cancellationToken);
+    public ValueTask ReplyAsync(string text, Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
+        => ReplyAsync([Part.FromText(text)], metadata, cancellationToken);
 
     /// <summary>Send a reply with the specified parts.</summary>
     /// <param name="parts">The content parts of the reply.</param>
+    /// <param name="metadata">Optional metadata to attach to the message.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public ValueTask ReplyAsync(List<Part> parts, CancellationToken cancellationToken = default)
+    public ValueTask ReplyAsync(List<Part> parts, Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
         => eventQueue.EnqueueMessageAsync(new Message
         {
             Role = Role.Agent,
             MessageId = Guid.NewGuid().ToString("N"),
             ContextId = contextId,
             Parts = parts,
+            Metadata = metadata,
         }, cancellationToken);
 }

--- a/src/A2A/Server/TaskUpdater.cs
+++ b/src/A2A/Server/TaskUpdater.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace A2A;
 
 /// <summary>
@@ -18,8 +20,9 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
     public string ContextId => contextId;
 
     /// <summary>Emit the initial task with Submitted status.</summary>
+    /// <param name="metadata">Optional metadata to attach to the task.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public ValueTask SubmitAsync(CancellationToken cancellationToken = default)
+    public ValueTask SubmitAsync(Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
         => eventQueue.EnqueueTaskAsync(new AgentTask
         {
             Id = taskId,
@@ -29,12 +32,14 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 State = TaskState.Submitted,
                 Timestamp = DateTimeOffset.UtcNow,
             },
+            Metadata = metadata,
         }, cancellationToken);
 
     /// <summary>Transition task to Working state with an optional status message.</summary>
     /// <param name="message">Optional message describing the current work.</param>
+    /// <param name="metadata">Optional metadata to attach to the status update event.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public ValueTask StartWorkAsync(Message? message = null, CancellationToken cancellationToken = default)
+    public ValueTask StartWorkAsync(Message? message = null, Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
         => eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
         {
             TaskId = taskId,
@@ -45,6 +50,7 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 Timestamp = DateTimeOffset.UtcNow,
                 Message = message,
             },
+            Metadata = metadata,
         }, cancellationToken);
 
     /// <summary>Add an artifact to the task.</summary>
@@ -54,6 +60,7 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
     /// <param name="description">Optional artifact description.</param>
     /// <param name="lastChunk">Whether this is the final chunk for this artifact.</param>
     /// <param name="append">Whether to append to an existing artifact with the same ID.</param>
+    /// <param name="metadata">Optional metadata to attach to the artifact.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public ValueTask AddArtifactAsync(
         IReadOnlyList<Part> parts,
@@ -62,6 +69,7 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
         string? description = null,
         bool lastChunk = true,
         bool append = false,
+        Dictionary<string, JsonElement>? metadata = null,
         CancellationToken cancellationToken = default)
         => eventQueue.EnqueueArtifactUpdateAsync(new TaskArtifactUpdateEvent
         {
@@ -73,6 +81,7 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 Name = name,
                 Description = description,
                 Parts = [.. parts],
+                Metadata = metadata,
             },
             Append = append,
             LastChunk = lastChunk,
@@ -80,8 +89,9 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
 
     /// <summary>Complete the task with an optional final message.</summary>
     /// <param name="message">Optional completion message.</param>
+    /// <param name="metadata">Optional metadata to attach to the status update event.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public async ValueTask CompleteAsync(Message? message = null, CancellationToken cancellationToken = default)
+    public async ValueTask CompleteAsync(Message? message = null, Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
     {
         await eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
         {
@@ -93,14 +103,16 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 Timestamp = DateTimeOffset.UtcNow,
                 Message = message,
             },
+            Metadata = metadata,
         }, cancellationToken);
         eventQueue.Complete();
     }
 
     /// <summary>Fail the task with an optional error message.</summary>
     /// <param name="message">Optional error message.</param>
+    /// <param name="metadata">Optional metadata to attach to the status update event.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public async ValueTask FailAsync(Message? message = null, CancellationToken cancellationToken = default)
+    public async ValueTask FailAsync(Message? message = null, Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
     {
         await eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
         {
@@ -112,13 +124,15 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 Timestamp = DateTimeOffset.UtcNow,
                 Message = message,
             },
+            Metadata = metadata,
         }, cancellationToken);
         eventQueue.Complete();
     }
 
     /// <summary>Cancel the task.</summary>
+    /// <param name="metadata">Optional metadata to attach to the status update event.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public async ValueTask CancelAsync(CancellationToken cancellationToken = default)
+    public async ValueTask CancelAsync(Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
     {
         await eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
         {
@@ -129,14 +143,16 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 State = TaskState.Canceled,
                 Timestamp = DateTimeOffset.UtcNow,
             },
+            Metadata = metadata,
         }, cancellationToken);
         eventQueue.Complete();
     }
 
     /// <summary>Reject the task with an optional reason message.</summary>
     /// <param name="message">Optional rejection reason.</param>
+    /// <param name="metadata">Optional metadata to attach to the status update event.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public async ValueTask RejectAsync(Message? message = null, CancellationToken cancellationToken = default)
+    public async ValueTask RejectAsync(Message? message = null, Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
     {
         await eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
         {
@@ -148,14 +164,16 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 Timestamp = DateTimeOffset.UtcNow,
                 Message = message,
             },
+            Metadata = metadata,
         }, cancellationToken);
         eventQueue.Complete();
     }
 
     /// <summary>Request additional input from the client.</summary>
     /// <param name="message">Message describing what input is needed.</param>
+    /// <param name="metadata">Optional metadata to attach to the status update event.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public async ValueTask RequireInputAsync(Message message, CancellationToken cancellationToken = default)
+    public async ValueTask RequireInputAsync(Message message, Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
     {
         await eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
         {
@@ -167,14 +185,16 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 Timestamp = DateTimeOffset.UtcNow,
                 Message = message,
             },
+            Metadata = metadata,
         }, cancellationToken);
         eventQueue.Complete();
     }
 
     /// <summary>Request authentication from the client.</summary>
     /// <param name="message">Optional message describing the auth requirement.</param>
+    /// <param name="metadata">Optional metadata to attach to the status update event.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public async ValueTask RequireAuthAsync(Message? message = null, CancellationToken cancellationToken = default)
+    public async ValueTask RequireAuthAsync(Message? message = null, Dictionary<string, JsonElement>? metadata = null, CancellationToken cancellationToken = default)
     {
         await eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
         {
@@ -186,6 +206,7 @@ public sealed class TaskUpdater(AgentEventQueue eventQueue, string taskId, strin
                 Timestamp = DateTimeOffset.UtcNow,
                 Message = message,
             },
+            Metadata = metadata,
         }, cancellationToken);
         eventQueue.Complete();
     }

--- a/tests/A2A.AspNetCore.UnitTests/A2AHttpProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AHttpProcessorTests.cs
@@ -33,7 +33,7 @@ public class A2AHttpProcessorTests
         public async Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
         {
             var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
-            await updater.CancelAsync(cancellationToken);
+            await updater.CancelAsync(cancellationToken: cancellationToken);
         }
     }
 

--- a/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
@@ -444,7 +444,7 @@ public class A2AJsonRpcProcessorTests
         public async Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
         {
             var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
-            await updater.CancelAsync(cancellationToken);
+            await updater.CancelAsync(cancellationToken: cancellationToken);
         }
     }
 

--- a/tests/A2A.UnitTests/Server/A2AServerTests.cs
+++ b/tests/A2A.UnitTests/Server/A2AServerTests.cs
@@ -16,7 +16,7 @@ public class A2AServerTests
 
         public Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
             => OnCancel?.Invoke(context, eventQueue, cancellationToken)
-               ?? new TaskUpdater(eventQueue, context.TaskId, context.ContextId).CancelAsync(cancellationToken).AsTask();
+               ?? new TaskUpdater(eventQueue, context.TaskId, context.ContextId).CancelAsync(cancellationToken: cancellationToken).AsTask();
     }
 
     private static (A2AServer server, InMemoryTaskStore store, TestAgentHandler handler)
@@ -68,7 +68,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.CompleteAsync(cancellationToken: ct);
         };
 
@@ -96,7 +96,7 @@ public class A2AServerTests
         {
             capturedTaskId = ctx.TaskId;
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.CompleteAsync(cancellationToken: ct);
         };
 
@@ -229,7 +229,7 @@ public class A2AServerTests
         {
             cancelCalled = true;
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.CancelAsync(ct);
+            await updater.CancelAsync(cancellationToken: ct);
         };
 
         // Act
@@ -257,7 +257,7 @@ public class A2AServerTests
         {
             capturedMetadata = ctx.Metadata;
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.CancelAsync(ct);
+            await updater.CancelAsync(cancellationToken: ct);
         };
 
         var metadata = new Dictionary<string, System.Text.Json.JsonElement>
@@ -470,7 +470,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.CompleteAsync(cancellationToken: ct);
         };
 
@@ -572,7 +572,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.FailAsync(cancellationToken: ct);
         };
 
@@ -613,7 +613,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.StartWorkAsync(cancellationToken: ct);
             await Task.Delay(5000, CancellationToken.None); // slow work
             await updater.CompleteAsync(cancellationToken: CancellationToken.None);
@@ -694,7 +694,7 @@ public class A2AServerTests
         {
             capturedTaskId = ctx.TaskId;
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.StartWorkAsync(cancellationToken: ct);
             await updater.AddArtifactAsync(
                 [Part.FromText("result data")],
@@ -743,7 +743,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.StartWorkAsync(cancellationToken: ct);
             await Task.Delay(200, ct); // some work
             await updater.CompleteAsync(cancellationToken: ct);
@@ -776,7 +776,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.StartWorkAsync(cancellationToken: ct);
             handlerStarted.TrySetResult();
 
@@ -798,7 +798,7 @@ public class A2AServerTests
         handler.OnCancel = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.CancelAsync(ct);
+            await updater.CancelAsync(cancellationToken: ct);
         };
 
         var request = new SendMessageRequest
@@ -842,7 +842,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.StartWorkAsync(cancellationToken: ct);
             handlerStarted.TrySetResult();
 
@@ -889,7 +889,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.StartWorkAsync(cancellationToken: ct);
             handlerStarted.TrySetResult();
             await proceedToComplete.Task.WaitAsync(CancellationToken.None);
@@ -942,7 +942,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.StartWorkAsync(cancellationToken: ct);
             await updater.AddArtifactAsync(
                 [Part.FromText("result data")],
@@ -997,7 +997,7 @@ public class A2AServerTests
         handler.OnExecute = async (ctx, eq, ct) =>
         {
             var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
-            await updater.SubmitAsync(ct);
+            await updater.SubmitAsync(cancellationToken: ct);
             await updater.StartWorkAsync(cancellationToken: ct);
             handlerReachedWait.TrySetResult();
             await proceedToComplete.Task.WaitAsync(CancellationToken.None);

--- a/tests/A2A.UnitTests/Server/MessageResponderTests.cs
+++ b/tests/A2A.UnitTests/Server/MessageResponderTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace A2A.UnitTests.Server;
 
 public class MessageResponderTests
@@ -55,6 +57,49 @@ public class MessageResponderTests
         var events = await CollectEventsAsync(queue);
         Assert.Equal(2, events.Count);
         Assert.NotEqual(events[0].Message!.MessageId, events[1].Message!.MessageId);
+    }
+
+    [Fact]
+    public async Task ReplyAsync_TextWithMetadata_SetsMetadataOnMessage()
+    {
+        var queue = new AgentEventQueue();
+        var responder = new MessageResponder(queue, "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["source"] = JsonDocument.Parse("\"agent-v2\"").RootElement,
+        };
+
+        await responder.ReplyAsync("hello", metadata: metadata);
+
+        queue.Complete();
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        var msg = events[0].Message;
+        Assert.NotNull(msg);
+        Assert.NotNull(msg!.Metadata);
+        Assert.Equal("agent-v2", msg.Metadata!["source"].GetString());
+    }
+
+    [Fact]
+    public async Task ReplyAsync_PartsWithMetadata_SetsMetadataOnMessage()
+    {
+        var queue = new AgentEventQueue();
+        var responder = new MessageResponder(queue, "ctx-2");
+        var parts = new List<Part> { Part.FromText("a") };
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["tag"] = JsonDocument.Parse("\"important\"").RootElement,
+        };
+
+        await responder.ReplyAsync(parts, metadata: metadata);
+
+        queue.Complete();
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        var msg = events[0].Message;
+        Assert.NotNull(msg);
+        Assert.NotNull(msg!.Metadata);
+        Assert.Equal("important", msg.Metadata!["tag"].GetString());
     }
 
     private static async Task<List<StreamResponse>> CollectEventsAsync(AgentEventQueue queue)

--- a/tests/A2A.UnitTests/Server/TaskUpdaterTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskUpdaterTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace A2A.UnitTests.Server;
 
 public class TaskUpdaterTests
@@ -136,6 +138,175 @@ public class TaskUpdaterTests
         Assert.Equal(TaskState.Working, events[1].StatusUpdate!.Status.State);
         Assert.NotNull(events[2].ArtifactUpdate); // Artifact
         Assert.Equal(TaskState.Completed, events[3].StatusUpdate!.Status.State);
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenSubmitAsyncWithMetadata_ThenMetadataIsSetOnTask()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["key"] = JsonDocument.Parse("\"value\"").RootElement,
+        };
+
+        await updater.SubmitAsync(metadata: metadata);
+
+        queue.Complete();
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].Task);
+        Assert.NotNull(events[0].Task!.Metadata);
+        Assert.Equal("value", events[0].Task!.Metadata!["key"].GetString());
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenStartWorkAsyncWithMetadata_ThenMetadataIsSetOnEvent()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["step"] = JsonDocument.Parse("1").RootElement,
+        };
+
+        await updater.StartWorkAsync(metadata: metadata);
+
+        queue.Complete();
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].StatusUpdate);
+        Assert.NotNull(events[0].StatusUpdate!.Metadata);
+        Assert.Equal(1, events[0].StatusUpdate!.Metadata!["step"].GetInt32());
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenAddArtifactAsyncWithMetadata_ThenMetadataIsSetOnArtifact()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["source"] = JsonDocument.Parse("\"generated\"").RootElement,
+        };
+
+        await updater.AddArtifactAsync([Part.FromText("data")], metadata: metadata);
+
+        queue.Complete();
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].ArtifactUpdate);
+        Assert.NotNull(events[0].ArtifactUpdate!.Artifact.Metadata);
+        Assert.Equal("generated", events[0].ArtifactUpdate!.Artifact.Metadata!["source"].GetString());
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenCompleteAsyncWithMetadata_ThenMetadataIsSetOnEvent()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["duration"] = JsonDocument.Parse("42").RootElement,
+        };
+
+        await updater.CompleteAsync(metadata: metadata);
+
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].StatusUpdate!.Metadata);
+        Assert.Equal(42, events[0].StatusUpdate!.Metadata!["duration"].GetInt32());
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenFailAsyncWithMetadata_ThenMetadataIsSetOnEvent()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["error"] = JsonDocument.Parse("\"timeout\"").RootElement,
+        };
+
+        await updater.FailAsync(metadata: metadata);
+
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].StatusUpdate!.Metadata);
+        Assert.Equal("timeout", events[0].StatusUpdate!.Metadata!["error"].GetString());
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenCancelAsyncWithMetadata_ThenMetadataIsSetOnEvent()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["reason"] = JsonDocument.Parse("\"user-requested\"").RootElement,
+        };
+
+        await updater.CancelAsync(metadata: metadata);
+
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].StatusUpdate!.Metadata);
+        Assert.Equal("user-requested", events[0].StatusUpdate!.Metadata!["reason"].GetString());
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenRejectAsyncWithMetadata_ThenMetadataIsSetOnEvent()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["policy"] = JsonDocument.Parse("\"rate-limit\"").RootElement,
+        };
+
+        await updater.RejectAsync(metadata: metadata);
+
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].StatusUpdate!.Metadata);
+        Assert.Equal("rate-limit", events[0].StatusUpdate!.Metadata!["policy"].GetString());
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenRequireInputAsyncWithMetadata_ThenMetadataIsSetOnEvent()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var message = new Message { Role = Role.Agent, MessageId = "m1", Parts = [Part.FromText("need input")] };
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["schema"] = JsonDocument.Parse("\"form-v2\"").RootElement,
+        };
+
+        await updater.RequireInputAsync(message, metadata: metadata);
+
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].StatusUpdate!.Metadata);
+        Assert.Equal("form-v2", events[0].StatusUpdate!.Metadata!["schema"].GetString());
+    }
+
+    [Fact]
+    public async Task GivenTaskUpdater_WhenRequireAuthAsyncWithMetadata_ThenMetadataIsSetOnEvent()
+    {
+        var queue = new AgentEventQueue();
+        var updater = new TaskUpdater(queue, "t1", "ctx-1");
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["provider"] = JsonDocument.Parse("\"oauth2\"").RootElement,
+        };
+
+        await updater.RequireAuthAsync(metadata: metadata);
+
+        var events = await CollectEventsAsync(queue);
+        Assert.Single(events);
+        Assert.NotNull(events[0].StatusUpdate!.Metadata);
+        Assert.Equal("oauth2", events[0].StatusUpdate!.Metadata!["provider"].GetString());
     }
 
     private static async Task<List<StreamResponse>> CollectEventsAsync(AgentEventQueue queue)

--- a/tests/A2A.V0_3Compat.UnitTests/V03ServerProcessorTests.cs
+++ b/tests/A2A.V0_3Compat.UnitTests/V03ServerProcessorTests.cs
@@ -259,7 +259,7 @@ public class V03ServerProcessorTests
         public async Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
         {
             var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
-            await updater.CancelAsync(cancellationToken);
+            await updater.CancelAsync(cancellationToken: cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Summary

Extends all `TaskUpdater` and `MessageResponder` methods with an optional `Dictionary<string, JsonElement>? metadata` parameter, allowing callers to attach protocol-level metadata to tasks, status update events, artifacts, and messages.

## Changes

All new parameters are optional (`= null`) and placed before `CancellationToken`, preserving backward compatibility for callers using named arguments.

### Caller updates

Updated all existing call sites that passed `CancellationToken` positionally to use the named `cancellationToken:` syntax, across samples, tests, and the `IAgentHandler` default implementation.

### Tests

Added 11 new unit tests verifying metadata flows through to the correct model objects for every method on both classes.