### PR TITLE
feat: Map JSON DataContent to Part.Data

### DIFF
--- a/src/A2A/Extensions/AIContentExtensions.cs
+++ b/src/A2A/Extensions/AIContentExtensions.cs
@@ -97,7 +97,7 @@ public static class AIContentExtensions
         {
             content = new DataContent(
                 JsonSerializer.SerializeToUtf8Bytes(data, A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonElement))),
-                "application/json");
+                IsJsonMediaType(part.MediaType) ? part.MediaType! : "application/json");
         }
 
         content ??= new AIContent();

--- a/src/A2A/Extensions/AIContentExtensions.cs
+++ b/src/A2A/Extensions/AIContentExtensions.cs
@@ -140,7 +140,15 @@ public static class AIContentExtensions
                 break;
 
             case DataContent dataContent:
-                part = Part.FromRaw(dataContent.Data.ToArray(), dataContent.MediaType);
+                if (IsJsonMediaType(dataContent.MediaType))
+                {
+                    part = Part.FromData(ParseJson(dataContent.Data));
+                    part.MediaType = dataContent.MediaType;
+                }
+                else
+                {
+                    part = Part.FromRaw(dataContent.Data.ToArray(), dataContent.MediaType);
+                }
                 break;
         }
 
@@ -160,5 +168,34 @@ public static class AIContentExtensions
         }
 
         return part;
+    }
+
+    private static bool IsJsonMediaType(string? mediaType)
+    {
+        if (mediaType is null)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> mediaTypeName = mediaType.AsSpan();
+
+        // "application/json; charset=utf-8" becomes "application/json".
+        int parameterIndex = mediaTypeName.IndexOf(';');
+        if (parameterIndex >= 0)
+        {
+            mediaTypeName = mediaTypeName[..parameterIndex];
+        }
+
+        mediaTypeName = mediaTypeName.Trim();
+
+        // Include structured syntax suffixes such as "application/problem+json".
+        return mediaTypeName.Equals("application/json", StringComparison.OrdinalIgnoreCase) ||
+            mediaTypeName.EndsWith("+json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static JsonElement ParseJson(ReadOnlyMemory<byte> data)
+    {
+        using JsonDocument document = JsonDocument.Parse(data);
+        return document.RootElement.Clone();
     }
 }

--- a/tests/A2A.UnitTests/Models/AIContentExtensionsTests.cs
+++ b/tests/A2A.UnitTests/Models/AIContentExtensionsTests.cs
@@ -150,13 +150,20 @@ namespace A2A.UnitTests.Models
             Assert.Equal("image/png", dc.MediaType);
         }
 
-        [Fact]
-        public void WhenDataPart_ToAIContent_ReturnsDataContent()
+        [Theory]
+        [InlineData(null, "application/json")]
+        [InlineData("text/plain", "application/json")]
+        [InlineData("application/json", "application/json")]
+        [InlineData("application/problem+json", "application/problem+json")]
+        [InlineData("Application/Json; charset=utf-8", "Application/Json; charset=utf-8")]
+        public void WhenDataPart_ToAIContent_ReturnsDataContent(string? mediaType, string expectedMediaType)
         {
             var part = Part.FromData(JsonSerializer.SerializeToElement(new { x = "y" }));
+            part.MediaType = mediaType;
             part.Metadata = new Dictionary<string, JsonElement> { ["m"] = JsonSerializer.SerializeToElement(123) };
             var content = part.ToAIContent();
-            Assert.IsType<DataContent>(content);
+            var dataContent = Assert.IsType<DataContent>(content);
+            Assert.Equal(expectedMediaType, dataContent.MediaType);
             Assert.NotNull(content.AdditionalProperties);
             Assert.True(content.AdditionalProperties!.TryGetValue("m", out var obj));
             Assert.True(obj is JsonElement je && je.GetInt32() == 123);

--- a/tests/A2A.UnitTests/Models/AIContentExtensionsTests.cs
+++ b/tests/A2A.UnitTests/Models/AIContentExtensionsTests.cs
@@ -207,6 +207,33 @@ namespace A2A.UnitTests.Models
             Assert.Equal("application/custom", part.MediaType);
         }
 
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("Application/Json; charset=utf-8")]
+        [InlineData("application/problem+json")]
+        public void ToPart_ConvertsJsonDataContentToStructuredData(string mediaType)
+        {
+            var payload = JsonSerializer.SerializeToUtf8Bytes(new { key = "value" });
+            var content = new DataContent(payload, mediaType);
+
+            var part = content.ToPart();
+
+            Assert.NotNull(part);
+            Assert.Null(part!.Raw);
+            Assert.Equal(PartContentCase.Data, part.ContentCase);
+            Assert.Equal("value", part.Data!.Value.GetProperty("key").GetString());
+            Assert.Equal(mediaType, part.MediaType);
+        }
+
+        [Fact]
+        public void ToPart_ThrowsForInvalidJsonDataContent()
+        {
+            var payload = "not json"u8.ToArray();
+            var content = new DataContent(payload, "application/json");
+
+            Assert.ThrowsAny<JsonException>(() => content.ToPart());
+        }
+
         [Fact]
         public void ToPart_TransfersAdditionalPropertiesToMetadata()
         {


### PR DESCRIPTION
## Summary

- map JSON `DataContent` payloads to structured `Part.Data` values
- recognize `application/json`, media type parameters, and `+json` suffixes
- preserve the original media type and surface invalid JSON
- keep non-JSON `DataContent` mapped to `Part.Raw`

## Tests

- `dotnet test tests\A2A.UnitTests\A2A.UnitTests.csproj --no-restore --filter "FullyQualifiedName~AIContentExtensionsTests" --verbosity quiet`

Fixes #447