### PR TITLE
feat: support v0.3 agent card parsing in A2ACardResolver

### DIFF
--- a/src/A2A/Client/A2ACardResolver.cs
+++ b/src/A2A/Client/A2ACardResolver.cs
@@ -76,12 +76,9 @@ public sealed class A2ACardResolver
                 return JsonSerializer.Deserialize(bytes, A2AJsonUtilities.JsonContext.Default.AgentCard)
                     ?? throw new A2AException("Failed to parse agent card JSON.");
             }
-            catch (JsonException ex) when (ex.Message.Contains("supportedInterfaces") ||
-                                           ex.Message.Contains("skills") ||
-                                           ex.Message.Contains("defaultInputModes") ||
-                                           ex.Message.Contains("defaultOutputModes"))
+            catch (JsonException ex)
             {
-                // The card is missing v1.0 required properties — attempt v0.3 upcast
+                // v1.0 deserialization failed — attempt v0.3 upcast
                 _logger.AttemptingV03AgentCardUpcast(ex);
                 return UpcastV03AgentCard(bytes)
                     ?? throw new A2AException($"Failed to parse JSON: {ex.Message}");
@@ -114,6 +111,11 @@ public sealed class A2ACardResolver
         using var doc = JsonDocument.Parse(bytes);
         var root = doc.RootElement;
 
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
         // v0.3 cards MUST have a "url" property
         if (!root.TryGetProperty("url", out var urlElement) || urlElement.ValueKind != JsonValueKind.String)
         {
@@ -126,13 +128,19 @@ public sealed class A2ACardResolver
             return null;
         }
 
+        // v0.3 cards MUST have a top-level "protocolVersion" — use as a discriminator since we only reach here after v1.0 deserialization failed
+        if (!root.TryGetProperty("protocolVersion", out var pvElement) || pvElement.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
         // Determine the protocol binding from preferredTransport (defaults to JSONRPC)
         var protocolBinding = ProtocolBindingNames.JsonRpc;
         if (root.TryGetProperty("preferredTransport", out var transportElement))
         {
             var transport = transportElement.ValueKind == JsonValueKind.String
                 ? transportElement.GetString()
-                : transportElement.ValueKind == JsonValueKind.Object && transportElement.TryGetProperty("value", out var val)
+                : transportElement.ValueKind == JsonValueKind.Object && transportElement.TryGetProperty("value", out var val) && val.ValueKind == JsonValueKind.String
                     ? val.GetString()
                     : null;
 
@@ -155,7 +163,7 @@ public sealed class A2ACardResolver
             {
                 ProtocolBinding = protocolBinding,
                 Url = url,
-                ProtocolVersion = root.TryGetProperty("protocolVersion", out var pv) ? pv.GetString() ?? "0.3" : "0.3",
+                ProtocolVersion = pvElement.GetString() ?? "0.3",
             }
         };
 
@@ -175,9 +183,9 @@ public sealed class A2ACardResolver
         // Extract common fields
         var card = new AgentCard
         {
-            Name = root.TryGetProperty("name", out var name) ? name.GetString() ?? "" : "",
-            Description = root.TryGetProperty("description", out var desc) ? desc.GetString() ?? "" : "",
-            Version = root.TryGetProperty("version", out var ver) ? ver.GetString() ?? "0.3" : "0.3",
+            Name = root.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String ? name.GetString() ?? "" : "",
+            Description = root.TryGetProperty("description", out var desc) && desc.ValueKind == JsonValueKind.String ? desc.GetString() ?? "" : "",
+            Version = root.TryGetProperty("version", out var ver) && ver.ValueKind == JsonValueKind.String ? ver.GetString() ?? "0.3" : "0.3",
             SupportedInterfaces = interfaces,
             Capabilities = new AgentCapabilities(),
             DefaultInputModes = ["text/plain"],
@@ -224,9 +232,9 @@ public sealed class A2ACardResolver
             }
         }
 
-        if (root.TryGetProperty("documentationUrl", out var docUrl))
+        if (root.TryGetProperty("documentationUrl", out var docUrl) && docUrl.ValueKind == JsonValueKind.String)
             card.DocumentationUrl = docUrl.GetString();
-        if (root.TryGetProperty("iconUrl", out var iconUrl))
+        if (root.TryGetProperty("iconUrl", out var iconUrl) && iconUrl.ValueKind == JsonValueKind.String)
             card.IconUrl = iconUrl.GetString();
 
         return card;

--- a/src/A2A/Client/A2ACardResolver.cs
+++ b/src/A2A/Client/A2ACardResolver.cs
@@ -68,10 +68,24 @@ public sealed class A2ACardResolver
 
             response.EnsureSuccessStatusCode();
 
-            using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            // Buffer the response so we can attempt multiple deserialization strategies
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 
-            return await JsonSerializer.DeserializeAsync(responseStream, A2AJsonUtilities.JsonContext.Default.AgentCard, cancellationToken).ConfigureAwait(false) ??
-                throw new A2AException("Failed to parse agent card JSON.");
+            try
+            {
+                return JsonSerializer.Deserialize(bytes, A2AJsonUtilities.JsonContext.Default.AgentCard)
+                    ?? throw new A2AException("Failed to parse agent card JSON.");
+            }
+            catch (JsonException ex) when (ex.Message.Contains("supportedInterfaces") ||
+                                           ex.Message.Contains("skills") ||
+                                           ex.Message.Contains("defaultInputModes") ||
+                                           ex.Message.Contains("defaultOutputModes"))
+            {
+                // The card is missing v1.0 required properties — attempt v0.3 upcast
+                _logger.AttemptingV03AgentCardUpcast(ex);
+                return UpcastV03AgentCard(bytes)
+                    ?? throw new A2AException($"Failed to parse JSON: {ex.Message}");
+            }
         }
         catch (JsonException ex)
         {
@@ -87,5 +101,134 @@ public sealed class A2ACardResolver
             _logger.HttpRequestFailedWithStatusCode(ex, statusCode);
             throw new A2AException("HTTP request failed", ex);
         }
