### PR TITLE
fix: add SSE keep-alive/event ids and enforce 10MB request body limit

### DIFF
--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -285,7 +285,7 @@ internal sealed class A2AEventStreamResult : IResult
         var bufferingFeature = httpContext.Features.GetRequiredFeature<IHttpResponseBodyFeature>();
         bufferingFeature.DisableBuffering();
 
-        // SseStreamWriter emits periodic keep-alive comment frames and per-event ids (BUG-09).
+        // SseStreamWriter emits periodic keep-alive comment frames and per-event ids.
         await using var writer = new SseStreamWriter(httpContext);
 
         try

--- a/src/A2A.AspNetCore/A2AHttpProcessor.cs
+++ b/src/A2A.AspNetCore/A2AHttpProcessor.cs
@@ -285,15 +285,16 @@ internal sealed class A2AEventStreamResult : IResult
         var bufferingFeature = httpContext.Features.GetRequiredFeature<IHttpResponseBodyFeature>();
         bufferingFeature.DisableBuffering();
 
+        // SseStreamWriter emits periodic keep-alive comment frames and per-event ids (BUG-09).
+        await using var writer = new SseStreamWriter(httpContext);
+
         try
         {
             await foreach (var taskEvent in _events.WithCancellation(httpContext.RequestAborted))
             {
                 var json = JsonSerializer.Serialize(taskEvent,
                     A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(StreamResponse)));
-                await httpContext.Response.BodyWriter.WriteAsync(
-                    Encoding.UTF8.GetBytes($"data: {json}\n\n"), httpContext.RequestAborted);
-                await httpContext.Response.BodyWriter.FlushAsync(httpContext.RequestAborted);
+                await writer.WriteEventAsync(json, httpContext.RequestAborted);
             }
         }
         catch (OperationCanceledException)
