### PR TITLE
fix: add owner/tenant isolation to ITaskStore to prevent cross-tenant task access

### DIFF
--- a/samples/AgentServer/FileTaskStore.cs
+++ b/samples/AgentServer/FileTaskStore.cs
@@ -14,11 +14,15 @@ namespace AgentServer;
 /// processes, has no atomic index updates, and performs full file scans for
 /// unindexed queries.</para>
 /// <para>
+/// Tasks are isolated per owner (tenant): each owner has its own directory so that
+/// tasks created under one owner are not visible to another. The shared default owner
+/// scope (<see cref="RequestContext.DefaultOwner"/>) is stored under the "default"
+/// directory, preserving unauthenticated behavior.
 /// Storage layout:
 /// <code>
 /// {baseDir}/
-///   tasks/{taskId}.json           — materialized AgentTask snapshot
-///   indexes/context_{id}.idx      — newline-delimited task IDs per context
+///   tasks/{owner}/{taskId}.json      — materialized AgentTask snapshot
+///   indexes/{owner}/context_{id}.idx — newline-delimited task IDs per context
 /// </code>
 /// </para>
 /// </remarks>
@@ -46,25 +50,26 @@ public sealed class FileTaskStore : ITaskStore
     }
 
     /// <inheritdoc />
-    public async Task<AgentTask?> GetTaskAsync(string taskId, CancellationToken cancellationToken = default)
+    public async Task<AgentTask?> GetTaskAsync(string taskId, string? owner = null, CancellationToken cancellationToken = default)
     {
-        return await ReadTaskAsync(taskId, cancellationToken).ConfigureAwait(false);
+        return await ReadTaskAsync(taskId, GetEffectiveOwner(owner), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task SaveTaskAsync(string taskId, AgentTask task, CancellationToken cancellationToken = default)
+    public async Task SaveTaskAsync(string taskId, AgentTask task, string? owner = null, CancellationToken cancellationToken = default)
     {
-        var taskLock = _taskLocks.GetOrAdd(taskId, _ => new SemaphoreSlim(1, 1));
+        var effectiveOwner = GetEffectiveOwner(owner);
+        var taskLock = _taskLocks.GetOrAdd($"{effectiveOwner}/{taskId}", _ => new SemaphoreSlim(1, 1));
         await taskLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
-            await WriteTaskAsync(taskId, task, cancellationToken).ConfigureAwait(false);
+            await WriteTaskAsync(taskId, effectiveOwner, task, cancellationToken).ConfigureAwait(false);
 
             // Update context index on save (idempotent)
             if (!string.IsNullOrEmpty(task.ContextId))
             {
-                await AppendToIndexAsync("context", task.ContextId, taskId, cancellationToken)
+                await AppendToIndexAsync("context", task.ContextId, taskId, effectiveOwner, cancellationToken)
                     .ConfigureAwait(false);
             }
         }
@@ -76,21 +81,23 @@ public sealed class FileTaskStore : ITaskStore
 
     /// <inheritdoc />
     /// <remarks>Not implemented in this sample. Throws <see cref="NotSupportedException"/>.</remarks>
-    public Task DeleteTaskAsync(string taskId, CancellationToken cancellationToken = default)
+    public Task DeleteTaskAsync(string taskId, string? owner = null, CancellationToken cancellationToken = default)
         => throw new NotSupportedException("Task deletion is not supported by this sample store.");
 
     /// <inheritdoc />
     public async Task<ListTasksResponse> ListTasksAsync(ListTasksRequest request,
-        CancellationToken cancellationToken = default)
+        string? owner = null, CancellationToken cancellationToken = default)
     {
+        var effectiveOwner = GetEffectiveOwner(owner);
+
         // Step 1: Find candidate task IDs from index files
-        var taskIds = await GetTaskIdsForQueryAsync(request, cancellationToken).ConfigureAwait(false);
+        var taskIds = await GetTaskIdsForQueryAsync(request, effectiveOwner, cancellationToken).ConfigureAwait(false);
 
         // Step 2: Load tasks for candidates
         var tasks = new List<AgentTask>();
         foreach (var taskId in taskIds)
         {
-            var task = await ReadTaskAsync(taskId, cancellationToken).ConfigureAwait(false);
+            var task = await ReadTaskAsync(taskId, effectiveOwner, cancellationToken).ConfigureAwait(false);
             if (task is null) continue;
 
             // Apply filters that aren't covered by the index
@@ -150,12 +157,24 @@ public sealed class FileTaskStore : ITaskStore
 
     // ─── File I/O Helpers ───
 
-    private string GetTaskFilePath(string taskId) => Path.Combine(_tasksDir, $"{taskId}.json");
-    private string GetIndexFilePath(string prefix, string id) => Path.Combine(_indexesDir, $"{prefix}_{id}.idx");
+    private static string GetEffectiveOwner(string? owner)
+        => string.IsNullOrEmpty(owner) ? "default" : owner;
 
-    private async Task<AgentTask?> ReadTaskAsync(string taskId, CancellationToken ct)
+    private static string SanitizeOwner(string owner)
+        => owner.Replace('\\', '_').Replace('/', '_');
+
+    private string GetTaskFilePath(string taskId, string owner)
+        => Path.Combine(_tasksDir, SanitizeOwner(owner), $"{taskId}.json");
+
+    private string GetIndexFilePath(string prefix, string id, string owner)
+        => Path.Combine(_indexesDir, SanitizeOwner(owner), $"{prefix}_{id}.idx");
+
+    private string GetOwnerTasksDir(string owner) => Path.Combine(_tasksDir, SanitizeOwner(owner));
+    private string GetOwnerIndexesDir(string owner) => Path.Combine(_indexesDir, SanitizeOwner(owner));
+
+    private async Task<AgentTask?> ReadTaskAsync(string taskId, string owner, CancellationToken ct)
     {
-        var path = GetTaskFilePath(taskId);
+        var path = GetTaskFilePath(taskId, owner);
         if (!File.Exists(path)) return null;
 
         await using var stream = File.OpenRead(path);
@@ -163,9 +182,11 @@ public sealed class FileTaskStore : ITaskStore
             .ConfigureAwait(false);
     }
 
-    private async Task WriteTaskAsync(string taskId, AgentTask task, CancellationToken ct)
+    private async Task WriteTaskAsync(string taskId, string owner, AgentTask task, CancellationToken ct)
     {
-        var path = GetTaskFilePath(taskId);
+        var dir = GetOwnerTasksDir(owner);
+        Directory.CreateDirectory(dir);
+        var path = GetTaskFilePath(taskId, owner);
         var tempPath = path + ".tmp";
 
         await using (var stream = File.Create(tempPath))
@@ -177,11 +198,11 @@ public sealed class FileTaskStore : ITaskStore
         File.Move(tempPath, path, overwrite: true);
     }
 
-    private async Task AppendToIndexAsync(string prefix, string id, string taskId, CancellationToken ct)
+    private async Task AppendToIndexAsync(string prefix, string id, string taskId, string owner, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(id)) return;
 
-        var indexPath = GetIndexFilePath(prefix, id);
+        var indexPath = GetIndexFilePath(prefix, id, owner);
 
         // Check if task is already in the index (avoid duplicates)
         if (File.Exists(indexPath))
@@ -191,27 +212,32 @@ public sealed class FileTaskStore : ITaskStore
                 return;
         }
 
+        Directory.CreateDirectory(GetOwnerIndexesDir(owner));
         await File.AppendAllTextAsync(indexPath, taskId + Environment.NewLine, ct).ConfigureAwait(false);
     }
 
     private async Task<IReadOnlyList<string>> GetTaskIdsForQueryAsync(
-        ListTasksRequest request, CancellationToken ct)
+        ListTasksRequest request, string owner, CancellationToken ct)
     {
         // Use the most specific index available
         if (!string.IsNullOrEmpty(request.ContextId))
-            return await ReadIndexAsync("context", request.ContextId, ct).ConfigureAwait(false);
+            return await ReadIndexAsync("context", request.ContextId, owner, ct).ConfigureAwait(false);
 
-        // No index match — scan all task files
-        return Directory.GetFiles(_tasksDir, "*.json")
+        // No index match — scan all task files for this owner
+        var dir = GetOwnerTasksDir(owner);
+        if (!Directory.Exists(dir))
+            return [];
+
+        return Directory.GetFiles(dir, "*.json")
             .Select(Path.GetFileNameWithoutExtension)
             .Where(name => name is not null)
             .Cast<string>()
             .ToList();
     }
 