+    }
+
+    /// <summary>
+    /// Attempts to parse a v0.3 agent card and upcast it to a v1.0 <see cref="AgentCard"/>.
+    /// A v0.3 card has a top-level "url" and optional "preferredTransport" instead of "supportedInterfaces".
+    /// </summary>
+    /// <param name="bytes">The raw JSON bytes of the agent card response.</param>
+    /// <returns>An upcast v1.0 <see cref="AgentCard"/> if the JSON is a valid v0.3 card; otherwise <c>null</c>.</returns>
+    private static AgentCard? UpcastV03AgentCard(byte[] bytes)
+    {
+        using var doc = JsonDocument.Parse(bytes);
+        var root = doc.RootElement;
+
+        // v0.3 cards MUST have a "url" property
+        if (!root.TryGetProperty("url", out var urlElement) || urlElement.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var url = urlElement.GetString();
+        if (string.IsNullOrEmpty(url))
+        {
+            return null;
+        }
+
+        // Determine the protocol binding from preferredTransport (defaults to JSONRPC)
+        var protocolBinding = ProtocolBindingNames.JsonRpc;
+        if (root.TryGetProperty("preferredTransport", out var transportElement))
+        {
+            var transport = transportElement.ValueKind == JsonValueKind.String
+                ? transportElement.GetString()
+                : transportElement.ValueKind == JsonValueKind.Object && transportElement.TryGetProperty("value", out var val)
+                    ? val.GetString()
+                    : null;
+
+            if (!string.IsNullOrEmpty(transport))
+            {
+                protocolBinding = transport.ToUpperInvariant() switch
+                {
+                    "JSONRPC" or "JSON-RPC" => ProtocolBindingNames.JsonRpc,
+                    "HTTP+JSON" or "HTTP_JSON" or "REST" => ProtocolBindingNames.HttpJson,
+                    "GRPC" => ProtocolBindingNames.Grpc,
+                    _ => transport
+                };
+            }
+        }
+
+        // Build the supportedInterfaces list from the v0.3 url + preferredTransport
+        var interfaces = new List<AgentInterface>
+        {
+            new()
+            {
+                ProtocolBinding = protocolBinding,
+                Url = url,
+                ProtocolVersion = root.TryGetProperty("protocolVersion", out var pv) ? pv.GetString() ?? "0.3" : "0.3",
+            }
+        };
+
+        // Also include additionalInterfaces if present (a v0.3 extension)
+        if (root.TryGetProperty("additionalInterfaces", out var addlInterfaces) && addlInterfaces.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var iface in addlInterfaces.EnumerateArray())
+            {
+                var ai = JsonSerializer.Deserialize(iface.GetRawText(), A2AJsonUtilities.JsonContext.Default.AgentInterface);
+                if (ai is not null)
+                {
+                    interfaces.Add(ai);
+                }
+            }
+        }
+
+        // Extract common fields
+        var card = new AgentCard
+        {
+            Name = root.TryGetProperty("name", out var name) ? name.GetString() ?? "" : "",
+            Description = root.TryGetProperty("description", out var desc) ? desc.GetString() ?? "" : "",
+            Version = root.TryGetProperty("version", out var ver) ? ver.GetString() ?? "0.3" : "0.3",
+            SupportedInterfaces = interfaces,
+            Capabilities = new AgentCapabilities(),
+            DefaultInputModes = ["text/plain"],
+            DefaultOutputModes = ["text/plain"],
+            Skills = [],
+        };
+
+        // Parse capabilities
+        if (root.TryGetProperty("capabilities", out var caps) && caps.ValueKind == JsonValueKind.Object)
+        {
+            if (caps.TryGetProperty("streaming", out var streaming))
+                card.Capabilities.Streaming = streaming.ValueKind == JsonValueKind.True;
+            if (caps.TryGetProperty("pushNotifications", out var push))
+                card.Capabilities.PushNotifications = push.ValueKind == JsonValueKind.True;
+        }
+
+        // Parse default modes if present
+        if (root.TryGetProperty("defaultInputModes", out var inputModes) && inputModes.ValueKind == JsonValueKind.Array)
+        {
+            card.DefaultInputModes = inputModes.EnumerateArray()
+                .Where(e => e.ValueKind == JsonValueKind.String)
+                .Select(e => e.GetString()!)
+                .ToList();
+        }
+
+        if (root.TryGetProperty("defaultOutputModes", out var outputModes) && outputModes.ValueKind == JsonValueKind.Array)
+        {
+            card.DefaultOutputModes = outputModes.EnumerateArray()
+                .Where(e => e.ValueKind == JsonValueKind.String)
+                .Select(e => e.GetString()!)
+                .ToList();
+        }
+
+        // Parse skills if present
+        if (root.TryGetProperty("skills", out var skills) && skills.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var skillElement in skills.EnumerateArray())
+            {
+                var skill = JsonSerializer.Deserialize(skillElement.GetRawText(), A2AJsonUtilities.JsonContext.Default.AgentSkill);
+                if (skill is not null)
+                {
+                    card.Skills.Add(skill);
+                }
+            }
+        }
+
+        if (root.TryGetProperty("documentationUrl", out var docUrl))
+            card.DocumentationUrl = docUrl.GetString();
+        if (root.TryGetProperty("iconUrl", out var iconUrl))
+            card.IconUrl = iconUrl.GetString();
+
+        return card;
     }
 }

