### PR TITLE
fix: sanitize JSON-RPC parse error messages to prevent internal detail leak

### DIFF
--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -57,7 +57,7 @@ public static class A2AJsonRpcProcessor
         catch (JsonException ex)
         {
             // Never leak System.Text.Json parser details (paths, line numbers, library
-            // names) to the client (BUG-12). The raw message is kept for observability
+            // names) to the client. The raw message is kept for observability
             // via the activity; the client receives a generic parse error.
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.AddEvent(new ActivityEvent("json.parse.error",

--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -56,9 +56,18 @@ public static class A2AJsonRpcProcessor
         }
         catch (JsonException ex)
         {
+            // Never leak System.Text.Json parser details (paths, line numbers, library
+            // names) to the client (BUG-12). The raw message is kept for observability
+            // via the activity; the client receives a generic parse error.
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.AddEvent(new ActivityEvent("json.parse.error",
+                tags: new ActivityTagsCollection
+                {
+                    { "exception.type", ex.GetType().FullName },
+                    { "exception.message", ex.Message },
+                }));
             var errorId = rpcRequest?.Id ?? new JsonRpcId((string?)null);
-            return new JsonRpcResponseResult(JsonRpcResponse.ParseErrorResponse(errorId, ex.Message));
+            return new JsonRpcResponseResult(JsonRpcResponse.ParseErrorResponse(errorId));
         }
         catch (Exception ex)
         {

--- a/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
@@ -435,6 +435,36 @@ public class A2AJsonRpcProcessorTests
         Assert.Equal(-32700, BodyContent.Error!.Code); // Parse error per JSON-RPC 2.0 spec
     }
 
+    [Theory]
+    [InlineData("{invalid json")]
+    [InlineData("not json at all")]
+    [InlineData("{\"jsonrpc\": \"2.0\", \"method\":")]
+    public async Task ProcessRequestAsync_GivenInvalidJson_DoesNotLeakParserDetails(string body)
+    {
+        // Arrange — System.Text.Json exceptions embed paths, line/byte positions and
+        // library names; none of that must reach the client (BUG-12, CWE-209).
+        var requestHandler = CreateTestServer();
+        var httpRequest = CreateHttpRequestFromJson(body);
+
+        // Act
+        var result = await A2AJsonRpcProcessor.ProcessRequestAsync(requestHandler, httpRequest, CancellationToken.None);
+
+        // Assert — generic message, no raw parser output, error code preserved
+        var responseResult = Assert.IsType<JsonRpcResponseResult>(result);
+        var (_, _, BodyContent) = await GetJsonRpcResponseHttpDetails<JsonRpcResponse>(responseResult);
+
+        Assert.Equal(-32700, BodyContent.Error!.Code);
+        Assert.DoesNotContain(body, BodyContent.Error.Message);
+        Assert.DoesNotContain("JsonException", BodyContent.Error.Message);
+        Assert.DoesNotContain("LineNumber", BodyContent.Error.Message);
+        Assert.DoesNotContain("BytePositionInLine", BodyContent.Error.Message);
+        // The message is one of the two generic parse-error messages, never raw parser output
+        Assert.Contains(GenericParseErrorMessages, msg => BodyContent.Error.Message == msg);
+    }
+
+    private static readonly string[] GenericParseErrorMessages =
+        ["Invalid JSON payload", "Invalid JSON-RPC request payload."];
+
     /// <summary>Creates a test A2AServer with in-memory store and default callbacks.</summary>
     private static IA2ARequestHandler CreateTestServer()
     {

--- a/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
@@ -442,7 +442,7 @@ public class A2AJsonRpcProcessorTests
     public async Task ProcessRequestAsync_GivenInvalidJson_DoesNotLeakParserDetails(string body)
     {
         // Arrange — System.Text.Json exceptions embed paths, line/byte positions and
-        // library names; none of that must reach the client (BUG-12, CWE-209).
+        // library names; none of that must reach the client (CWE-209).
         var requestHandler = CreateTestServer();
         var httpRequest = CreateHttpRequestFromJson(body);
 


### PR DESCRIPTION
## What changed

### 1. JSON-RPC parse error responses no longer leak `System.Text.Json` internals 

**Problem:** `A2AJsonRpcProcessor.ProcessRequestAsync` caught `JsonException` and returned `ParseErrorResponse(errorId, ex.Message)`, propagating the raw parser exception message to the client. System.Text.Json messages embed input paths, line numbers, byte positions, and library names, enabling server fingerprinting and information disclosure (CWE-209).

**Fix (src/A2A.AspNetCore/A2AJsonRpcProcessor.cs):**
- The `JsonException` catch now returns `ParseErrorResponse(errorId)` with the generic message (default `"Invalid JSON payload"`), preserving the JSON-RPC `-32700` parse error code.
- The raw parser details are retained for server-side observability: the activity's status is set to error and a `json.parse.error` activity event records the exception type and message, so operators can still diagnose malformed requests.
- Note: most malformed JSON is already wrapped by `JsonRpcRequestConverter` into an `A2AException` with the generic message `"Invalid JSON-RPC request payload."`; this change closes the remaining path where a raw `JsonException` could surface.

## Testing

- `dotnet test tests/A2A.AspNetCore.UnitTests --framework net8.0` — **91 passed, 0 failed** (baseline 88, +3 new theory cases for `ProcessRequestAsync_GivenInvalidJson_DoesNotLeakParserDetails`: for `{invalid json`, `not json at all`, and truncated JSON, the response keeps code `-32700` and the message is one of the two generic parse messages, containing no raw input, no `JsonException`, no `LineNumber`, and no `BytePositionInLine`).
- `dotnet test tests/A2A.UnitTests --framework net8.0` — **420 passed, 0 failed** (unchanged).
- **Behavior change:** parse-error responses now carry a generic message instead of the raw parser exception message. No existing test asserted the specific leaked text.