-    private async Task<IReadOnlyList<string>> ReadIndexAsync(string prefix, string id, CancellationToken ct)
+    private async Task<IReadOnlyList<string>> ReadIndexAsync(string prefix, string id, string owner, CancellationToken ct)
     {
-        var path = GetIndexFilePath(prefix, id);
+        var path = GetIndexFilePath(prefix, id, owner);
         if (!File.Exists(path)) return [];
 
         var content = await File.ReadAllTextAsync(path, ct).ConfigureAwait(false);

--- a/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
+++ b/src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs
@@ -77,9 +77,11 @@ public static class A2ARouteBuilderExtensions
     /// Use the <paramref name="path"/> parameter to add a base path prefix if needed.</para>
     /// <para><strong>Limitation:</strong> Multi-tenant route variants
     /// (<c>/{tenant}/tasks/{id}</c>) defined in the A2A specification are not currently
-    /// supported. The <c>Tenant</c> field on request types will always be <c>null</c>
-    /// for REST API calls. Use the JSON-RPC binding with explicit tenant parameters
-    /// if multi-tenant routing is required.</para>
+    /// supported. The <c>Tenant</c> field on REST request types will always be <c>null</c>,
+    /// so REST calls operate in the shared default owner scope. Use the JSON-RPC binding
+    /// with an explicit <c>tenant</c> parameter if per-tenant isolation is required:
+    /// the SDK scopes task store access by the request tenant, so tasks created under one
+    /// tenant are not visible to another.</para>
     /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="requestHandler">The A2A request handler.</param>

--- a/src/A2A/Server/A2AServer.cs
+++ b/src/A2A/Server/A2AServer.cs
@@ -399,7 +399,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
                 A2AErrorCode.InvalidParams);
         }
 
