### PR TITLE
feat: Add configureRequest callback to A2A clients

### DIFF
--- a/src/A2A.V0_3/Client/A2AClient.cs
+++ b/src/A2A.V0_3/Client/A2AClient.cs
@@ -13,13 +13,18 @@ public sealed class A2AClient : IA2AClient
     internal static readonly HttpClient s_sharedClient = new();
     private readonly HttpClient _httpClient;
     private readonly Uri _baseUri;
+    private readonly Func<HttpRequestMessage, CancellationToken, Task>? _configureRequest;
 
     /// <summary>
     /// Initializes a new instance of <see cref="A2AClient"/>.
     /// </summary>
     /// <param name="baseUrl">The base url of the agent's hosting service.</param>
     /// <param name="httpClient">The HTTP client to use for requests.</param>
-    public A2AClient(Uri baseUrl, HttpClient? httpClient = null)
+    /// <param name="configureRequest">
+    /// An optional callback invoked for every outgoing <see cref="HttpRequestMessage"/> before it is sent.
+    /// Use this to add authentication headers or other per-request customizations.
+    /// </param>
+    public A2AClient(Uri baseUrl, HttpClient? httpClient = null, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {
         if (baseUrl is null)
         {
@@ -29,6 +34,7 @@ public sealed class A2AClient : IA2AClient
         _baseUri = baseUrl;
 
         _httpClient = httpClient ?? s_sharedClient;
+        _configureRequest = configureRequest;
     }
 
     /// <inheritdoc />
@@ -168,7 +174,7 @@ public sealed class A2AClient : IA2AClient
         string expectedContentType,
         CancellationToken cancellationToken)
     {
-        var response = await _httpClient.SendAsync(new(HttpMethod.Post, _baseUri)
+        var request = new HttpRequestMessage(HttpMethod.Post, _baseUri)
         {
             Content = new JsonRpcContent(new JsonRpcRequest()
             {
@@ -176,7 +182,14 @@ public sealed class A2AClient : IA2AClient
                 Method = method,
                 Params = JsonSerializer.SerializeToElement(jsonRpcParams, inputTypeInfo),
             })
-        }, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        };
+
+        if (_configureRequest is not null)
+        {
+            await _configureRequest(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
         try
         {

--- a/src/A2A.V0_3/Client/A2AClient.cs
+++ b/src/A2A.V0_3/Client/A2AClient.cs
@@ -174,15 +174,13 @@ public sealed class A2AClient : IA2AClient
         string expectedContentType,
         CancellationToken cancellationToken)
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, _baseUri)
+        using var request = new HttpRequestMessage(HttpMethod.Post, _baseUri);
+        request.Content = new JsonRpcContent(new JsonRpcRequest
         {
-            Content = new JsonRpcContent(new JsonRpcRequest()
-            {
-                Id = Guid.NewGuid().ToString(),
-                Method = method,
-                Params = JsonSerializer.SerializeToElement(jsonRpcParams, inputTypeInfo),
-            })
-        };
+            Id = Guid.NewGuid().ToString(),
+            Method = method,
+            Params = JsonSerializer.SerializeToElement(jsonRpcParams, inputTypeInfo)
+        });
 
         if (_configureRequest is not null)
         {

--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -19,7 +19,10 @@ public sealed class A2AClient : IA2AClient, IDisposable
     /// <param name="httpClient">The HTTP client to use for requests.</param>
     /// <param name="configureRequest">
     /// An optional callback invoked for every outgoing <see cref="HttpRequestMessage"/> before it is sent.
-    /// Use this to add authentication headers or other per-request customizations.
+    /// Use this to add or override request headers such as authentication headers or other per-request customizations.
+    /// Default headers set by the library (e.g. <c>A2A-Version</c>) are already present when the callback runs;
+    /// to replace one, call <c>request.Headers.Remove(name)</c> before adding a new value, since
+    /// <c>TryAddWithoutValidation</c> appends to multi-valued headers rather than replacing them.
     /// </param>
     public A2AClient(Uri baseUrl, HttpClient? httpClient = null, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {

--- a/src/A2A/Client/A2AClient.cs
+++ b/src/A2A/Client/A2AClient.cs
@@ -12,11 +12,16 @@ public sealed class A2AClient : IA2AClient, IDisposable
     internal static readonly HttpClient s_sharedClient = new();
     private readonly HttpClient _httpClient;
     private readonly string _url;
+    private readonly Func<HttpRequestMessage, CancellationToken, Task>? _configureRequest;
 
     /// <summary>Initializes a new instance of the <see cref="A2AClient"/> class.</summary>
     /// <param name="baseUrl">The base url of the agent's hosting service.</param>
     /// <param name="httpClient">The HTTP client to use for requests.</param>
-    public A2AClient(Uri baseUrl, HttpClient? httpClient = null)
+    /// <param name="configureRequest">
+    /// An optional callback invoked for every outgoing <see cref="HttpRequestMessage"/> before it is sent.
+    /// Use this to add authentication headers or other per-request customizations.
+    /// </param>
+    public A2AClient(Uri baseUrl, HttpClient? httpClient = null, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {
         if (baseUrl is null)
         {
@@ -25,6 +30,7 @@ public sealed class A2AClient : IA2AClient, IDisposable
 
         _url = baseUrl.ToString();
         _httpClient = httpClient ?? s_sharedClient;
+        _configureRequest = configureRequest;
     }
 
     /// <inheritdoc />
@@ -134,6 +140,12 @@ public sealed class A2AClient : IA2AClient, IDisposable
             using var content = new JsonRpcContent(rpcRequest);
             using var requestMessage = new HttpRequestMessage(HttpMethod.Post, _url) { Content = content };
             requestMessage.Headers.TryAddWithoutValidation("A2A-Version", "1.0");
+
+            if (_configureRequest is not null)
+            {
+                await _configureRequest(requestMessage, cancellationToken).ConfigureAwait(false);
+            }
+
             using var response = await _httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
@@ -193,6 +205,11 @@ public sealed class A2AClient : IA2AClient, IDisposable
             };
             requestMessage.Headers.TryAddWithoutValidation("A2A-Version", "1.0");
             requestMessage.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+            if (_configureRequest is not null)
+            {
+                await _configureRequest(requestMessage, cancellationToken).ConfigureAwait(false);
+            }
 
             response = await _httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();

--- a/tests/A2A.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.UnitTests/Client/A2AClientTests.cs
@@ -372,7 +372,100 @@ public class A2AClientTests
         Assert.Equal(A2AMethods.DeleteTaskPushNotificationConfig, requestJson.RootElement.GetProperty("method").GetString());
     }
 
-    private static A2AClient CreateA2AClient(object result, Action<HttpRequestMessage>? onRequest = null, bool isSse = false)
+    [Fact]
+    public async Task ConfigureRequest_IsInvokedAndCanMutateRequest()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        var callbackInvoked = false;
+
+        var responseResult = new SendMessageResponse
+        {
+            Message = new Message { MessageId = "id-1", Role = Role.User, Parts = [] }
+        };
+
+        Func<HttpRequestMessage, CancellationToken, Task> configureRequest = (req, _) =>
+        {
+            callbackInvoked = true;
+            req.Headers.TryAddWithoutValidation("X-Test-Header", "test-value");
+            return Task.CompletedTask;
+        };
+
+        var sut = CreateA2AClient(responseResult, req => capturedRequest = req, configureRequest: configureRequest);
+
+        var sendRequest = new SendMessageRequest { Message = new Message { Parts = [], Role = Role.User } };
+
+        // Act
+        await sut.SendMessageAsync(sendRequest);
+
+        // Assert
+        Assert.True(callbackInvoked);
+        Assert.NotNull(capturedRequest);
+        Assert.True(capturedRequest.Headers.TryGetValues("X-Test-Header", out var values));
+        Assert.Equal("test-value", values.Single());
+    }
+
+    [Fact]
+    public async Task ConfigureRequest_IsInvokedForStreamingRequests()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        var callbackInvocations = 0;
+
+        var responseResult = new StreamResponse
+        {
+            Message = new Message { MessageId = "id-1", Role = Role.Agent, Parts = [] }
+        };
+
+        Func<HttpRequestMessage, CancellationToken, Task> configureRequest = (req, _) =>
+        {
+            callbackInvocations++;
+            req.Headers.TryAddWithoutValidation("X-Stream-Auth", "bearer-token");
+            return Task.CompletedTask;
+        };
+
+        var sut = CreateA2AClient(responseResult, req => capturedRequest = req, isSse: true, configureRequest: configureRequest);
+
+        var sendRequest = new SendMessageRequest { Message = new Message { Parts = [], Role = Role.User } };
+
+        // Act
+        await foreach (var _ in sut.SendStreamingMessageAsync(sendRequest))
+        {
+            break;
+        }
+
+        // Assert
+        Assert.Equal(1, callbackInvocations);
+        Assert.NotNull(capturedRequest);
+        Assert.True(capturedRequest.Headers.TryGetValues("X-Stream-Auth", out var values));
+        Assert.Equal("bearer-token", values.Single());
+    }
+
+    [Fact]
+    public async Task ConfigureRequest_PropagatesExceptionAndDoesNotSendRequest()
+    {
+        // Arrange
+        var requestSent = false;
+
+        var responseResult = new SendMessageResponse
+        {
+            Message = new Message { MessageId = "id-1", Role = Role.User, Parts = [] }
+        };
+
+        Func<HttpRequestMessage, CancellationToken, Task> configureRequest = (_, _) =>
+            throw new InvalidOperationException("configure failed");
+
+        var sut = CreateA2AClient(responseResult, _ => requestSent = true, configureRequest: configureRequest);
+
+        var sendRequest = new SendMessageRequest { Message = new Message { Parts = [], Role = Role.User } };
+
+        // Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.SendMessageAsync(sendRequest));
+        Assert.Equal("configure failed", ex.Message);
+        Assert.False(requestSent);
+    }
+
+    private static A2AClient CreateA2AClient(object result, Action<HttpRequestMessage>? onRequest = null, bool isSse = false, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {
         var response = new JsonRpcResponse
         {
@@ -380,10 +473,10 @@ public class A2AClientTests
             Result = JsonSerializer.SerializeToNode(result, A2AJsonUtilities.DefaultOptions)
         };
 
-        return CreateA2AClient(response, onRequest, isSse);
+        return CreateA2AClient(response, onRequest, isSse, configureRequest);
     }
 
-    private static A2AClient CreateA2AClient(JsonRpcResponse jsonResponse, Action<HttpRequestMessage>? onRequest = null, bool isSse = false)
+    private static A2AClient CreateA2AClient(JsonRpcResponse jsonResponse, Action<HttpRequestMessage>? onRequest = null, bool isSse = false, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {
         var responseContent = JsonSerializer.Serialize(jsonResponse, A2AJsonUtilities.DefaultOptions);
 
@@ -398,6 +491,6 @@ public class A2AClientTests
         var handler = new MockHttpMessageHandler(response, onRequest);
         var httpClient = new HttpClient(handler);
 
-        return new A2AClient(new Uri("http://localhost"), httpClient);
+        return new A2AClient(new Uri("http://localhost"), httpClient, configureRequest);
     }
 }

--- a/tests/A2A.V0_3.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.V0_3.UnitTests/Client/A2AClientTests.cs
@@ -617,7 +617,104 @@ public class A2AClientTests
         Assert.Contains("Method not found", exception.Message);
     }
 
-    private static A2AClient CreateA2AClient(object result, Action<HttpRequestMessage>? onRequest = null, bool isSse = false)
+    [Fact]
+    public async Task ConfigureRequest_IsInvokedAndCanMutateRequest()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        var callbackInvoked = false;
+
+        Func<HttpRequestMessage, CancellationToken, Task> configureRequest = (req, _) =>
+        {
+            callbackInvoked = true;
+            req.Headers.TryAddWithoutValidation("X-Test-Header", "test-value");
+            return Task.CompletedTask;
+        };
+
+        var sut = CreateA2AClient(
+            new AgentMessage { MessageId = "id-1", Role = MessageRole.Agent, Parts = [] },
+            req => capturedRequest = req,
+            configureRequest: configureRequest);
+
+        var sendParams = new MessageSendParams
+        {
+            Message = new AgentMessage { Parts = [], Role = MessageRole.User, MessageId = "msg-1" }
+        };
+
+        // Act
+        await sut.SendMessageAsync(sendParams);
+
+        // Assert
+        Assert.True(callbackInvoked);
+        Assert.NotNull(capturedRequest);
+        Assert.True(capturedRequest.Headers.TryGetValues("X-Test-Header", out var values));
+        Assert.Equal("test-value", values.Single());
+    }
+
+    [Fact]
+    public async Task ConfigureRequest_IsInvokedForStreamingRequests()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        var callbackInvocations = 0;
+
+        Func<HttpRequestMessage, CancellationToken, Task> configureRequest = (req, _) =>
+        {
+            callbackInvocations++;
+            req.Headers.TryAddWithoutValidation("X-Stream-Auth", "bearer-token");
+            return Task.CompletedTask;
+        };
+
+        var sut = CreateA2AClient(
+            new AgentMessage { MessageId = "id-1", Role = MessageRole.Agent, Parts = [] },
+            req => capturedRequest = req,
+            isSse: true,
+            configureRequest: configureRequest);
+
+        var sendParams = new MessageSendParams
+        {
+            Message = new AgentMessage { Parts = [], Role = MessageRole.User, MessageId = "msg-1" }
+        };
+
+        // Act
+        await foreach (var _ in sut.SendMessageStreamingAsync(sendParams))
+        {
+            break;
+        }
+
+        // Assert
+        Assert.Equal(1, callbackInvocations);
+        Assert.NotNull(capturedRequest);
+        Assert.True(capturedRequest.Headers.TryGetValues("X-Stream-Auth", out var values));
+        Assert.Equal("bearer-token", values.Single());
+    }
+
+    [Fact]
+    public async Task ConfigureRequest_PropagatesExceptionAndDoesNotSendRequest()
+    {
+        // Arrange
+        var requestSent = false;
+
+        Func<HttpRequestMessage, CancellationToken, Task> configureRequest = (_, _) =>
+            throw new InvalidOperationException("configure failed");
+
+        var sut = CreateA2AClient(
+            new AgentMessage { MessageId = "id-1", Role = MessageRole.Agent, Parts = [] },
+            _ => requestSent = true,
+            configureRequest: configureRequest);
+
+        var sendParams = new MessageSendParams
+        {
+            Message = new AgentMessage { Parts = [], Role = MessageRole.User, MessageId = "msg-1" }
+        };
+
+        // Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => sut.SendMessageAsync(sendParams));
+        Assert.Equal("configure failed", ex.Message);
+        Assert.False(requestSent);
+    }
+
+    private static A2AClient CreateA2AClient(object result, Action<HttpRequestMessage>? onRequest = null, bool isSse = false, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {
         var response = new JsonRpcResponse
         {
@@ -625,10 +722,10 @@ public class A2AClientTests
             Result = JsonSerializer.SerializeToNode(result)
         };
 
-        return CreateA2AClient(response, onRequest, isSse);
+        return CreateA2AClient(response, onRequest, isSse, configureRequest);
     }
 
-    private static A2AClient CreateA2AClient(JsonRpcResponse jsonResponse, Action<HttpRequestMessage>? onRequest = null, bool isSse = false)
+    private static A2AClient CreateA2AClient(JsonRpcResponse jsonResponse, Action<HttpRequestMessage>? onRequest = null, bool isSse = false, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {
         var responseContent = JsonSerializer.Serialize(jsonResponse);
 
@@ -644,6 +741,6 @@ public class A2AClientTests
 
         var httpClient = new HttpClient(handler);
 
-        return new A2AClient(new Uri("http://localhost"), httpClient);
+        return new A2AClient(new Uri("http://localhost"), httpClient, configureRequest);
     }
 }

--- a/tests/A2A.V0_3.UnitTests/Client/A2AClientTests.cs
+++ b/tests/A2A.V0_3.UnitTests/Client/A2AClientTests.cs
@@ -11,9 +11,9 @@ public class A2AClientTests
     public async Task SendMessageAsync_MapsRequestParamsCorrectly()
     {
         // Arrange
-        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
 
-        var sut = CreateA2AClient(new AgentMessage() { MessageId = "id-1", Role = MessageRole.User, Parts = [] }, req => capturedRequest = req);
+        var sut = CreateA2AClient(new AgentMessage() { MessageId = "id-1", Role = MessageRole.User, Parts = [] }, (_, body) => capturedBody = body);
 
         var sendParams = new MessageSendParams
         {
@@ -41,9 +41,9 @@ public class A2AClientTests
         await sut.SendMessageAsync(sendParams);
 
         // Assert
-        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedBody);
 
-        var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
+        var requestJson = JsonDocument.Parse(capturedBody);
         Assert.Equal("message/send", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
@@ -113,9 +113,9 @@ public class A2AClientTests
     public async Task GetTaskAsync_MapsRequestParamsCorrectly()
     {
         // Arrange
-        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
 
-        var sut = CreateA2AClient(new AgentTask { Id = "id-1", ContextId = "ctx-1" }, req => capturedRequest = req);
+        var sut = CreateA2AClient(new AgentTask { Id = "id-1", ContextId = "ctx-1" }, (_, body) => capturedBody = body);
 
         var taskId = "task-1";
 
@@ -123,9 +123,9 @@ public class A2AClientTests
         await sut.GetTaskAsync(taskId);
 
         // Assert
-        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedBody);
 
-        var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
+        var requestJson = JsonDocument.Parse(capturedBody);
         Assert.Equal("tasks/get", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
@@ -168,9 +168,9 @@ public class A2AClientTests
     public async Task CancelTaskAsync_MapsRequestParamsCorrectly()
     {
         // Arrange
-        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
 
-        var sut = CreateA2AClient(new AgentTask { Id = "task-2" }, req => capturedRequest = req);
+        var sut = CreateA2AClient(new AgentTask { Id = "task-2" }, (_, body) => capturedBody = body);
 
         var taskIdParams = new TaskIdParams
         {
@@ -182,9 +182,9 @@ public class A2AClientTests
         await sut.CancelTaskAsync(taskIdParams);
 
         // Assert
-        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedBody);
 
-        var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
+        var requestJson = JsonDocument.Parse(capturedBody);
         Assert.Equal("tasks/cancel", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
@@ -230,9 +230,9 @@ public class A2AClientTests
     public async Task SetPushNotificationAsync_MapsRequestParamsCorrectly()
     {
         // Arrange
-        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
 
-        var sut = CreateA2AClient(new TaskPushNotificationConfig() { TaskId = "id-1", PushNotificationConfig = new PushNotificationConfig() { Url = "url-1" } }, req => capturedRequest = req);
+        var sut = CreateA2AClient(new TaskPushNotificationConfig() { TaskId = "id-1", PushNotificationConfig = new PushNotificationConfig() { Url = "url-1" } }, (_, body) => capturedBody = body);
 
         var pushConfig = new TaskPushNotificationConfig
         {
@@ -253,9 +253,9 @@ public class A2AClientTests
         await sut.SetPushNotificationAsync(pushConfig);
 
         // Assert
-        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedBody);
 
-        var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
+        var requestJson = JsonDocument.Parse(capturedBody);
         Assert.Equal("tasks/pushNotificationConfig/set", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
@@ -304,11 +304,11 @@ public class A2AClientTests
     public async Task GetPushNotificationAsync_MapsRequestParamsCorrectly()
     {
         // Arrange
-        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
 
         var config = new TaskPushNotificationConfig { TaskId = "task-4", PushNotificationConfig = new PushNotificationConfig { Url = "url-1" } };
 
-        var sut = CreateA2AClient(config, req => capturedRequest = req);
+        var sut = CreateA2AClient(config, (_, body) => capturedBody = body);
 
         var notificationConfigParams = new GetTaskPushNotificationConfigParams
         {
@@ -321,9 +321,9 @@ public class A2AClientTests
         await sut.GetPushNotificationAsync(notificationConfigParams);
 
         // Assert
-        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedBody);
 
-        var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
+        var requestJson = JsonDocument.Parse(capturedBody);
         Assert.Equal("tasks/pushNotificationConfig/get", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
@@ -371,11 +371,11 @@ public class A2AClientTests
     public async Task GetPushNotificationAsync_WithPushNotificationConfigId_MapsRequestCorrectly()
     {
         // Arrange
-        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
 
         var config = new TaskPushNotificationConfig { TaskId = "task-5", PushNotificationConfig = new PushNotificationConfig { Url = "url-1" } };
 
-        var sut = CreateA2AClient(config, req => capturedRequest = req);
+        var sut = CreateA2AClient(config, (_, body) => capturedBody = body);
 
         var notificationConfigParams = new GetTaskPushNotificationConfigParams
         {
@@ -387,9 +387,9 @@ public class A2AClientTests
         await sut.GetPushNotificationAsync(notificationConfigParams);
 
         // Assert
-        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedBody);
 
-        var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
+        var requestJson = JsonDocument.Parse(capturedBody);
         var parameters = requestJson.RootElement.GetProperty("params").Deserialize<GetTaskPushNotificationConfigParams>();
         Assert.NotNull(parameters);
         Assert.Equal(notificationConfigParams.Id, parameters.Id);
@@ -401,9 +401,9 @@ public class A2AClientTests
     public async Task SendMessageStreamingAsync_MapsRequestParamsCorrectly()
     {
         // Arrange
-        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
 
-        var sut = CreateA2AClient(new AgentMessage() { MessageId = "id-1", Role = MessageRole.User, Parts = [] }, req => capturedRequest = req, isSse: true);
+        var sut = CreateA2AClient(new AgentMessage() { MessageId = "id-1", Role = MessageRole.User, Parts = [] }, (_, body) => capturedBody = body, isSse: true);
 
         var sendParams = new MessageSendParams
         {
@@ -434,9 +434,9 @@ public class A2AClientTests
         }
 
         // Assert
-        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedBody);
 
-        var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
+        var requestJson = JsonDocument.Parse(capturedBody);
         Assert.Equal("message/stream", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
@@ -509,9 +509,9 @@ public class A2AClientTests
     public async Task SubscribeToTaskAsync_MapsRequestParamsCorrectly()
     {
         // Arrange
-        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
 
-        var sut = CreateA2AClient(new AgentMessage() { MessageId = "id-1", Role = MessageRole.User, Parts = [] }, req => capturedRequest = req, isSse: true);
+        var sut = CreateA2AClient(new AgentMessage() { MessageId = "id-1", Role = MessageRole.User, Parts = [] }, (_, body) => capturedBody = body, isSse: true);
 
         var taskId = "task-123";
 
@@ -522,9 +522,9 @@ public class A2AClientTests
         }
 
         // Assert
-        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedBody);
 
-        var requestJson = JsonDocument.Parse(await capturedRequest.Content!.ReadAsStringAsync());
+        var requestJson = JsonDocument.Parse(capturedBody);
         Assert.Equal("tasks/resubscribe", requestJson.RootElement.GetProperty("method").GetString());
         Assert.True(Guid.TryParse(requestJson.RootElement.GetProperty("id").GetString(), out _));
 
@@ -633,7 +633,7 @@ public class A2AClientTests
 
         var sut = CreateA2AClient(
             new AgentMessage { MessageId = "id-1", Role = MessageRole.Agent, Parts = [] },
-            req => capturedRequest = req,
+            (req, _) => capturedRequest = req,
             configureRequest: configureRequest);
 
         var sendParams = new MessageSendParams
@@ -667,7 +667,7 @@ public class A2AClientTests
 
         var sut = CreateA2AClient(
             new AgentMessage { MessageId = "id-1", Role = MessageRole.Agent, Parts = [] },
-            req => capturedRequest = req,
+            (req, _) => capturedRequest = req,
             isSse: true,
             configureRequest: configureRequest);
 
@@ -700,7 +700,7 @@ public class A2AClientTests
 
         var sut = CreateA2AClient(
             new AgentMessage { MessageId = "id-1", Role = MessageRole.Agent, Parts = [] },
-            _ => requestSent = true,
+            (_, _) => requestSent = true,
             configureRequest: configureRequest);
 
         var sendParams = new MessageSendParams
@@ -714,7 +714,7 @@ public class A2AClientTests
         Assert.False(requestSent);
     }
 
-    private static A2AClient CreateA2AClient(object result, Action<HttpRequestMessage>? onRequest = null, bool isSse = false, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
+    private static A2AClient CreateA2AClient(object result, Action<HttpRequestMessage, string?>? onRequest = null, bool isSse = false, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {
         var response = new JsonRpcResponse
         {
@@ -725,7 +725,7 @@ public class A2AClientTests
         return CreateA2AClient(response, onRequest, isSse, configureRequest);
     }
 
-    private static A2AClient CreateA2AClient(JsonRpcResponse jsonResponse, Action<HttpRequestMessage>? onRequest = null, bool isSse = false, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
+    private static A2AClient CreateA2AClient(JsonRpcResponse jsonResponse, Action<HttpRequestMessage, string?>? onRequest = null, bool isSse = false, Func<HttpRequestMessage, CancellationToken, Task>? configureRequest = null)
     {
         var responseContent = JsonSerializer.Serialize(jsonResponse);
 

--- a/tests/A2A.V0_3.UnitTests/MockHttpMessageHandler.cs
+++ b/tests/A2A.V0_3.UnitTests/MockHttpMessageHandler.cs
@@ -3,16 +3,23 @@ namespace A2A.V0_3.UnitTests;
 public class MockHttpMessageHandler : HttpMessageHandler
 {
     private readonly HttpResponseMessage _response;
-    private readonly Action<HttpRequestMessage>? _capture;
+    private readonly Action<HttpRequestMessage, string?>? _capture;
 
-    public MockHttpMessageHandler(HttpResponseMessage response, Action<HttpRequestMessage>? capture = null)
+    public MockHttpMessageHandler(HttpResponseMessage response, Action<HttpRequestMessage, string?>? capture = null)
     {
         _response = response;
         _capture = capture;
     }
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        _capture?.Invoke(request);
-        return Task.FromResult(_response);
+        string? body = null;
+        if (request.Content is not null)
+        {
+            body = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        _capture?.Invoke(request, body);
+        return _response;
     }
 }


### PR DESCRIPTION
## Summary
  - Adds an optional `Func<HttpRequestMessage, CancellationToken, Task>? configureRequest` parameter to the `A2AClient`
  constructors in both `A2A` and `A2A.V0_3`. When provided, it is invoked for every outgoing `HttpRequestMessage` (unary
   and SSE/streaming) just before `HttpClient.SendAsync`, allowing callers to attach authentication headers or other per-request customizations asynchronously.
  - Removes the need to subclass `A2AClient` to inject per-request headers.

## Tests
  - Adds unit tests covering: callback invocation + header propagation on unary requests, invocation + header
  propagation on streaming requests, and exception propagation (which prevents the request from being sent).
- Refactors the V0_3 `MockHttpMessageHandler` capture delegate from `Action<HttpRequestMessage>?` to
  `Action<HttpRequestMessage, string?>?`. The handler now reads the request body once and passes both the request and  the body string to the callback. This was needed because the V0_3 client now disposes `HttpRequestMessage` via `using`, which would otherwise dispose the content before tests could read it.

  ## Notes
  - The new parameter is optional with a `null` default, so existing callers are unaffected (source- and
  binary-compatible at the call-site level).
  - Callback runs after the library has set default headers (e.g. `A2A-Version`, `Accept`) so callers can override them
  if needed.