### PR TITLE
fix: enforce terminal state transitions and serialize cancel check-then-act

### DIFF
--- a/src/A2A/Server/A2AServer.cs
+++ b/src/A2A/Server/A2AServer.cs
@@ -419,53 +419,63 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
         using var activity = A2ADiagnostics.Source.StartActivity("A2AServer.CancelTask", ActivityKind.Internal);
         activity?.SetTag("a2a.task.id", request.Id);
 
-        var task = await _taskStore.GetTaskAsync(request.Id, cancellationToken).ConfigureAwait(false)
-            ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
-
-        if (task.Status.State.IsTerminal())
+        // Hold the per-task lock across the entire cancel operation. This makes the
+        // terminal-state check-then-act atomic with respect to concurrent mutations
+        // (message/send ApplyEventAsync) and serializes concurrent cancel requests:
+        // the loser of the race re-reads the now-terminal task and fails with
+        // TaskNotCancelable instead of double-cancelling (BUG-44).
+        // Events are applied via ApplyEventUnderLockAsync because the per-task
+        // semaphore is not reentrant.
+        using (await _notifier.AcquireTaskLockAsync(request.Id, cancellationToken).ConfigureAwait(false))
         {
-            throw new A2AException("Task is already in a terminal state.", A2AErrorCode.TaskNotCancelable);
-        }
+            var task = await _taskStore.GetTaskAsync(request.Id, cancellationToken).ConfigureAwait(false)
+                ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
 
-        // Signal any background return-immediately work to stop.
-        // Don't dispose the CTS here — the drain's finally block owns disposal.
-        if (_backgroundCancellations.TryRemove(request.Id, out var backgroundCts))
-        {
-            await backgroundCts.CancelAsync().ConfigureAwait(false);
-        }
-
-        var context = new RequestContext
-        {
-            Message = task.History?.LastOrDefault() ?? new Message { Role = Role.User, MessageId = string.Empty, Parts = [] },
-            Task = task,
-            TaskId = task.Id,
-            ContextId = task.ContextId,
-            StreamingResponse = false,
-            Metadata = request.Metadata,
-        };
-
-        var eventQueue = new AgentEventQueue();
-        var agentTask = Task.Run(async () =>
-        {
-            try
+            if (task.Status.State.IsTerminal())
             {
-                await _handler.CancelAsync(context, eventQueue, cancellationToken).ConfigureAwait(false);
+                throw new A2AException("Task is already in a terminal state.", A2AErrorCode.TaskNotCancelable);
             }
-            finally
+
+            // Signal any background return-immediately work to stop.
+            // Don't dispose the CTS here — the drain's finally block owns disposal.
+            if (_backgroundCancellations.TryRemove(request.Id, out var backgroundCts))
             {
-                eventQueue.Complete();
+                await backgroundCts.CancelAsync().ConfigureAwait(false);
             }
-        }, cancellationToken);
 
-        await foreach (var response in eventQueue.WithCancellation(cancellationToken).ConfigureAwait(false))
-        {
-            await ApplyEventAsync(response, context, cancellationToken).ConfigureAwait(false);
+            var context = new RequestContext
+            {
+                Message = task.History?.LastOrDefault() ?? new Message { Role = Role.User, MessageId = string.Empty, Parts = [] },
+                Task = task,
+                TaskId = task.Id,
+                ContextId = task.ContextId,
+                StreamingResponse = false,
+                Metadata = request.Metadata,
+            };
+
+            var eventQueue = new AgentEventQueue();
+            var agentTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await _handler.CancelAsync(context, eventQueue, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    eventQueue.Complete();
+                }
+            }, cancellationToken);
+
+            await foreach (var response in eventQueue.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                await ApplyEventUnderLockAsync(response, context, cancellationToken).ConfigureAwait(false);
+            }
+
+            await agentTask.ConfigureAwait(false);
+
+            return await _taskStore.GetTaskAsync(request.Id, cancellationToken).ConfigureAwait(false)
+                ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
         }
-
-        await agentTask.ConfigureAwait(false);
-
-        return await _taskStore.GetTaskAsync(request.Id, cancellationToken).ConfigureAwait(false)
-            ?? throw new A2AException($"Task '{request.Id}' not found.", A2AErrorCode.TaskNotFound);
     }
 
     /// <inheritdoc />