--- a/src/A2A/Client/A2ACardResolver.cs
+++ b/src/A2A/Client/A2ACardResolver.cs
@@ -134,25 +134,16 @@ public sealed class A2ACardResolver
             return null;
         }
 
+        var protocolVersion = pvElement.GetString() ?? "0.3";
+
         // Determine the protocol binding from preferredTransport (defaults to JSONRPC)
         var protocolBinding = ProtocolBindingNames.JsonRpc;
         if (root.TryGetProperty("preferredTransport", out var transportElement))
         {
-            var transport = transportElement.ValueKind == JsonValueKind.String
-                ? transportElement.GetString()
-                : transportElement.ValueKind == JsonValueKind.Object && transportElement.TryGetProperty("value", out var val) && val.ValueKind == JsonValueKind.String
-                    ? val.GetString()
-                    : null;
-
+            var transport = ExtractTransportName(transportElement);
             if (!string.IsNullOrEmpty(transport))
             {
-                protocolBinding = transport.ToUpperInvariant() switch
-                {
-                    "JSONRPC" or "JSON-RPC" => ProtocolBindingNames.JsonRpc,
-                    "HTTP+JSON" or "HTTP_JSON" or "REST" => ProtocolBindingNames.HttpJson,
-                    "GRPC" => ProtocolBindingNames.Grpc,
-                    _ => transport
-                };
+                protocolBinding = MapV03TransportToBinding(transport!);
             }
         }
 
@@ -163,20 +154,51 @@ public sealed class A2ACardResolver
             {
                 ProtocolBinding = protocolBinding,
                 Url = url,
-                ProtocolVersion = pvElement.GetString() ?? "0.3",
+                ProtocolVersion = protocolVersion,
             }
         };
 
-        // Also include additionalInterfaces if present (a v0.3 extension)
+        // Also include additionalInterfaces if present.
+        // v0.3 entries have shape { "transport": "...", "url": "..." }, which does not
+        // match v1's AgentInterface shape { "url", "protocolBinding", "protocolVersion" }.
+        // Map explicitly so HTTP+JSON / GRPC bindings are preserved rather than silently
+        // defaulted to JSONRPC by the v1 deserializer.
         if (root.TryGetProperty("additionalInterfaces", out var addlInterfaces) && addlInterfaces.ValueKind == JsonValueKind.Array)
         {
             foreach (var iface in addlInterfaces.EnumerateArray())
             {
-                var ai = JsonSerializer.Deserialize(iface.GetRawText(), A2AJsonUtilities.JsonContext.Default.AgentInterface);
-                if (ai is not null)
+                if (iface.ValueKind != JsonValueKind.Object)
                 {
-                    interfaces.Add(ai);
+                    continue;
                 }
+
+                if (!iface.TryGetProperty("url", out var ifaceUrlElement) || ifaceUrlElement.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                var ifaceUrl = ifaceUrlElement.GetString();
+                if (string.IsNullOrEmpty(ifaceUrl))
+                {
+                    continue;
+                }
+
+                var ifaceBinding = ProtocolBindingNames.JsonRpc;
+                if (iface.TryGetProperty("transport", out var ifaceTransportElement))
+                {
+                    var ifaceTransport = ExtractTransportName(ifaceTransportElement);
+                    if (!string.IsNullOrEmpty(ifaceTransport))
+                    {
+                        ifaceBinding = MapV03TransportToBinding(ifaceTransport!);
+                    }
+                }
+
+                interfaces.Add(new AgentInterface
+                {
+                    Url = ifaceUrl!,
+                    ProtocolBinding = ifaceBinding,
+                    ProtocolVersion = protocolVersion,
+                });
             }
         }
 
@@ -239,4 +261,34 @@ public sealed class A2ACardResolver
 
         return card;
     }
