### PR TITLE
fix: clone Metadata dictionary in TaskProjection.Apply

### DIFF
--- a/src/A2A/Server/TaskProjection.cs
+++ b/src/A2A/Server/TaskProjection.cs
@@ -45,7 +45,9 @@ public static class TaskProjection
             Status = current.Status,
             History = current.History,
             Artifacts = current.Artifacts is not null ? [.. current.Artifacts] : null,
-            Metadata = current.Metadata is not null ? new Dictionary<string, JsonElement>(current.Metadata) : null,
+            Metadata = current.Metadata is not null
+                ? new Dictionary<string, JsonElement>(current.Metadata, current.Metadata.Comparer)
+                : null,
         };
 
         if (streamEvent.StatusUpdate is { } su)

--- a/src/A2A/Server/TaskProjection.cs
+++ b/src/A2A/Server/TaskProjection.cs
@@ -35,6 +35,8 @@ public static class TaskProjection
 
         // Shallow copy so the caller's AgentTask reference is never mutated.
         // Artifacts list is copied because ApplyArtifact mutates it (Add/index-set).
+        // Metadata is copied so a caller holding the projected task cannot mutate
+        // the original task's Metadata dictionary through it.
         // History is not copied — every branch that touches it replaces the reference entirely.
         var result = new AgentTask
         {
@@ -43,7 +45,7 @@ public static class TaskProjection
             Status = current.Status,
             History = current.History,
             Artifacts = current.Artifacts is not null ? [.. current.Artifacts] : null,
-            Metadata = current.Metadata,
+            Metadata = current.Metadata is not null ? new Dictionary<string, JsonElement>(current.Metadata) : null,
         };
 
         if (streamEvent.StatusUpdate is { } su)

--- a/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
@@ -608,6 +608,40 @@ public class TaskProjectionTests
     }
 
     [Fact]
+    public void Apply_WithStatusUpdate_DoesNotShareMetadataReferenceWithOriginal()
+    {
+        // Arrange
+        var originalMetadata = new Dictionary<string, JsonElement>
+        {
+            ["key"] = JsonSerializer.SerializeToElement("val")
+        };
+        var task = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "c1",
+            Status = new TaskStatus { State = TaskState.Working },
+            Metadata = originalMetadata
+        };
+
+        // Act
+        var result = TaskProjection.Apply(task, new StreamResponse
+        {
+            StatusUpdate = new TaskStatusUpdateEvent
+            {
+                Status = new TaskStatus { State = TaskState.Completed }
+            }
+        });
+
+        // Assert: projected task has its own Metadata dictionary instance
+        Assert.NotSame(originalMetadata, result!.Metadata);
+        Assert.Equal(originalMetadata.Count, result.Metadata!.Count);
+
+        // Assert: mutating the copy does not affect the original
+        result.Metadata["new"] = JsonSerializer.SerializeToElement("new-val");
+        Assert.Single(originalMetadata);
+    }
+
+    [Fact]
     public void Apply_ReturnsNewAgentTaskInstance_OriginalUnmutated()
     {
         // Arrange

--- a/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
@@ -642,6 +642,38 @@ public class TaskProjectionTests
     }
 
     [Fact]
+    public void Apply_WithStatusUpdate_PreservesMetadataComparer()
+    {
+        // Arrange
+        var originalMetadata = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["key"] = JsonSerializer.SerializeToElement("val")
+        };
+        var task = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "c1",
+            Status = new TaskStatus { State = TaskState.Working },
+            Metadata = originalMetadata
+        };
+
+        // Act
+        var result = TaskProjection.Apply(task, new StreamResponse
+        {
+            StatusUpdate = new TaskStatusUpdateEvent
+            {
+                Status = new TaskStatus { State = TaskState.Completed }
+            }
+        });
+
+        // Assert: projected task's Metadata keeps a case-insensitive lookup working
+        Assert.True(result!.Metadata!.ContainsKey("KEY"));
+
+        // Assert: the comparer instance itself is preserved, not defaulted
+        Assert.Same(originalMetadata.Comparer, result.Metadata.Comparer);
+    }
+
+    [Fact]
     public void Apply_ReturnsNewAgentTaskInstance_OriginalUnmutated()
     {
         // Arrange


### PR DESCRIPTION
Fixes #400.

## Problem

`TaskProjection.Apply`'s shallow copy clones `Artifacts` but assigns `Metadata` by
reference, so a caller mutating the projected task's `Metadata` silently mutates the
original task too. This breaks the isolation the class's own doc comment promises:
"concurrent readers holding references to prior artifacts or history lists see
consistent snapshots."

## Fix

Clones `Metadata` into a new dictionary in `Apply`, matching how `Artifacts` is
already handled one line above and reusing the clone idiom already used in
`MergeMetadata`. Passes `current.Metadata.Comparer` through to the new dictionary
(per review) so a caller-supplied comparer, e.g. `StringComparer.OrdinalIgnoreCase`,
survives the clone rather than silently reverting to the default comparer.

## Tests

- `Apply_WithStatusUpdate_DoesNotShareMetadataReferenceWithOriginal`: the projected
  task's `Metadata` is a distinct instance, and mutating it does not affect the
  original.
- `Apply_WithStatusUpdate_PreservesMetadataComparer`: constructs `Metadata` with
  `StringComparer.OrdinalIgnoreCase` and asserts the projected task keeps a
  case-insensitive lookup working and the same comparer instance.

## Testing performed

No local .NET SDK in my primary environment, so built and tested on a separate
machine against a fresh clone of `main` (commit `8fe65cfaa6`), matching this repo's
CI exactly:

- `dotnet build ./src/A2ALibs.slnx --framework net8.0` (buildLibs net8.0 leg): succeeded, 0 warnings, 0 errors.
- `dotnet build --framework net10.0` + `dotnet test --no-build --framework net10.0` (buildSamples job, root `A2A.slnx`): all 4 test projects passed, 826/826 tests, including both new tests by name.
- Regression-proof, both fixes: reverted each fix individually while keeping its test, confirmed the test fails with the exact symptom the fix addresses (`Assert.NotSame` failure for the reference fix, `Assert.True` failure on the case-insensitive lookup for the comparer fix), then reapplied and confirmed green.