@@ -628,28 +638,43 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
     {
         using (await _notifier.AcquireTaskLockAsync(context.TaskId, cancellationToken).ConfigureAwait(false))
         {
-            var currentTask = await _taskStore.GetTaskAsync(context.TaskId, cancellationToken)
-                .ConfigureAwait(false);
-
-            var updatedTask = TaskProjection.Apply(currentTask, response);
-
-            // Message-only responses with no existing task have nothing to persist.
-            if (updatedTask is null)
-            {
-                _notifier.Notify(context.TaskId, response);
-                return;
-            }
-
-            if (currentTask is null)
-            {
-                A2ADiagnostics.TaskCreatedCount.Add(1);
-            }
-
-            await _taskStore.SaveTaskAsync(context.TaskId, updatedTask, cancellationToken)
-                .ConfigureAwait(false);
-
-            _notifier.Notify(context.TaskId, response);
+            await ApplyEventUnderLockAsync(response, context, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Applies an event to the task store while the caller holds the per-task lock.
+    /// Used by <see cref="ApplyEventAsync"/> and by <see cref="CancelTaskAsync"/>, which
+    /// holds the lock across the whole cancel operation to make the terminal-state
+    /// check-then-act atomic (BUG-44).
+    /// </summary>
+    /// <param name="response">The event to apply.</param>
+    /// <param name="context">The request context identifying the task.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    private async Task ApplyEventUnderLockAsync(
+        StreamResponse response, RequestContext context, CancellationToken cancellationToken)
+    {
+        var currentTask = await _taskStore.GetTaskAsync(context.TaskId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var updatedTask = TaskProjection.Apply(currentTask, response);
+
+        // Message-only responses with no existing task have nothing to persist.
+        if (updatedTask is null)
+        {
+            _notifier.Notify(context.TaskId, response);
+            return;
+        }
+
+        if (currentTask is null)
+        {
+            A2ADiagnostics.TaskCreatedCount.Add(1);
+        }
+
+        await _taskStore.SaveTaskAsync(context.TaskId, updatedTask, cancellationToken)
+            .ConfigureAwait(false);
+
+        _notifier.Notify(context.TaskId, response);
     }
 
     /// <summary>

--- a/src/A2A/Server/A2AServer.cs
+++ b/src/A2A/Server/A2AServer.cs
@@ -423,7 +423,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
         // terminal-state check-then-act atomic with respect to concurrent mutations
         // (message/send ApplyEventAsync) and serializes concurrent cancel requests:
         // the loser of the race re-reads the now-terminal task and fails with
-        // TaskNotCancelable instead of double-cancelling (BUG-44).
+        // TaskNotCancelable instead of double-cancelling.
         // Events are applied via ApplyEventUnderLockAsync because the per-task
         // semaphore is not reentrant.
         using (await _notifier.AcquireTaskLockAsync(request.Id, cancellationToken).ConfigureAwait(false))
@@ -646,7 +646,7 @@ public class A2AServer : IA2ARequestHandler, IAsyncDisposable
     /// Applies an event to the task store while the caller holds the per-task lock.
     /// Used by <see cref="ApplyEventAsync"/> and by <see cref="CancelTaskAsync"/>, which
     /// holds the lock across the whole cancel operation to make the terminal-state
-    /// check-then-act atomic (BUG-44).
+    /// check-then-act atomic.
     /// </summary>
     /// <param name="response">The event to apply.</param>
     /// <param name="context">The request context identifying the task.</param>

--- a/src/A2A/Server/TaskProjection.cs
+++ b/src/A2A/Server/TaskProjection.cs
@@ -80,7 +80,7 @@ public static class TaskProjection
 
     /// <summary>
     /// Terminal states are final: a completed/canceled/failed/rejected task must not be
-    /// overwritten by a later status update or accept further messages (BUG-43).
+    /// overwritten by a later status update or accept further messages.
     /// Guards the projection against state-machine violations that bypass the
     /// request-level <see cref="A2AServer"/> terminal checks (e.g. a misbehaving agent
     /// handler emitting events after a terminal status).

--- a/src/A2A/Server/TaskProjection.cs
+++ b/src/A2A/Server/TaskProjection.cs
@@ -60,12 +60,15 @@ public static class TaskProjection
 
     private static AgentTask ApplyMessage(AgentTask current, Message msg)
     {
+        GuardNotTerminal(current);
         current.History = [.. (current.History ?? []), msg];
         return current;
     }
 
     private static AgentTask ApplyStatus(AgentTask current, TaskStatusUpdateEvent su)
     {
+        GuardNotTerminal(current);
+
         // Move superseded status.message to history (aligned with Python SDK behavior).
         if (current.Status.Message is not null)
         {
@@ -73,6 +76,27 @@ public static class TaskProjection
         }
         current.Status = su.Status;
         return current;
+    }
+
+    /// <summary>
+    /// Terminal states are final: a completed/canceled/failed/rejected task must not be
+    /// overwritten by a later status update or accept further messages (BUG-43).
+    /// Guards the projection against state-machine violations that bypass the
+    /// request-level <see cref="A2AServer"/> terminal checks (e.g. a misbehaving agent
+    /// handler emitting events after a terminal status).
+    /// </summary>
+    /// <param name="current">The current task state being projected.</param>
+    /// <exception cref="A2AException">
+    /// Thrown with <see cref="A2AErrorCode.UnsupportedOperation"/> when the task is terminal.
+    /// </exception>
+    private static void GuardNotTerminal(AgentTask current)
+    {
+        if (current.Status.State.IsTerminal())
+        {
+            throw new A2AException(
+                $"Task '{current.Id}' is in a terminal state ({current.Status.State}) and cannot be modified.",
+                A2AErrorCode.UnsupportedOperation);
+        }
     }
 
     private static AgentTask ApplyArtifact(AgentTask current, TaskArtifactUpdateEvent au)

--- a/tests/A2A.UnitTests/Server/A2AServerTests.cs
+++ b/tests/A2A.UnitTests/Server/A2AServerTests.cs
@@ -295,7 +295,7 @@ public class A2AServerTests
     [Fact]
     public async Task GivenWorkingTask_WhenTwoConcurrentCancels_ThenExactlyOneSucceeds()
     {
-        // Arrange — two concurrent cancel requests race on the same task (BUG-44 TOCTOU).
+        // Arrange — two concurrent cancel requests race on the same task (TOCTOU).
         // The per-task lock serializes check-then-act: the loser re-reads the now-terminal
         // task and fails with TaskNotCancelable instead of double-cancelling.
         var (server, store, handler) = CreateServer();

--- a/tests/A2A.UnitTests/Server/A2AServerTests.cs
+++ b/tests/A2A.UnitTests/Server/A2AServerTests.cs
@@ -293,6 +293,59 @@ public class A2AServerTests
     }
 
     [Fact]
+    public async Task GivenWorkingTask_WhenTwoConcurrentCancels_ThenExactlyOneSucceeds()
+    {
+        // Arrange — two concurrent cancel requests race on the same task (BUG-44 TOCTOU).
+        // The per-task lock serializes check-then-act: the loser re-reads the now-terminal
+        // task and fails with TaskNotCancelable instead of double-cancelling.
+        var (server, store, handler) = CreateServer();
+        await store.SaveTaskAsync("t1", new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Working },
+        });
+
+        handler.OnCancel = async (ctx, eq, ct) =>
+        {
+            // Slight delay so the two requests overlap inside the lock window
+            await Task.Delay(50, ct);
+            var updater = new TaskUpdater(eq, ctx.TaskId, ctx.ContextId);
+            await updater.CancelAsync(cancellationToken: ct);
+        };
+
+        // Act — fire both cancels concurrently
+        var cancel1 = server.CancelTaskAsync(new CancelTaskRequest { Id = "t1" });
+        var cancel2 = server.CancelTaskAsync(new CancelTaskRequest { Id = "t1" });
+
+        var results = await Task.WhenAll(
+            RunCatchingAsync(cancel1),
+            RunCatchingAsync(cancel2));
+
+        // Assert — exactly one succeeds; the other sees the terminal state
+        var succeeded = results.Where(r => r.Item1).ToList();
+        var failed = results.Where(r => !r.Item1).ToList();
+
+        Assert.Single(succeeded);
+        Assert.Single(failed);
+        Assert.Equal(TaskState.Canceled, succeeded[0].Item2!.Status.State);
+        Assert.Equal(A2AErrorCode.TaskNotCancelable, failed[0].Item3!.ErrorCode);
+    }
+
+    private static async Task<(bool IsSuccess, AgentTask? Task, A2AException? Error)> RunCatchingAsync(Task<AgentTask> operation)
+    {
+        try
+        {
+            var task = await operation;
+            return (true, task, null);
+        }
+        catch (A2AException ex)
+        {
+            return (false, null, ex);
+        }
+    }
+
+    [Fact]
     public async Task GetTaskAsync_ReturnsTask_WhenExists()
     {
         // Arrange

--- a/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
@@ -645,4 +645,118 @@ public class TaskProjectionTests
         // Assert — result has the updated state
         Assert.Equal(TaskState.Completed, result!.Status.State);
     }
+
+    [Theory]
+    [InlineData(TaskState.Completed)]
+    [InlineData(TaskState.Canceled)]
+    [InlineData(TaskState.Failed)]
+    [InlineData(TaskState.Rejected)]
+    public void Apply_WithStatusUpdate_OnTerminalTask_Throws(TaskState terminalState)
+    {
+        // Arrange — a terminal task whose status must not be overwritten (BUG-43)
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = terminalState },
+        };
+        var evt = new StreamResponse
+        {
+            StatusUpdate = new TaskStatusUpdateEvent
+            {
+                TaskId = "t1",
+                ContextId = "ctx-1",
+                Status = new TaskStatus { State = TaskState.Submitted },
+            }
+        };
+
+        // Act & Assert — terminal → non-terminal transition is rejected
+        var ex = Assert.Throws<A2AException>(() => TaskProjection.Apply(current, evt));
+        Assert.Equal(A2AErrorCode.UnsupportedOperation, ex.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData(TaskState.Completed)]
+    [InlineData(TaskState.Canceled)]
+    [InlineData(TaskState.Failed)]
+    [InlineData(TaskState.Rejected)]
+    public void Apply_WithStatusUpdate_SameTerminalState_Throws(TaskState terminalState)
+    {
+        // Arrange — even an idempotent re-emission of a terminal state is rejected;
+        // a terminal task is final and must be re-created rather than reused
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = terminalState },
+        };
+        var evt = new StreamResponse
+        {
+            StatusUpdate = new TaskStatusUpdateEvent
+            {
+                TaskId = "t1",
+                ContextId = "ctx-1",
+                Status = new TaskStatus { State = terminalState },
+            }
+        };
+
+        // Act & Assert
+        var ex = Assert.Throws<A2AException>(() => TaskProjection.Apply(current, evt));
+        Assert.Equal(A2AErrorCode.UnsupportedOperation, ex.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData(TaskState.Completed)]
+    [InlineData(TaskState.Canceled)]
+    [InlineData(TaskState.Failed)]
+    [InlineData(TaskState.Rejected)]
+    public void Apply_WithMessage_OnTerminalTask_Throws(TaskState terminalState)
+    {
+        // Arrange — a terminal task must not accept further messages (BUG-43)
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = terminalState },
+        };
+        var evt = new StreamResponse
+        {
+            Message = new Message { MessageId = "m1", Role = Role.Agent, Parts = [Part.FromText("late")] },
+        };
+
+        // Act & Assert
+        var ex = Assert.Throws<A2AException>(() => TaskProjection.Apply(current, evt));
+        Assert.Equal(A2AErrorCode.UnsupportedOperation, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Apply_WithArtifactUpdate_OnTerminalTask_DoesNotThrow()
+    {
+        // Arrange — artifact updates after terminal are tolerated by the projection;
+        // only status/message mutations are guarded
+        var current = new AgentTask
+        {
+            Id = "t1",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Completed },
+        };
+        var evt = new StreamResponse
+        {
+            ArtifactUpdate = new TaskArtifactUpdateEvent
+            {
+                TaskId = "t1",
+                ContextId = "ctx-1",
+                Append = false,
+                Artifact = new Artifact { ArtifactId = "a1", Parts = [Part.FromText("data")] },
+            }
+        };
+
+        // Act
+        var result = TaskProjection.Apply(current, evt);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(TaskState.Completed, result!.Status.State);
+        Assert.Single(result.Artifacts!);
+    }
 }