+
+    /// <summary>
+    /// Extracts a transport name from a v0.3 transport JSON element. v0.3 uses a string
+    /// (e.g. "JSONRPC"), but some producers wrap it as { "value": "JSONRPC" }.
+    /// </summary>
+    /// <param name="element">The JSON element to inspect.</param>
+    /// <returns>The transport name, or <c>null</c> if none could be extracted.</returns>
+    private static string? ExtractTransportName(JsonElement element) =>
+        element.ValueKind == JsonValueKind.String
+            ? element.GetString()
+            : element.ValueKind == JsonValueKind.Object
+              && element.TryGetProperty("value", out var val)
+              && val.ValueKind == JsonValueKind.String
+                ? val.GetString()
+                : null;
+
+    /// <summary>
+    /// Maps a v0.3 transport name to a v1 protocol binding name.
+    /// Unknown values are passed through so custom bindings still round-trip.
+    /// </summary>
+    /// <param name="transport">The v0.3 transport name.</param>
+    /// <returns>The corresponding v1 protocol binding name.</returns>
+    private static string MapV03TransportToBinding(string transport) =>
+        transport.ToUpperInvariant() switch
+        {
+            "JSONRPC" or "JSON-RPC" => ProtocolBindingNames.JsonRpc,
+            "HTTP+JSON" or "HTTP_JSON" or "REST" => ProtocolBindingNames.HttpJson,
+            "GRPC" => ProtocolBindingNames.Grpc,
+            _ => transport,
+        };
 }

--- a/src/A2A/Client/A2ACardResolver.cs
+++ b/src/A2A/Client/A2ACardResolver.cs
@@ -259,6 +259,73 @@ public sealed class A2ACardResolver
         if (root.TryGetProperty("iconUrl", out var iconUrl) && iconUrl.ValueKind == JsonValueKind.String)
             card.IconUrl = iconUrl.GetString();
 
+        // Provider — same shape in v0.3 and v1 ({ organization, url })
+        if (root.TryGetProperty("provider", out var provider) && provider.ValueKind == JsonValueKind.Object)
+        {
+            card.Provider = JsonSerializer.Deserialize(provider.GetRawText(), A2AJsonUtilities.JsonContext.Default.AgentProvider);
+        }
+
+        // Signatures — same shape in v0.3 and v1
+        if (root.TryGetProperty("signatures", out var signatures) && signatures.ValueKind == JsonValueKind.Array)
+        {
+            card.Signatures = [];
+            foreach (var sigElement in signatures.EnumerateArray())
+            {
+                var sig = JsonSerializer.Deserialize(sigElement.GetRawText(), A2AJsonUtilities.JsonContext.Default.AgentCardSignature);
+                if (sig is not null)
+                {
+                    card.Signatures.Add(sig);
+                }
+            }
+        }
+
+        // SecuritySchemes — v0.3 uses a polymorphic type discriminator ("type": "apiKey"|"http"|...),
+        // while v1 uses a flat container with optional sub-scheme fields. Deserialize each entry
+        // as v0.3, then map to v1's flat shape.
+        if (root.TryGetProperty("securitySchemes", out var schemes) && schemes.ValueKind == JsonValueKind.Object)
+        {
+            card.SecuritySchemes = [];
+            foreach (var prop in schemes.EnumerateObject())
+            {
+                var v1Scheme = MapV03SecurityScheme(prop.Value);
+                if (v1Scheme is not null)
+                {
+                    card.SecuritySchemes[prop.Name] = v1Scheme;
+                }
+            }
+        }
+
+        // Security — v0.3 uses List<Dictionary<string, string[]>>,
+        // v1 uses List<SecurityRequirement> where each has a Schemes dictionary.
+        if (root.TryGetProperty("security", out var security) && security.ValueKind == JsonValueKind.Array)
+        {
+            card.SecurityRequirements = [];
+            foreach (var reqElement in security.EnumerateArray())
+            {
+                if (reqElement.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                var requirement = new SecurityRequirement { Schemes = [] };
+                foreach (var prop in reqElement.EnumerateObject())
+                {
+                    var scopes = new StringList();
+                    if (prop.Value.ValueKind == JsonValueKind.Array)
+                    {
+                        scopes.List = prop.Value.EnumerateArray()
+                            .Where(e => e.ValueKind == JsonValueKind.String)
+                            .Select(e => e.GetString()!)
+                            .ToList();
+                    }
+
+                    requirement.Schemes[prop.Name] = scopes;
+                }
+
+                card.SecurityRequirements.Add(requirement);
+            }
+        }
+
         return card;
     }
 