-        var task = await _taskStore.GetTaskAsync(request.Id, cancellationToken).ConfigureAwait(false)
+        var task = await _taskStore.GetTaskAsync(request.Id, request.Tenant, cancellationToken).ConfigureAwait(false)
             ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
 
         return task.WithHistoryTrimmedTo(request.HistoryLength);
@@ -409,7 +409,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
     public virtual async Task<ListTasksResponse> ListTasksAsync(
         ListTasksRequest request, CancellationToken cancellationToken = default)
     {
-        return await _taskStore.ListTasksAsync(request, cancellationToken).ConfigureAwait(false);
+        return await _taskStore.ListTasksAsync(request, request.Tenant, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -419,7 +419,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
         using var activity = A2ADiagnostics.Source.StartActivity("A2AServer.CancelTask", ActivityKind.Internal);
         activity?.SetTag("a2a.task.id", request.Id);
 
-        var task = await _taskStore.GetTaskAsync(request.Id, cancellationToken).ConfigureAwait(false)
+        var task = await _taskStore.GetTaskAsync(request.Id, request.Tenant, cancellationToken).ConfigureAwait(false)
             ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
 
         if (task.Status.State.IsTerminal())
@@ -440,6 +440,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
             Task = task,
             TaskId = task.Id,
             ContextId = task.ContextId,
+            Owner = request.Tenant ?? RequestContext.DefaultOwner,
             StreamingResponse = false,
             Metadata = request.Metadata,
         };
@@ -464,7 +465,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
 
         await agentTask.ConfigureAwait(false);
 
-        return await _taskStore.GetTaskAsync(request.Id, cancellationToken).ConfigureAwait(false)
+        return await _taskStore.GetTaskAsync(request.Id, request.Tenant, cancellationToken).ConfigureAwait(false)
             ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
     }
 