--- a/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
+++ b/tests/A2A.UnitTests/Server/TaskProjectionTests.cs
@@ -653,7 +653,7 @@ public class TaskProjectionTests
     [InlineData(TaskState.Rejected)]
     public void Apply_WithStatusUpdate_OnTerminalTask_Throws(TaskState terminalState)
     {
-        // Arrange — a terminal task whose status must not be overwritten (BUG-43)
+        // Arrange — a terminal task whose status must not be overwritten
         var current = new AgentTask
         {
             Id = "t1",
@@ -712,7 +712,7 @@ public class TaskProjectionTests
     [InlineData(TaskState.Rejected)]
     public void Apply_WithMessage_OnTerminalTask_Throws(TaskState terminalState)
     {
-        // Arrange — a terminal task must not accept further messages (BUG-43)
+        // Arrange — a terminal task must not accept further messages
         var current = new AgentTask
         {
             Id = "t1",


### PR DESCRIPTION
## What changed

### 1. Terminal state transitions are enforced in `TaskProjection` 

**Problem:** `TaskProjection.ApplyStatus` unconditionally overwrote `current.Status`, and `ApplyMessage` unconditionally appended to history. A task in a terminal state (`COMPLETED`/`CANCELED`/`FAILED`/`REJECTED`) could be overwritten back to `SUBMITTED` or accept further messages via direct state assignment, whenever events bypassed the request-level terminal checks (e.g. a misbehaving agent handler emitting events after a terminal status).

**Fix (src/A2A/Server/TaskProjection.cs):**
- Added `GuardNotTerminal`, called from both `ApplyStatus` and `ApplyMessage`.
- Terminal tasks now throw `A2AException` with `A2AErrorCode.UnsupportedOperation` (-32004, the same code `A2AServer` uses for terminal-state rejections) instead of being mutated.
- Artifact updates on terminal tasks remain allowed (the projection only guards status/message mutations).

### 2. `CancelTaskAsync` check-then-act is serialized under the per-task lock 

**Problem:** `CancelTaskAsync` read the task state and checked terminal status with no lock between the check and the state transition. Two concurrent cancel requests could both pass the check and both run the cancel handler (TOCTOU), and cancel could race with `message/send` mutations.

**Fix (src/A2A/Server/A2AServer.cs):**
- The entire cancel operation — terminal check, background-CTS signalling, cancel-handler event application, and final state read — now runs under `_notifier.AcquireTaskLockAsync(request.Id)`, the same per-task lock `ApplyEventAsync` and `SubscribeToTaskAsync` use.
- The loser of a concurrent-cancel race re-reads the now-terminal task and fails with `TaskNotCancelable` instead of double-cancelling.
- `ApplyEventAsync` was refactored into a lock-acquiring wrapper plus `ApplyEventUnderLockAsync` (the locked body), so the cancel path can apply events without re-acquiring the non-reentrant per-task semaphore (which would deadlock).

## Testing

- `dotnet test tests/A2A.UnitTests --framework net8.0` — **434 passed, 0 failed** (baseline 420, +14 new regression tests: status-overwrite and message-append rejection for all four terminal states, same-terminal-state re-emission rejection, artifact-update tolerance on terminal tasks, and a two-concurrent-cancel test asserting exactly one succeeds while the other gets `TaskNotCancelable`).
- `dotnet test tests/A2A.AspNetCore.UnitTests --framework net8.0` — **88 passed, 0 failed** (unchanged).
- **Behavior change:** any agent handler that emits a status update or message after a task reaches a terminal state now gets an `UnsupportedOperation` error (previously silently applied). Well-behaved handlers are unaffected; cancel still transitions `WORKING` → `CANCELED` as before.