@@ -291,4 +358,70 @@ public sealed class A2ACardResolver
             "GRPC" => ProtocolBindingNames.Grpc,
             _ => transport,
         };
+
+    /// <summary>
+    /// Maps a v0.3 polymorphic SecurityScheme (discriminated by "type") to a v1 flat SecurityScheme container.
+    /// </summary>
+    /// <param name="element">A <see cref="JsonElement"/> representing a single v0.3 security scheme entry.</param>
+    private static SecurityScheme? MapV03SecurityScheme(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (!element.TryGetProperty("type", out var typeElement) || typeElement.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var type = typeElement.GetString();
+        var scheme = new SecurityScheme();
+
+        switch (type)
+        {
+            case "apiKey":
+                scheme.ApiKeySecurityScheme = new ApiKeySecurityScheme
+                {
+                    Name = element.TryGetProperty("name", out var name) ? name.GetString() ?? string.Empty : string.Empty,
+                    Location = element.TryGetProperty("in", out var location) ? location.GetString() ?? string.Empty : string.Empty,
+                    Description = element.TryGetProperty("description", out var akDesc) ? akDesc.GetString() : null,
+                };
+                break;
+
+            case "http":
+                scheme.HttpAuthSecurityScheme = new HttpAuthSecurityScheme
+                {
+                    Scheme = element.TryGetProperty("scheme", out var httpScheme) ? httpScheme.GetString() ?? string.Empty : string.Empty,
+                    BearerFormat = element.TryGetProperty("bearerFormat", out var bf) ? bf.GetString() : null,
+                    Description = element.TryGetProperty("description", out var httpDesc) ? httpDesc.GetString() : null,
+                };
+                break;
+
+            case "oauth2":
+                scheme.OAuth2SecurityScheme = JsonSerializer.Deserialize(
+                    element.GetRawText(), A2AJsonUtilities.JsonContext.Default.OAuth2SecurityScheme);
+                break;
+
+            case "openIdConnect":
+                scheme.OpenIdConnectSecurityScheme = new OpenIdConnectSecurityScheme
+                {
+                    OpenIdConnectUrl = element.TryGetProperty("openIdConnectUrl", out var oidcUrl) ? oidcUrl.GetString() ?? string.Empty : string.Empty,
+                    Description = element.TryGetProperty("description", out var oidcDesc) ? oidcDesc.GetString() : null,
+                };
+                break;
+
+            case "mutualTLS":
+                scheme.MtlsSecurityScheme = new MutualTlsSecurityScheme
+                {
+                    Description = element.TryGetProperty("description", out var mtlsDesc) ? mtlsDesc.GetString() : null,
+                };
+                break;
+
+            default:
+                return null;
+        }
+
+        return scheme;
+    }
 }

--- a/src/A2A/Log.cs
+++ b/src/A2A/Log.cs
@@ -17,7 +17,7 @@ namespace A2A
         [LoggerMessage(2, LogLevel.Error, "HTTP request failed with status code {StatusCode}")]
         internal static partial void HttpRequestFailedWithStatusCode(this ILogger logger, Exception exception, System.Net.HttpStatusCode StatusCode);
 
-        [LoggerMessage(5, LogLevel.Information, "Agent card missing v1.0 required properties, attempting v0.3 upcast")]
+        [LoggerMessage(5, LogLevel.Information, "V1.0 agent card deserialization failed, attempting v0.3 upcast")]
         internal static partial void AttemptingV03AgentCardUpcast(this ILogger logger, Exception exception);
 
         [LoggerMessage(3, LogLevel.Error, "Background event processing failed for task {TaskId}")]

--- a/src/A2A/Log.cs
+++ b/src/A2A/Log.cs
@@ -17,6 +17,9 @@ namespace A2A
         [LoggerMessage(2, LogLevel.Error, "HTTP request failed with status code {StatusCode}")]
         internal static partial void HttpRequestFailedWithStatusCode(this ILogger logger, Exception exception, System.Net.HttpStatusCode StatusCode);
 