@@ -305,9 +306,9 @@ internal sealed class A2AEventStreamResult : IResult
             // Stream error — response already started, best-effort error event
             try
             {
-                await httpContext.Response.BodyWriter.WriteAsync(
-                    Encoding.UTF8.GetBytes("data: {\"error\":\"An internal error occurred during streaming.\"}\n\n"), httpContext.RequestAborted);
-                await httpContext.Response.BodyWriter.FlushAsync(httpContext.RequestAborted);
+                await writer.WriteEventAsync(
+                    "{\"error\":\"An internal error occurred during streaming.\"}",
+                    httpContext.RequestAborted);
             }
             catch
             {

--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -32,7 +32,7 @@ public static class A2AJsonRpcProcessor
 
         using var activity = A2AAspNetCoreDiagnostics.Source.StartActivity("HandleA2ARequest", ActivityKind.Server);
 
-        // Explicit request body size limit (BUG-10): reject oversized requests before
+        // Explicit request body size limit: reject oversized requests before
         // reading the body, regardless of the host's framework default.
         if (request.ContentLength is { } contentLength && contentLength > A2ARequestLimits.MaxRequestBodySize)
         {

--- a/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
+++ b/src/A2A.AspNetCore/A2AJsonRpcProcessor.cs
@@ -32,6 +32,15 @@ public static class A2AJsonRpcProcessor
 
         using var activity = A2AAspNetCoreDiagnostics.Source.StartActivity("HandleA2ARequest", ActivityKind.Server);
 
+        // Explicit request body size limit (BUG-10): reject oversized requests before
+        // reading the body, regardless of the host's framework default.
+        if (request.ContentLength is { } contentLength && contentLength > A2ARequestLimits.MaxRequestBodySize)
+        {
+            return new JsonRpcResponseResult(JsonRpcResponse.InvalidRequestResponse(
+                new JsonRpcId((string?)null),
+                $"Request body exceeds the maximum allowed size of {A2ARequestLimits.MaxRequestBodySizeInMb}MB."));
+        }
+
         JsonRpcRequest? rpcRequest = null;
 
         try

--- a/src/A2A.AspNetCore/A2ARequestLimits.cs
+++ b/src/A2A.AspNetCore/A2ARequestLimits.cs
@@ -1,0 +1,13 @@
+namespace A2A.AspNetCore;
+
+/// <summary>
+/// Request/response transport limits enforced by the A2A endpoints (BUG-10).
+/// </summary>
+internal static class A2ARequestLimits
+{
+    /// <summary>Maximum accepted request body size in bytes (10 MB).</summary>
+    public const long MaxRequestBodySize = 10 * 1024 * 1024;
+
+    /// <summary>Maximum accepted request body size in megabytes, for user-facing messages.</summary>
+    public const long MaxRequestBodySizeInMb = MaxRequestBodySize / (1024 * 1024);
+}

--- a/src/A2A.AspNetCore/A2ARequestLimits.cs
+++ b/src/A2A.AspNetCore/A2ARequestLimits.cs
@@ -1,7 +1,7 @@
 namespace A2A.AspNetCore;
 
 /// <summary>
-/// Request/response transport limits enforced by the A2A endpoints (BUG-10).
+/// Request/response transport limits enforced by the A2A endpoints.
 /// </summary>
 internal static class A2ARequestLimits
 {

--- a/src/A2A.AspNetCore/A2AServiceCollectionExtensions.cs
+++ b/src/A2A.AspNetCore/A2AServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -36,6 +37,13 @@ public static class A2AServiceCollectionExtensions
         services.TryAddSingleton<ChannelEventNotifier>();
 
         services.TryAddSingleton<ITaskStore, InMemoryTaskStore>();
+
+        // Explicitly cap the request body size at 10 MB (BUG-10) instead of relying on
+        // the host's framework default (Kestrel's default is ~30 MB and varies by host).
+        // Configuring KestrelServerOptions is a no-op on non-Kestrel hosts; the JSON-RPC
+        // processor additionally enforces the same limit per-request.
+        services.Configure<KestrelServerOptions>(
+            options => options.Limits.MaxRequestBodySize = A2ARequestLimits.MaxRequestBodySize);
 
         services.TryAddSingleton<IA2ARequestHandler>(sp =>
             new A2AServer(

--- a/src/A2A.AspNetCore/A2AServiceCollectionExtensions.cs
+++ b/src/A2A.AspNetCore/A2AServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ public static class A2AServiceCollectionExtensions
 
         services.TryAddSingleton<ITaskStore, InMemoryTaskStore>();
 
-        // Explicitly cap the request body size at 10 MB (BUG-10) instead of relying on
+        // Explicitly cap the request body size at 10 MB instead of relying on
         // the host's framework default (Kestrel's default is ~30 MB and varies by host).
         // Configuring KestrelServerOptions is a no-op on non-Kestrel hosts; the JSON-RPC
         // processor additionally enforces the same limit per-request.

--- a/src/A2A.AspNetCore/JsonRpcStreamedResult.cs
+++ b/src/A2A.AspNetCore/JsonRpcStreamedResult.cs
@@ -1,7 +1,5 @@
 using Microsoft.AspNetCore.Http;
-using System.Net.ServerSentEvents;
-using System.Text;
-using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Http.Features;
 using System.Text.Json;
 
 namespace A2A.AspNetCore;
@@ -33,18 +31,20 @@ public sealed class JsonRpcStreamedResult : IResult
         httpContext.Response.ContentType = "text/event-stream";
         httpContext.Response.Headers.Append("Cache-Control", "no-cache");
 
+        // Disable response buffering so heartbeat and event frames flush immediately.
+        httpContext.Features.GetRequiredFeature<IHttpResponseBodyFeature>().DisableBuffering();
+
+        // SseStreamWriter emits periodic keep-alive comment frames and per-event ids (BUG-09).
+        await using var writer = new SseStreamWriter(httpContext);
         var responseTypeInfo = A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcResponse));
         try
         {
-            await SseFormatter.WriteAsync(
-                _events.Select(e => new SseItem<JsonRpcResponse>(JsonRpcResponse.CreateJsonRpcResponse(_requestId, e))),
-                httpContext.Response.Body,
-                (item, writer) =>
-                {
-                    using Utf8JsonWriter json = new(writer, new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
-                    JsonSerializer.Serialize(json, item.Data, responseTypeInfo);
-                },
-                httpContext.RequestAborted).ConfigureAwait(false);
+            await foreach (var ev in _events.WithCancellation(httpContext.RequestAborted).ConfigureAwait(false))
+            {
+                var response = JsonRpcResponse.CreateJsonRpcResponse(_requestId, ev);
+                var json = JsonSerializer.Serialize(response, responseTypeInfo);
+                await writer.WriteEventAsync(json, httpContext.RequestAborted);
+            }
         }
         catch (OperationCanceledException)
         {
@@ -62,9 +62,7 @@ public sealed class JsonRpcStreamedResult : IResult
                     : JsonRpcResponse.InternalErrorResponse(
                         _requestId, "An internal error occurred during streaming.");
                 var errorJson = JsonSerializer.Serialize(errorResponse, responseTypeInfo);
-                var errorBytes = Encoding.UTF8.GetBytes($"data: {errorJson}\n\n");
-                await httpContext.Response.Body.WriteAsync(errorBytes, httpContext.RequestAborted);
-                await httpContext.Response.Body.FlushAsync(httpContext.RequestAborted);
+                await writer.WriteEventAsync(errorJson, httpContext.RequestAborted);
             }
             catch
             {

--- a/src/A2A.AspNetCore/JsonRpcStreamedResult.cs
+++ b/src/A2A.AspNetCore/JsonRpcStreamedResult.cs
@@ -34,7 +34,7 @@ public sealed class JsonRpcStreamedResult : IResult
         // Disable response buffering so heartbeat and event frames flush immediately.
         httpContext.Features.GetRequiredFeature<IHttpResponseBodyFeature>().DisableBuffering();
 
-        // SseStreamWriter emits periodic keep-alive comment frames and per-event ids (BUG-09).
+        // SseStreamWriter emits periodic keep-alive comment frames and per-event ids.
         await using var writer = new SseStreamWriter(httpContext);
         var responseTypeInfo = A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcResponse));
         try

--- a/src/A2A.AspNetCore/SseStreamWriter.cs
+++ b/src/A2A.AspNetCore/SseStreamWriter.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using System.Globalization;
+using System.IO.Pipelines;
+using System.Text;
+
+namespace A2A.AspNetCore;
+
+/// <summary>
+/// Writes Server-Sent Events (SSE) frames with periodic keep-alive comment frames and
+/// monotonically increasing event ids (BUG-09).
+/// </summary>
+/// <remarks>
+/// <para>Keep-alive comment frames (<c>: keep-alive</c>) prevent proxies and load balancers
+/// from terminating idle SSE connections, and event ids let clients resume subscriptions
+/// from a known point.</para>
+/// <para>All writes are serialized through a single lock, so the heartbeat task and the
+/// event writer can never interleave frames.</para>
+/// </remarks>
+internal sealed class SseStreamWriter : IAsyncDisposable
+{
+    private static readonly TimeSpan DefaultKeepAliveInterval = TimeSpan.FromSeconds(15);
+
+    private readonly PipeWriter _writer;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly CancellationTokenSource _heartbeatCts;
+    private readonly Task _heartbeatTask;
+    private long _eventId;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance and starts the keep-alive heartbeat.
+    /// </summary>
+    /// <param name="httpContext">The HTTP context to write the SSE stream to.</param>
+    /// <param name="keepAliveInterval">Optional heartbeat interval; defaults to 15 seconds.</param>
+    public SseStreamWriter(HttpContext httpContext, TimeSpan? keepAliveInterval = null)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        _writer = httpContext.Features.GetRequiredFeature<IHttpResponseBodyFeature>().Writer;
+        _heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(httpContext.RequestAborted);
+        var interval = keepAliveInterval ?? DefaultKeepAliveInterval;
+
+        _heartbeatTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (!_heartbeatCts.IsCancellationRequested)
+                {
+                    await Task.Delay(interval, _heartbeatCts.Token).ConfigureAwait(false);
+                    await WriteFrameAsync(": keep-alive\n\n", _heartbeatCts.Token).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Stream completed or client disconnected — expected
+            }
+            catch
+            {
+                // Response body no longer writable — stop heartbeating
+            }
+        }, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Writes a single SSE event frame: <c>id: {n}</c> followed by the <c>data:</c> payload.
+    /// </summary>
+    /// <param name="dataJson">The JSON payload for the event.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task WriteEventAsync(string dataJson, CancellationToken cancellationToken)
+    {
+        var id = Interlocked.Increment(ref _eventId);
+        await WriteFrameAsync(
+            $"id: {id.ToString(CultureInfo.InvariantCulture)}\ndata: {dataJson}\n\n",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        await _heartbeatCts.CancelAsync().ConfigureAwait(false);
+
+#pragma warning disable VSTHRD003 // Intentional: the heartbeat task was started in the constructor and is owned by this instance
+        try { await _heartbeatTask.ConfigureAwait(false); }
+        catch { /* Already cancelled */ }
+#pragma warning restore VSTHRD003
+
+        _heartbeatCts.Dispose();
+        _writeLock.Dispose();
+    }
+
+    private async Task WriteFrameAsync(string frame, CancellationToken cancellationToken)
+    {
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var bytes = Encoding.UTF8.GetBytes(frame);
+            await _writer.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+            await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+}

--- a/src/A2A.AspNetCore/SseStreamWriter.cs
+++ b/src/A2A.AspNetCore/SseStreamWriter.cs
@@ -8,7 +8,7 @@ namespace A2A.AspNetCore;
 
 /// <summary>
 /// Writes Server-Sent Events (SSE) frames with periodic keep-alive comment frames and
-/// monotonically increasing event ids (BUG-09).
+/// monotonically increasing event ids.
 /// </summary>
 /// <remarks>
 /// <para>Keep-alive comment frames (<c>: keep-alive</c>) prevent proxies and load balancers

--- a/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
@@ -435,6 +435,26 @@ public class A2AJsonRpcProcessorTests
         Assert.Equal(-32700, BodyContent.Error!.Code); // Parse error per JSON-RPC 2.0 spec
     }
 
+    [Fact]
+    public async Task ProcessRequestAsync_GivenOversizedBody_ReturnsInvalidRequest()
+    {
+        // Arrange — body larger than the explicit 10 MB SDK limit (BUG-10)
+        var requestHandler = CreateTestServer();
+        var httpRequest = CreateHttpRequestFromJson("{}");
+        httpRequest.ContentLength = 11L * 1024 * 1024;
+
+        // Act
+        var result = await A2AJsonRpcProcessor.ProcessRequestAsync(requestHandler, httpRequest, CancellationToken.None);
+
+        // Assert — rejected before the body is read, with a clear error
+        var responseResult = Assert.IsType<JsonRpcResponseResult>(result);
+        var (_, _, BodyContent) = await GetJsonRpcResponseHttpDetails<JsonRpcResponse>(responseResult);
+
+        Assert.NotNull(BodyContent.Error);
+        Assert.Equal((int)A2AErrorCode.InvalidRequest, BodyContent.Error!.Code);
+        Assert.Contains("maximum allowed size", BodyContent.Error.Message);
+    }
+
     /// <summary>Creates a test A2AServer with in-memory store and default callbacks.</summary>
     private static IA2ARequestHandler CreateTestServer()
     {

--- a/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
@@ -438,7 +438,7 @@ public class A2AJsonRpcProcessorTests
     [Fact]
     public async Task ProcessRequestAsync_GivenOversizedBody_ReturnsInvalidRequest()
     {
-        // Arrange — body larger than the explicit 10 MB SDK limit (BUG-10)
+        // Arrange — body larger than the explicit 10 MB SDK limit
         var requestHandler = CreateTestServer();
         var httpRequest = CreateHttpRequestFromJson("{}");
         httpRequest.ContentLength = 11L * 1024 * 1024;

--- a/tests/A2A.AspNetCore.UnitTests/A2AServiceCollectionExtensionsTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AServiceCollectionExtensionsTests.cs
@@ -24,7 +24,7 @@ public class A2AServiceCollectionExtensionsTests
     [Fact]
     public void AddA2AAgent_ConfiguresExplicitRequestBodySizeLimit()
     {
-        // Arrange (BUG-10) — the SDK must not rely on the host's framework default
+        // Arrange — the SDK must not rely on the host's framework default
         var services = new ServiceCollection();
 
         // Act

--- a/tests/A2A.AspNetCore.UnitTests/A2AServiceCollectionExtensionsTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AServiceCollectionExtensionsTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace A2A.AspNetCore.Tests;
+
+public class A2AServiceCollectionExtensionsTests
+{
+    private sealed class TestAgentHandler : IAgentHandler
+    {
+        public Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+        {
+            eventQueue.Complete();
+            return Task.CompletedTask;
+        }
+
+        public Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+        {
+            eventQueue.Complete();
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void AddA2AAgent_ConfiguresExplicitRequestBodySizeLimit()
+    {
+        // Arrange (BUG-10) — the SDK must not rely on the host's framework default
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddA2AAgent<TestAgentHandler>(new AgentCard { Name = "test", Description = "test agent" });
+
+        // Assert — Kestrel is explicitly configured to the 10 MB SDK limit
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<KestrelServerOptions>>().Value;
+        Assert.Equal(10 * 1024 * 1024, options.Limits.MaxRequestBodySize);
+    }
+}

--- a/tests/A2A.AspNetCore.UnitTests/SseStreamWriterTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/SseStreamWriterTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.AspNetCore.Http;
+using System.Text;
+
+namespace A2A.AspNetCore.Tests;
+
+public class SseStreamWriterTests
+{
+    [Fact]
+    public async Task WriteEventAsync_EmitsMonotonicEventIdsBeforeData()
+    {
+        // Arrange
+        var context = CreateHttpContext();
+        await using var writer = new SseStreamWriter(context, TimeSpan.FromSeconds(60));
+
+        // Act
+        await writer.WriteEventAsync("{\"a\":1}", CancellationToken.None);
+        await writer.WriteEventAsync("{\"b\":2}", CancellationToken.None);
+
+        // Assert — each data frame is preceded by an incrementing "id:" field
+        var body = GetResponseBody(context);
+        Assert.Contains("id: 1\ndata: {\"a\":1}\n\n", body);
+        Assert.Contains("id: 2\ndata: {\"b\":2}\n\n", body);
+    }
+
+    [Fact]
+    public async Task Heartbeat_EmitsKeepAliveCommentFrames()
+    {
+        // Arrange — short heartbeat interval so the test doesn't wait long (BUG-09)
+        var context = CreateHttpContext();
+        var writer = new SseStreamWriter(context, TimeSpan.FromMilliseconds(50));
+
+        // Act — write one event, then wait long enough for several heartbeat ticks
+        await writer.WriteEventAsync("{\"x\":1}", CancellationToken.None);
+        await Task.Delay(300);
+        await writer.DisposeAsync();
+
+        // Assert — keep-alive comment frames were written
+        var body = GetResponseBody(context);
+        Assert.Contains(": keep-alive\n\n", body);
+    }
+
+    [Fact]
+    public async Task Dispose_StopsHeartbeat()
+    {
+        // Arrange
+        var context = CreateHttpContext();
+        var writer = new SseStreamWriter(context, TimeSpan.FromMilliseconds(30));
+        await writer.DisposeAsync();
+
+        // Act — capture the body right after dispose, then wait past several ticks
+        var bodyAfterDispose = GetResponseBody(context);
+        await Task.Delay(150);
+
+        // Assert — no heartbeat frames appeared after disposal
+        var bodyLater = GetResponseBody(context);
+        Assert.Equal(bodyAfterDispose, bodyLater);
+        Assert.DoesNotContain(": keep-alive", bodyAfterDispose);
+    }
+
+    // --- Helpers ---
+
+    private static DefaultHttpContext CreateHttpContext()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static string GetResponseBody(DefaultHttpContext context)
+    {
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8, leaveOpen: true);
+        return reader.ReadToEnd();
+    }
+}

--- a/tests/A2A.AspNetCore.UnitTests/SseStreamWriterTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/SseStreamWriterTests.cs
@@ -25,7 +25,7 @@ public class SseStreamWriterTests
     [Fact]
     public async Task Heartbeat_EmitsKeepAliveCommentFrames()
     {
-        // Arrange — short heartbeat interval so the test doesn't wait long (BUG-09)
+        // Arrange — short heartbeat interval so the test doesn't wait long
         var context = CreateHttpContext();
         var writer = new SseStreamWriter(context, TimeSpan.FromMilliseconds(50));
 


### PR DESCRIPTION
## What changed

### 1. SSE streams now emit keep-alive heartbeats and event ids 

**Problem:** Neither SSE writer emitted heartbeat (keep-alive) frames or event ids. A client that opened an SSE connection and never disconnected held server resources indefinitely, proxies/load balancers could terminate idle connections, and clients had no way to resume a subscription from a known event.

**Fix (src/A2A.AspNetCore/SseStreamWriter.cs, JsonRpcStreamedResult.cs, A2AHttpProcessor.cs):**
- Added a shared internal `SseStreamWriter` used by both the JSON-RPC SSE stream (`JsonRpcStreamedResult`) and the REST SSE stream (`A2AEventStreamResult`):
 - Emits `: keep-alive` comment frames every 15 seconds on a background timer (heartbeat stops on completion/disconnect/disposal).
 - Prefixes every event frame with a monotonically increasing `id: {n}` field so clients can resume from a known point.
 - All writes are serialized through one lock so heartbeat frames and data frames never interleave.
- The JSON-RPC stream was migrated from `SseFormatter` to `SseStreamWriter` (same JSON payloads, same error event behavior). Both writers now call `DisableBuffering()` so frames flush immediately.

### 2. Explicit 10 MB request body size limit 

**Problem:** No A2A endpoint enforced a maximum request body size; the SDK relied on host framework defaults (Kestrel's default is ~30 MB and varies by host). A client could send multi-GB JSON payloads to exhaust server memory.

**Fix (src/A2A.AspNetCore/A2AServiceCollectionExtensions.cs, A2AJsonRpcProcessor.cs, A2ARequestLimits.cs):**
- Added `A2ARequestLimits.MaxRequestBodySize` = 10 MB.
- `AddA2AAgent` explicitly configures `KestrelServerOptions.Limits.MaxRequestBodySize` to 10 MB, so the limit no longer depends on the host's framework default (a no-op on non-Kestrel hosts).
- `A2AJsonRpcProcessor.ProcessRequestAsync` additionally rejects requests whose `Content-Length` exceeds 10 MB before reading the body, returning an `InvalidRequest` JSON-RPC error with a clear message — this covers hosts where the Kestrel configuration does not apply.

## Testing

- `dotnet test tests/A2A.AspNetCore.UnitTests --framework net8.0` — **93 passed, 0 failed** (baseline 88, +5 new regression tests: monotonic event ids, keep-alive heartbeat frames, heartbeat stops after disposal, `AddA2AAgent` configures the 10 MB Kestrel limit, and oversized `Content-Length` requests are rejected with `InvalidRequest`).
- `dotnet test tests/A2A.UnitTests --framework net8.0` — **420 passed, 0 failed** (unchanged).
- **Behavior change:** SSE data frames now carry an `id:` field before `data:` (ignored by standard SSE parsers), and idle SSE connections receive `: keep-alive` comment frames. Request bodies larger than 10 MB are now rejected instead of being read.