@@ -484,7 +485,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
         // guaranteeing no events are lost between snapshot and live stream.
         using (await _notifier.AcquireTaskLockAsync(request.Id, cancellationToken).ConfigureAwait(false))
         {
-            currentTask = await _taskStore.GetTaskAsync(request.Id, cancellationToken).ConfigureAwait(false)
+            currentTask = await _taskStore.GetTaskAsync(request.Id, request.Tenant, cancellationToken).ConfigureAwait(false)
                 ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
 
             if (currentTask.Status.State.IsTerminal())
@@ -562,7 +563,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
     {
         try
         {
-            var task = await _taskStore.GetTaskAsync(context.TaskId, cancellationToken).ConfigureAwait(false);
+            var task = await _taskStore.GetTaskAsync(context.TaskId, context.Owner, cancellationToken).ConfigureAwait(false);
             if (task is not null && !task.Status.State.IsTerminal())
             {
                 await ApplyEventAsync(new StreamResponse
@@ -595,7 +596,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
 
         if (!string.IsNullOrEmpty(taskId))
         {
-            existingTask = await _taskStore.GetTaskAsync(taskId, cancellationToken).ConfigureAwait(false)
+            existingTask = await _taskStore.GetTaskAsync(taskId, request.Tenant, cancellationToken).ConfigureAwait(false)
                 ?? throw new A2AException($"Task '{taskId}' not found.", A2AErrorCode.TaskNotFound);
             contextId ??= existingTask.ContextId;
         }
@@ -606,6 +607,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
             Task = existingTask,
             TaskId = taskId ?? Guid.NewGuid().ToString("N"),
             ContextId = contextId ?? Guid.NewGuid().ToString("N"),
+            Owner = request.Tenant ?? RequestContext.DefaultOwner,
             ClientProvidedContextId = contextId is not null,
             StreamingResponse = streamingResponse,
             Configuration = request.Configuration,
@@ -628,7 +630,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
     {
         using (await _notifier.AcquireTaskLockAsync(context.TaskId, cancellationToken).ConfigureAwait(false))
         {
-            var currentTask = await _taskStore.GetTaskAsync(context.TaskId, cancellationToken)
+            var currentTask = await _taskStore.GetTaskAsync(context.TaskId, context.Owner, cancellationToken)
                 .ConfigureAwait(false);
 
             var updatedTask = TaskProjection.Apply(currentTask, response);
@@ -645,7 +647,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
                 A2ADiagnostics.TaskCreatedCount.Add(1);
             }
 
-            await _taskStore.SaveTaskAsync(context.TaskId, updatedTask, cancellationToken)
+            await _taskStore.SaveTaskAsync(context.TaskId, updatedTask, context.Owner, cancellationToken)
                 .ConfigureAwait(false);
 
             _notifier.Notify(context.TaskId, response);
@@ -743,7 +745,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
 #pragma warning restore CS4014, VSTHRD003
 
             // Re-fetch from store to return the current persisted state
-            result.Task = await _taskStore.GetTaskAsync(context.TaskId, CancellationToken.None).ConfigureAwait(false)
+            result.Task = await _taskStore.GetTaskAsync(context.TaskId, context.Owner, CancellationToken.None).ConfigureAwait(false)
                 ?? throw new A2AException($"Task '{context.TaskId}' not found after processing.", A2AErrorCode.TaskNotFound);
 
             return result;
@@ -786,7 +788,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
         // all persisted events, not a stale snapshot.
         if (result?.Task is not null)
         {
-            result.Task = await _taskStore.GetTaskAsync(context.TaskId, cancellationToken).ConfigureAwait(false)
+            result.Task = await _taskStore.GetTaskAsync(context.TaskId, context.Owner, cancellationToken).ConfigureAwait(false)
                 ?? throw new A2AException($"Task '{context.TaskId}' not found after processing.", A2AErrorCode.TaskNotFound);
         }
 

--- a/src/A2A/Server/ITaskStore.cs
+++ b/src/A2A/Server/ITaskStore.cs
@@ -16,32 +16,48 @@ public interface ITaskStore
 {
     /// <summary>Get the current state of a task.</summary>
     /// <param name="taskId">The task identifier.</param>
+    /// <param name="owner">
+    /// Optional owner/tenant scope. When <c>null</c> or empty, the shared default owner
+    /// scope is used (unauthenticated flows). Tasks are isolated per owner.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task<AgentTask?> GetTaskAsync(string taskId, CancellationToken cancellationToken = default);
+    Task<AgentTask?> GetTaskAsync(string taskId, string? owner = null, CancellationToken cancellationToken = default);
 
     /// <summary>Save (upsert) the current state of a task.</summary>
     /// <param name="taskId">The task identifier.</param>
     /// <param name="task">The task to persist.</param>
+    /// <param name="owner">
+    /// Optional owner/tenant scope. When <c>null</c> or empty, the shared default owner
+    /// scope is used (unauthenticated flows). Tasks are isolated per owner.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task SaveTaskAsync(string taskId, AgentTask task, CancellationToken cancellationToken = default);
+    Task SaveTaskAsync(string taskId, AgentTask task, string? owner = null, CancellationToken cancellationToken = default);
 
     /// <summary>Delete a task.</summary>
     /// <param name="taskId">The task identifier.</param>
+    /// <param name="owner">
+    /// Optional owner/tenant scope. When <c>null</c> or empty, the shared default owner
+    /// scope is used (unauthenticated flows). Tasks are isolated per owner.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <remarks>
     /// This method is not called by the SDK itself. It is provided for implementations
     /// that need task pruning (e.g. TTL expiry, admin cleanup). Implementations that
     /// do not need deletion may leave the body empty or throw <see cref="NotSupportedException"/>.
     /// </remarks>
-    Task DeleteTaskAsync(string taskId, CancellationToken cancellationToken = default);
+    Task DeleteTaskAsync(string taskId, string? owner = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Query tasks with filtering and pagination.
     /// Supports filtering by <see cref="ListTasksRequest.ContextId"/>,
     /// <see cref="ListTasksRequest.Status"/>, <see cref="ListTasksRequest.StatusTimestampAfter"/>,
-    /// and cursor-based pagination.
+    /// and cursor-based pagination. Results are scoped to <paramref name="owner"/>.
     /// </summary>
     /// <param name="request">The query request with filters and pagination.</param>
+    /// <param name="owner">
+    /// Optional owner/tenant scope. When <c>null</c> or empty, the shared default owner
+    /// scope is used (unauthenticated flows). Tasks are isolated per owner.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task<ListTasksResponse> ListTasksAsync(ListTasksRequest request, CancellationToken cancellationToken = default);
+    Task<ListTasksResponse> ListTasksAsync(ListTasksRequest request, string? owner = null, CancellationToken cancellationToken = default);
 }

--- a/src/A2A/Server/InMemoryTaskStore.cs
+++ b/src/A2A/Server/InMemoryTaskStore.cs
@@ -8,37 +8,46 @@ namespace A2A;
 /// In-memory task store using <see cref="ConcurrentDictionary{TKey, TValue}"/>.
 /// Suitable for development and testing.
 /// </summary>
+/// <remarks>
+/// Tasks are keyed by <c>(owner, taskId)</c> so that tasks created under one owner/tenant
+/// scope are not visible to other owners (tenant isolation). When no owner is supplied
+/// (unauthenticated requests), the shared <see cref="RequestContext.DefaultOwner"/> scope
+/// is used, which preserves the previous flat-store behavior.
+/// </remarks>
 public sealed class InMemoryTaskStore : ITaskStore
 {
-    private readonly ConcurrentDictionary<string, AgentTask> _tasks = new();
+    private readonly ConcurrentDictionary<(string Owner, string TaskId), AgentTask> _tasks = new();
 
     /// <inheritdoc />
-    public Task<AgentTask?> GetTaskAsync(string taskId, CancellationToken cancellationToken = default)
+    public Task<AgentTask?> GetTaskAsync(string taskId, string? owner = null, CancellationToken cancellationToken = default)
     {
-        if (!_tasks.TryGetValue(taskId, out var task))
+        if (!_tasks.TryGetValue((GetEffectiveOwner(owner), taskId), out var task))
             return Task.FromResult<AgentTask?>(null);
         return Task.FromResult<AgentTask?>(CloneTask(task));
     }
 
     /// <inheritdoc />
-    public Task SaveTaskAsync(string taskId, AgentTask task, CancellationToken cancellationToken = default)
+    public Task SaveTaskAsync(string taskId, AgentTask task, string? owner = null, CancellationToken cancellationToken = default)
     {
-        _tasks[taskId] = CloneTask(task);
+        _tasks[(GetEffectiveOwner(owner), taskId)] = CloneTask(task);
         return Task.CompletedTask;
     }
 
     /// <inheritdoc />
-    public Task DeleteTaskAsync(string taskId, CancellationToken cancellationToken = default)
+    public Task DeleteTaskAsync(string taskId, string? owner = null, CancellationToken cancellationToken = default)
     {
-        _tasks.TryRemove(taskId, out _);
+        _tasks.TryRemove((GetEffectiveOwner(owner), taskId), out _);
         return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public Task<ListTasksResponse> ListTasksAsync(ListTasksRequest request,
-        CancellationToken cancellationToken = default)
+        string? owner = null, CancellationToken cancellationToken = default)
     {
-        IEnumerable<AgentTask> allTasks = _tasks.Values
+        var effectiveOwner = GetEffectiveOwner(owner);
+        IEnumerable<AgentTask> allTasks = _tasks
+            .Where(kvp => kvp.Key.Owner == effectiveOwner)
+            .Select(kvp => kvp.Value)
             .Select(CloneTask);
 
         // Apply filters
@@ -116,6 +125,15 @@ public sealed class InMemoryTaskStore : ITaskStore
             TotalSize = totalSize,
         });
     }
+
+    /// <summary>
+    /// Normalizes the caller-supplied owner: <c>null</c> or empty maps to the shared
+    /// default owner scope so unauthenticated flows keep the flat-store behavior.
+    /// </summary>
+    /// <param name="owner">The caller-supplied owner scope, possibly <c>null</c>.</param>
+    /// <returns>The effective owner scope.</returns>
+    private static string GetEffectiveOwner(string? owner)
+        => string.IsNullOrEmpty(owner) ? RequestContext.DefaultOwner : owner;
 
     [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "All types are registered in source-generated JsonContext.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "All types are registered in source-generated JsonContext.")]

--- a/src/A2A/Server/RequestContext.cs
+++ b/src/A2A/Server/RequestContext.cs
@@ -8,6 +8,12 @@ namespace A2A;
 /// </summary>
 public sealed class RequestContext
 {
+    /// <summary>
+    /// Default owner scope used when no tenant/owner identity is available (unauthenticated requests).
+    /// All unauthenticated callers share this scope, preserving backward compatibility.
+    /// </summary>
+    public const string DefaultOwner = "";
+
     /// <summary>The incoming client message.</summary>
     public required Message Message { get; init; }
 
@@ -19,6 +25,13 @@ public sealed class RequestContext
 
     /// <summary>The context ID — client-provided, inherited from existing task, or SDK-generated.</summary>
     public required string ContextId { get; init; }
+
+    /// <summary>
+    /// Owner/tenant scope for the current request. Defaults to <see cref="DefaultOwner"/>
+    /// for unauthenticated requests. The SDK scopes all task store CRUD by this value,
+    /// so tasks created under one owner are not visible to another owner.
+    /// </summary>
+    public string Owner { get; init; } = DefaultOwner;
 
     /// <summary>
     /// Whether <see cref="ContextId"/> was provided by the client (or inherited from an existing task)

--- a/tests/A2A.AspNetCore.UnitTests/A2AHttpProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AHttpProcessorTests.cs
@@ -140,7 +140,7 @@ public class A2AHttpProcessorTests
         // Arrange
         var mockTaskStore = new Mock<ITaskStore>();
         mockTaskStore
-            .Setup(ts => ts.GetTaskAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(ts => ts.GetTaskAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new A2AException("Test exception", errorCode));
 
         var handler = new Mock<IAgentHandler>().Object;
@@ -166,7 +166,7 @@ public class A2AHttpProcessorTests
         // Create an A2AException with an unknown/invalid error code by casting an integer that doesn't correspond to any enum value
         var unknownErrorCode = (A2AErrorCode)(-99999);
         mockTaskStore
-            .Setup(ts => ts.GetTaskAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(ts => ts.GetTaskAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new A2AException("Test exception with unknown error code", unknownErrorCode));
 
         var handler = new Mock<IAgentHandler>().Object;

--- a/tests/A2A.UnitTests/Server/A2AServerTests.cs
+++ b/tests/A2A.UnitTests/Server/A2AServerTests.cs
@@ -326,6 +326,50 @@ public class A2AServerTests
     }
 
     [Fact]
+    public async Task SendMessage_WithTenant_PersistsTaskUnderTenantScope()
+    {
+        // Arrange
+        var (server, store, handler) = CreateServer();
+        string? capturedTaskId = null;
+        handler.OnExecute = async (ctx, eq, ct) =>
+        {
+            capturedTaskId = ctx.TaskId;
+            Assert.Equal("alice", ctx.Owner); // RequestContext carries the tenant as owner
+            var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
+            await updater.SubmitAsync(cancellationToken: ct);
+            await updater.CompleteAsync(cancellationToken: ct);
+        };
+
+        var request = new SendMessageRequest
+        {
+            Tenant = "alice",
+            Message = new Message { MessageId = "u1", Parts = [Part.FromText("Hello!")], Role = Role.User }
+        };
+
+        // Act
+        await server.SendMessageAsync(request);
+
+        // Assert — task is retrievable under the same tenant only (IDOR fix)
+        Assert.NotNull(capturedTaskId);
+        var sameTenant = await server.GetTaskAsync(new GetTaskRequest { Id = capturedTaskId!, Tenant = "alice" });
+        Assert.NotNull(sameTenant);
+        Assert.Equal(TaskState.Completed, sameTenant!.Status.State);
+
+        // Different tenant (or no tenant → default owner) must NOT see the task
+        var otherTenantEx = await Assert.ThrowsAsync<A2AException>(() =>
+            server.GetTaskAsync(new GetTaskRequest { Id = capturedTaskId!, Tenant = "bob" }));
+        Assert.Equal(A2AErrorCode.TaskNotFound, otherTenantEx.ErrorCode);
+
+        var noTenantEx = await Assert.ThrowsAsync<A2AException>(() =>
+            server.GetTaskAsync(new GetTaskRequest { Id = capturedTaskId! }));
+        Assert.Equal(A2AErrorCode.TaskNotFound, noTenantEx.ErrorCode);
+
+        // The task IS in the store under the tenant scope
+        var persisted = await store.GetTaskAsync(capturedTaskId!, owner: "alice");
+        Assert.NotNull(persisted);
+    }
+
+    [Fact]
     public async Task GetTaskAsync_RespectsHistoryLength()
     {
         // Arrange
@@ -519,7 +563,7 @@ public class A2AServerTests
         Channel<StreamResponse> channel;
         using (await notifier.AcquireTaskLockAsync("t1", cts.Token))
         {
-            var task = await store.GetTaskAsync("t1", cts.Token);
+            var task = await store.GetTaskAsync("t1", cancellationToken: cts.Token);
             Assert.NotNull(task);
             channel = notifier.CreateChannel("t1");
         }
@@ -528,7 +572,7 @@ public class A2AServerTests
         using (await notifier.AcquireTaskLockAsync("t1", cts.Token))
         {
             var completed = new AgentTask { Id = "t1", ContextId = "ctx", Status = new TaskStatus { State = TaskState.Completed } };
-            await store.SaveTaskAsync("t1", completed, cts.Token);
+            await store.SaveTaskAsync("t1", completed, cancellationToken: cts.Token);
             notifier.Notify("t1", new StreamResponse
             {
                 StatusUpdate = new TaskStatusUpdateEvent { TaskId = "t1", ContextId = "ctx", Status = new TaskStatus { State = TaskState.Completed } }

--- a/tests/A2A.UnitTests/Server/InMemoryTaskStoreTests.cs
+++ b/tests/A2A.UnitTests/Server/InMemoryTaskStoreTests.cs
@@ -297,4 +297,102 @@ public class InMemoryTaskStoreTests
 
         await Task.WhenAll(tasks); // Should not throw, corrupt, or deadlock
     }
+
+    [Fact]
+    public async Task GetTaskAsync_IsIsolatedByOwner()
+    {
+        // Arrange — task saved under owner "alice"
+        var sut = new InMemoryTaskStore();
+        await sut.SaveTaskAsync("t1", new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Submitted },
+        }, owner: "alice");
+
+        // Act & Assert — same taskId, different owner → not visible (IDOR fix)
+        var otherOwner = await sut.GetTaskAsync("t1", owner: "bob");
+        Assert.Null(otherOwner);
+
+        var sameOwner = await sut.GetTaskAsync("t1", owner: "alice");
+        Assert.NotNull(sameOwner);
+        Assert.Equal("t1", sameOwner!.Id);
+    }
+
+    [Fact]
+    public async Task SaveTaskAsync_SameTaskIdDifferentOwners_AreIndependent()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+        await sut.SaveTaskAsync("t1", new AgentTask
+        {
+            Id = "t1", ContextId = "ctx-a",
+            Status = new TaskStatus { State = TaskState.Submitted },
+        }, owner: "alice");
+        await sut.SaveTaskAsync("t1", new AgentTask
+        {
+            Id = "t1", ContextId = "ctx-b",
+            Status = new TaskStatus { State = TaskState.Working },
+        }, owner: "bob");
+
+        // Act
+        var aliceTask = await sut.GetTaskAsync("t1", owner: "alice");
+        var bobTask = await sut.GetTaskAsync("t1", owner: "bob");
+
+        // Assert — each owner sees their own snapshot, no cross-talk
+        Assert.NotNull(aliceTask);
+        Assert.Equal(TaskState.Submitted, aliceTask!.Status.State);
+        Assert.NotNull(bobTask);
+        Assert.Equal(TaskState.Working, bobTask!.Status.State);
+    }
+
+    [Fact]
+    public async Task ListTasksAsync_OnlyReturnsTasksForOwner()
+    {
+        // Arrange
+        var sut = new InMemoryTaskStore();
+        await sut.SaveTaskAsync("t1", new AgentTask { Id = "t1", ContextId = "ctx", Status = new TaskStatus { State = TaskState.Submitted } }, owner: "alice");
+        await sut.SaveTaskAsync("t2", new AgentTask { Id = "t2", ContextId = "ctx", Status = new TaskStatus { State = TaskState.Working } }, owner: "alice");
+        await sut.SaveTaskAsync("t3", new AgentTask { Id = "t3", ContextId = "ctx", Status = new TaskStatus { State = TaskState.Working } }, owner: "bob");
+
+        // Act
+        var aliceTasks = await sut.ListTasksAsync(new ListTasksRequest(), owner: "alice");
+        var bobTasks = await sut.ListTasksAsync(new ListTasksRequest(), owner: "bob");
+
+        // Assert
+        Assert.Equal(2, aliceTasks.Tasks!.Count);
+        Assert.Equal(["t1", "t2"], aliceTasks.Tasks.Select(t => t.Id).OrderBy(id => id).ToArray());
+        Assert.Single(bobTasks.Tasks!);
+        Assert.Equal("t3", bobTasks.Tasks![0].Id);
+    }
+
+    [Fact]
+    public async Task DeleteTaskAsync_OnlyDeletesTaskForOwner()
+    {
+        // Arrange — same taskId under two owners
+        var sut = new InMemoryTaskStore();
+        await sut.SaveTaskAsync("t1", new AgentTask { Id = "t1", ContextId = "ctx", Status = new TaskStatus { State = TaskState.Submitted } }, owner: "alice");
+        await sut.SaveTaskAsync("t1", new AgentTask { Id = "t1", ContextId = "ctx", Status = new TaskStatus { State = TaskState.Submitted } }, owner: "bob");
+
+        // Act — delete only bob's copy
+        await sut.DeleteTaskAsync("t1", owner: "bob");
+
+        // Assert — alice's copy is untouched
+        Assert.Null(await sut.GetTaskAsync("t1", owner: "bob"));
+        Assert.NotNull(await sut.GetTaskAsync("t1", owner: "alice"));
+    }
+
+    [Fact]
+    public async Task NullAndEmptyOwner_ShareDefaultOwnerScope()
+    {
+        // Arrange — backward compatibility: unauthenticated flows share one scope
+        var sut = new InMemoryTaskStore();
+        await sut.SaveTaskAsync("t1", new AgentTask { Id = "t1", ContextId = "ctx", Status = new TaskStatus { State = TaskState.Submitted } }, owner: null);
+
+        // Act & Assert — null and empty-string owners resolve to the same scope
+        Assert.NotNull(await sut.GetTaskAsync("t1", owner: ""));
+        Assert.NotNull(await sut.GetTaskAsync("t1", owner: null));
+        var listed = await sut.ListTasksAsync(new ListTasksRequest(), owner: "");
+        Assert.Single(listed.Tasks!);
+    }
 }


### PR DESCRIPTION
## What changed

### 1. Owner/tenant isolation in `ITaskStore` (IDOR)

**Problem:** `InMemoryTaskStore` used a flat `ConcurrentDictionary<string, AgentTask>` keyed only by task ID. Any caller that knew a task ID could read, list, or delete any task — no owner/tenant scoping, enabling IDOR (CWE-862, missing access control).

**Fix (src/A2A/Server/ITaskStore.cs, src/A2A/Server/InMemoryTaskStore.cs, src/A2A/Server/RequestContext.cs):**
- Added an optional `owner` parameter to all four `ITaskStore` methods (`GetTaskAsync`, `SaveTaskAsync`, `DeleteTaskAsync`, `ListTasksAsync`). `null`/empty resolves to the shared default owner scope, keeping unauthenticated flows fully backward compatible.
- `InMemoryTaskStore` now keys tasks by `(owner, taskId)` and scopes `Get`/`Save`/`Delete`/`List` by the effective owner, so tasks created under one owner are invisible to other owners.
- `RequestContext` gained an `Owner` property (default `RequestContext.DefaultOwner`, empty string) representing the request identity.
- Added `A2AException`-compatible storage helper `GetEffectiveOwner` normalizing null/empty to the default scope.

### 2. Thread owner through `A2AServer` from the request `Tenant`

**Problem:** The A2A request types (`GetTaskRequest`, `SendMessageRequest`, `ListTasksRequest`, `CancelTaskRequest`, `SubscribeToTaskRequest`, …) already carry a `Tenant` field, but it was completely ignored — all task store access was unscoped.

**Fix (src/A2A/Server/A2AServer.cs):**
- All task store reads/writes now pass `request.Tenant` (or `RequestContext.Owner` where a context exists) as the owner scope.
- `ResolveContextAsync` and `CancelTaskAsync` set `RequestContext.Owner = request.Tenant ?? RequestContext.DefaultOwner`.
- A request that continues or reads a task under a different tenant now gets `TaskNotFound` instead of the other tenant's task.

### 3. Sample `FileTaskStore` adapted to owner-scoped storage

**Problem:** `samples/AgentServer/FileTaskStore.cs` implemented the old unscoped interface and would not compile against the updated `ITaskStore`.

**Fix (samples/AgentServer/FileTaskStore.cs):**
- Implements the new interface; storage layout is now `tasks/{owner}/{taskId}.json` and `indexes/{owner}/context_{id}.idx`, with the default owner stored under `default/`.
- `ListTasksAsync` scans/reads only the requesting owner's directory/index.

### 4. Documentation updated

**Problem:** The `MapHttpA2A` remarks admitted multi-tenant routing was unsupported without noting the store-level isolation that now exists.

**Fix (src/A2A.AspNetCore/A2AEndpointRouteBuilderExtensions.cs):**
- Updated remarks: REST route variants still aren't supported (REST calls operate in the default owner scope), but task store access is now scoped by the request `tenant`, so JSON-RPC calls with an explicit `tenant` get per-tenant isolation.

## Testing

- `dotnet test tests/A2A.UnitTests --framework net8.0` — **426 passed, 0 failed** (baseline 420, +6 new regression tests: owner-isolated get/save/list/delete, null-vs-empty default scope, server-level tenant isolation incl. cross-tenant `TaskNotFound`).
- `dotnet test tests/A2A.AspNetCore.UnitTests --framework net8.0` — **88 passed, 0 failed**.
- `dotnet build ./src/A2ALibs.slnx --framework net8.0` and `dotnet build samples/AgentServer` — clean, 0 warnings/errors.
- **Behavior change:** `ITaskStore` gained an optional `owner` parameter (source-compatible for existing call sites; implementers must update their signatures). Task store access is now scoped by the request `tenant`; without a tenant (unauthenticated), all callers share the default owner scope, so existing deployments behave as before. For callers that do not set `Tenant`, behavior is unchanged.