+        [LoggerMessage(5, LogLevel.Information, "Agent card missing v1.0 required properties, attempting v0.3 upcast")]
+        internal static partial void AttemptingV03AgentCardUpcast(this ILogger logger, Exception exception);
+
         [LoggerMessage(3, LogLevel.Error, "Background event processing failed for task {TaskId}")]
         internal static partial void BackgroundEventProcessingFailed(this ILogger logger, Exception exception, string TaskId);
 

--- a/tests/A2A.UnitTests/Client/A2ACardResolverV03UpcastTests.cs
+++ b/tests/A2A.UnitTests/Client/A2ACardResolverV03UpcastTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Text;
+
+namespace A2A.UnitTests.Client;
+
+/// <summary>
+/// Tests for the v0.3 → v1.0 agent card upcast fallback in <see cref="A2ACardResolver"/>.
+/// v0.3 cards use a top-level <c>url</c> + <c>preferredTransport</c> and an
+/// <c>additionalInterfaces</c> array of <c>{ transport, url }</c> objects, none of which
+/// match the v1.0 <c>supportedInterfaces</c> shape of <c>{ url, protocolBinding, protocolVersion }</c>.
+/// </summary>
+public class A2ACardResolverV03UpcastTests
+{
+    private static A2ACardResolver CreateResolver(string cardJson)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(cardJson, Encoding.UTF8, "application/json"),
+        };
+        var handler = new MockHttpMessageHandler(response);
+        var httpClient = new HttpClient(handler);
+        return new A2ACardResolver(new Uri("http://localhost"), httpClient);
+    }
+
+    [Fact]
+    public async Task UpcastsV03Card_MapsAdditionalInterfacesTransportAndProtocolVersion()
+    {
+        // A minimal but realistic v0.3 card with a JSONRPC primary interface and
+        // additional HTTP+JSON and GRPC interfaces. A v1.0 client that naively deserializes
+        // each entry as an AgentInterface would drop the "transport" field and default
+        // ProtocolBinding to JSONRPC, silently misrouting requests.
+        const string cardJson = """
+        {
+          "protocolVersion": "0.3",
+          "name": "Test Agent",
+          "description": "A v0.3 test agent",
+          "version": "1.0.0",
+          "url": "http://localhost/rpc",
+          "preferredTransport": "JSONRPC",
+          "additionalInterfaces": [
+            { "transport": "HTTP+JSON", "url": "http://localhost/http" },
+            { "transport": "GRPC",      "url": "http://localhost/grpc" }
+          ],
+          "capabilities": { "streaming": true, "pushNotifications": false },
+          "defaultInputModes": ["text/plain"],
+          "defaultOutputModes": ["text/plain"],
+          "skills": []
+        }
+        """;
+
+        var resolver = CreateResolver(cardJson);
+
+        var card = await resolver.GetAgentCardAsync();
+
+        Assert.NotNull(card);
+        Assert.Equal(3, card.SupportedInterfaces.Count);
+
+        var primary = card.SupportedInterfaces[0];
+        Assert.Equal("http://localhost/rpc", primary.Url);
+        Assert.Equal(ProtocolBindingNames.JsonRpc, primary.ProtocolBinding);
+        Assert.Equal("0.3", primary.ProtocolVersion);
+
+        var http = card.SupportedInterfaces[1];
+        Assert.Equal("http://localhost/http", http.Url);
+        Assert.Equal(ProtocolBindingNames.HttpJson, http.ProtocolBinding);
+        Assert.Equal("0.3", http.ProtocolVersion);
+
+        var grpc = card.SupportedInterfaces[2];
+        Assert.Equal("http://localhost/grpc", grpc.Url);
+        Assert.Equal(ProtocolBindingNames.Grpc, grpc.ProtocolBinding);
+        Assert.Equal("0.3", grpc.ProtocolVersion);
+    }
+
+    [Fact]
+    public async Task UpcastsV03Card_UnknownTransportPassesThrough()
+    {
+        // Custom / unknown transport strings should round-trip so custom protocol bindings
+        // are preserved rather than swallowed.
+        const string cardJson = """
+        {
+          "protocolVersion": "0.3",
+          "name": "Test Agent",
+          "description": "A v0.3 test agent",
+          "version": "1.0.0",
+          "url": "http://localhost/rpc",
+          "additionalInterfaces": [
+            { "transport": "WEBSOCKET", "url": "ws://localhost/ws" }
+          ],
+          "capabilities": {},
+          "defaultInputModes": ["text/plain"],
+          "defaultOutputModes": ["text/plain"],
+          "skills": []
+        }
+        """;
+
+        var resolver = CreateResolver(cardJson);
+
+        var card = await resolver.GetAgentCardAsync();
+
+        Assert.NotNull(card);
+        Assert.Equal(2, card.SupportedInterfaces.Count);
+        Assert.Equal("WEBSOCKET", card.SupportedInterfaces[1].ProtocolBinding);
+        Assert.Equal("ws://localhost/ws", card.SupportedInterfaces[1].Url);
+    }
+
+    [Fact]
+    public async Task UpcastsV03Card_SkipsMalformedAdditionalInterfaceEntries()
+    {
+        // Entries without a string url, or that aren't objects, must be skipped
+        // rather than throwing or producing invalid AgentInterface instances.
+        const string cardJson = """
+        {
+          "protocolVersion": "0.3",
+          "name": "Test Agent",
+          "description": "A v0.3 test agent",
+          "version": "1.0.0",
+          "url": "http://localhost/rpc",
+          "additionalInterfaces": [
+            { "transport": "HTTP+JSON", "url": "http://localhost/http" },
+            { "transport": "GRPC" },
+            "not-an-object",
+            { "transport": "HTTP+JSON", "url": 42 }
+          ],
+          "capabilities": {},
+          "defaultInputModes": ["text/plain"],
+          "defaultOutputModes": ["text/plain"],
+          "skills": []
+        }
+        """;
+
+        var resolver = CreateResolver(cardJson);
+
+        var card = await resolver.GetAgentCardAsync();
+
+        Assert.NotNull(card);
+        // primary + one valid additional
+        Assert.Equal(2, card.SupportedInterfaces.Count);
+        Assert.Equal("http://localhost/http", card.SupportedInterfaces[1].Url);
+        Assert.Equal(ProtocolBindingNames.HttpJson, card.SupportedInterfaces[1].ProtocolBinding);
+    }
+}

--- a/tests/A2A.UnitTests/Client/A2ACardResolverV03UpcastTests.cs
+++ b/tests/A2A.UnitTests/Client/A2ACardResolverV03UpcastTests.cs
@@ -104,6 +104,179 @@ public class A2ACardResolverV03UpcastTests
     }
 
     [Fact]
+    public async Task UpcastsV03Card_MapsProvider()
+    {
+        const string cardJson = """
+        {
+          "protocolVersion": "0.3",
+          "name": "Test Agent",
+          "description": "A v0.3 test agent",
+          "version": "1.0.0",
+          "url": "http://localhost/rpc",
+          "capabilities": {},
+          "defaultInputModes": ["text/plain"],
+          "defaultOutputModes": ["text/plain"],
+          "skills": [],
+          "provider": {
+            "organization": "Contoso",
+            "url": "https://contoso.com"
+          }
+        }
+        """;
+
+        var resolver = CreateResolver(cardJson);
+        var card = await resolver.GetAgentCardAsync();
+
+        Assert.NotNull(card);
+        Assert.NotNull(card.Provider);
+        Assert.Equal("Contoso", card.Provider.Organization);
+        Assert.Equal("https://contoso.com", card.Provider.Url);
+    }
+
+    [Fact]
+    public async Task UpcastsV03Card_MapsSignatures()
+    {
+        const string cardJson = """
+        {
+          "protocolVersion": "0.3",
+          "name": "Test Agent",
+          "description": "A v0.3 test agent",
+          "version": "1.0.0",
+          "url": "http://localhost/rpc",
+          "capabilities": {},
+          "defaultInputModes": ["text/plain"],
+          "defaultOutputModes": ["text/plain"],
+          "skills": [],
+          "signatures": [
+            {
+              "protected": "eyJhbGciOiJSUzI1NiJ9",
+              "signature": "abc123"
+            }
+          ]
+        }
+        """;
+
+        var resolver = CreateResolver(cardJson);
+        var card = await resolver.GetAgentCardAsync();
+
+        Assert.NotNull(card);
+        Assert.NotNull(card.Signatures);
+        Assert.Single(card.Signatures);
+        Assert.Equal("eyJhbGciOiJSUzI1NiJ9", card.Signatures[0].Protected);
+        Assert.Equal("abc123", card.Signatures[0].Signature);
+    }
+
+    [Fact]
+    public async Task UpcastsV03Card_MapsSecuritySchemes()
+    {
+        // v0.3 securitySchemes use polymorphic discriminator on "type".
+        // v1 uses a flat container with optional sub-scheme properties.
+        const string cardJson = """
+        {
+          "protocolVersion": "0.3",
+          "name": "Test Agent",
+          "description": "A v0.3 test agent",
+          "version": "1.0.0",
+          "url": "http://localhost/rpc",
+          "capabilities": {},
+          "defaultInputModes": ["text/plain"],
+          "defaultOutputModes": ["text/plain"],
+          "skills": [],
+          "securitySchemes": {
+            "apiKeyAuth": {
+              "type": "apiKey",
+              "name": "X-API-Key",
+              "in": "header",
+              "description": "API key auth"
+            },
+            "bearerAuth": {
+              "type": "http",
+              "scheme": "bearer",
+              "bearerFormat": "JWT"
+            },
+            "oidcAuth": {
+              "type": "openIdConnect",
+              "openIdConnectUrl": "https://auth.example.com/.well-known/openid-configuration"
+            },
+            "mtlsAuth": {
+              "type": "mutualTLS",
+              "description": "mTLS"
+            }
+          }
+        }
+        """;
+
+        var resolver = CreateResolver(cardJson);
+        var card = await resolver.GetAgentCardAsync();
+
+        Assert.NotNull(card);
+        Assert.NotNull(card.SecuritySchemes);
+        Assert.Equal(4, card.SecuritySchemes.Count);
+
+        // API Key
+        var apiKey = card.SecuritySchemes["apiKeyAuth"];
+        Assert.NotNull(apiKey.ApiKeySecurityScheme);
+        Assert.Equal("X-API-Key", apiKey.ApiKeySecurityScheme.Name);
+        Assert.Equal("header", apiKey.ApiKeySecurityScheme.Location);
+        Assert.Equal("API key auth", apiKey.ApiKeySecurityScheme.Description);
+
+        // HTTP Bearer
+        var bearer = card.SecuritySchemes["bearerAuth"];
+        Assert.NotNull(bearer.HttpAuthSecurityScheme);
+        Assert.Equal("bearer", bearer.HttpAuthSecurityScheme.Scheme);
+        Assert.Equal("JWT", bearer.HttpAuthSecurityScheme.BearerFormat);
+
+        // OpenID Connect
+        var oidc = card.SecuritySchemes["oidcAuth"];
+        Assert.NotNull(oidc.OpenIdConnectSecurityScheme);
+        Assert.Equal("https://auth.example.com/.well-known/openid-configuration", oidc.OpenIdConnectSecurityScheme.OpenIdConnectUrl);
+
+        // Mutual TLS
+        var mtls = card.SecuritySchemes["mtlsAuth"];
+        Assert.NotNull(mtls.MtlsSecurityScheme);
+        Assert.Equal("mTLS", mtls.MtlsSecurityScheme.Description);
+    }
+
+    [Fact]
+    public async Task UpcastsV03Card_MapsSecurity()
+    {
+        // v0.3 security is List<Dictionary<string, string[]>>,
+        // v1 is List<SecurityRequirement> with Schemes dictionary.
+        const string cardJson = """
+        {
+          "protocolVersion": "0.3",
+          "name": "Test Agent",
+          "description": "A v0.3 test agent",
+          "version": "1.0.0",
+          "url": "http://localhost/rpc",
+          "capabilities": {},
+          "defaultInputModes": ["text/plain"],
+          "defaultOutputModes": ["text/plain"],
+          "skills": [],
+          "security": [
+            {
+              "bearerAuth": ["read", "write"],
+              "apiKeyAuth": []
+            }
+          ]
+        }
+        """;
+
+        var resolver = CreateResolver(cardJson);
+        var card = await resolver.GetAgentCardAsync();
+
+        Assert.NotNull(card);
+        Assert.NotNull(card.SecurityRequirements);
+        Assert.Single(card.SecurityRequirements);
+
+        var req = card.SecurityRequirements[0];
+        Assert.NotNull(req.Schemes);
+        Assert.Equal(2, req.Schemes.Count);
+        Assert.Equal(["read", "write"], req.Schemes["bearerAuth"].List);
+        Assert.Empty(req.Schemes["apiKeyAuth"].List);
+    }
+
+    [Fact]
     public async Task UpcastsV03Card_SkipsMalformedAdditionalInterfaceEntries()
     {
         // Entries without a string url, or that aren't objects, must be skipped


### PR DESCRIPTION
## Summary

Adds backward-compatible parsing of v0.3 agent cards in A2ACardResolver.

### Problem
v0.3 agents expose agent cards without supportedInterfaces (a required field in v1.0), causing deserialization failures when a v1.0 client resolves a v0.3 agent's card.

### Solution
A2ACardResolver now performs two-pass deserialization:
1. First attempts standard v1.0 parsing
2. On JsonException (missing required properties), falls back to UpcastV03AgentCard() which maps v0.3 properties (url, preferredTransport, protocolVersion, additionalInterfaces) into a valid v1.0 AgentCard

The upcast:
- Synthesizes supportedInterfaces from url + preferredTransport
- Preserves additionalInterfaces entries
- Adds sensible defaults for defaultInputModes/defaultOutputModes
- Logs a warning when upcast is triggered

### Testing
- All existing tests continue to pass
- ITK interoperability tests pass (4/5 scenarios)