### PR TITLE
feat: add ITK interoperability test agent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+itk/uv.lock text eol=lf

--- a/.github/workflows/itk-nightly.yaml
+++ b/.github/workflows/itk-nightly.yaml
@@ -1,0 +1,77 @@
+name: Nightly ITK
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # 2:00 AM UTC daily (before 4 AM dashboard refresh)
+  workflow_dispatch:      # Allow manual execution
+
+permissions:
+  contents: write
+
+concurrency:
+  group: itk-nightly
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    name: Nightly ITK Run
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Pre-publish ITK agent
+        run: dotnet publish -c Release -o publish Itk.csproj
+        working-directory: itk
+
+      - name: Clone a2a-itk
+        uses: actions/checkout@v4
+        with:
+          repository: a2aproject/a2a-itk
+          ref: main
+          path: itk/a2a-itk
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build itk_service image (GHA layer cache)
+        uses: docker/build-push-action@v6
+        with:
+          context: itk/a2a-itk
+          tags: itk_service:latest
+          load: true
+          cache-from: type=gha,scope=itk_service
+          cache-to: type=gha,mode=max,scope=itk_service
+
+      - name: Cache launcher peer-SDK checkouts
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/a2a-itk-launcher
+          key: itk-launcher-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            itk-launcher-${{ runner.os }}-
+
+      - name: Run Nightly ITK Tests
+        run: bash run_itk.sh
+        working-directory: itk
+        env:
+          A2A_ITK_REVISION: main
+          ITK_NIGHTLY_RUN: "True"
+
+      - name: Upload Results to Rolling Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "nightly-metrics"
+          prerelease: true
+          files: |
+            itk/itk_dotnet.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/itk.yaml
+++ b/.github/workflows/itk.yaml
@@ -1,0 +1,33 @@
+name: ITK
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'itk/**'
+      - '.github/workflows/itk.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  itk:
+    name: ITK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Run ITK Tests
+        run: bash run_itk.sh
+        working-directory: itk
+        env:
+          A2A_ITK_REVISION: main

--- a/.github/workflows/itk.yaml
+++ b/.github/workflows/itk.yaml
@@ -24,7 +24,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Pre-publish ITK agent
+        run: dotnet publish -c Release -o publish Itk.csproj
+        working-directory: itk
 
       - name: Run ITK Tests
         run: bash run_itk.sh

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
         <PackageVersion Include="Microsoft.Extensions.ExtraAnalyzers" Version="8.0.0-rc.2.23510.2" />
         <PackageVersion Include="System.Text.Json" Version="10.0.11" />
         <!-- Product dependencies shared -->
+        <PackageVersion Include="Google.Protobuf" Version="3.30.2" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
         <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.8" />
         <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.10" />

--- a/itk/.gitignore
+++ b/itk/.gitignore
@@ -1,0 +1,13 @@
+# Build output
+bin/
+obj/
+publish/
+
+# Cloned test harness (fetched by run_itk.sh)
+a2a-itk/
+
+# Runtime logs
+logs/
+
+# Local debugging artifacts
+single_test.json

--- a/itk/InstructionProto.cs
+++ b/itk/InstructionProto.cs
@@ -1,0 +1,433 @@
+// Auto-generated from a2a-itk/protos/instruction.proto
+// Manually translated to C# using Google.Protobuf runtime.
+
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+
+namespace A2A.Itk.Proto;
+
+/// <summary>Root instruction message dispatched through the agent chain.</summary>
+public sealed class Instruction : IMessage<Instruction>
+{
+    public enum StepOneofCase
+    {
+        None = 0,
+        CallAgent = 1,
+        ReturnResponse = 2,
+        Steps = 3,
+    }
+
+    private StepOneofCase _stepCase = StepOneofCase.None;
+    private object? _step;
+
+    public StepOneofCase StepCase => _stepCase;
+
+    public CallAgent? CallAgent
+    {
+        get => _stepCase == StepOneofCase.CallAgent ? (CallAgent?)_step : null;
+        set { _step = value; _stepCase = value is null ? StepOneofCase.None : StepOneofCase.CallAgent; }
+    }
+
+    public ReturnResponse? ReturnResponse
+    {
+        get => _stepCase == StepOneofCase.ReturnResponse ? (ReturnResponse?)_step : null;
+        set { _step = value; _stepCase = value is null ? StepOneofCase.None : StepOneofCase.ReturnResponse; }
+    }
+
+    public SeriesOfSteps? Steps
+    {
+        get => _stepCase == StepOneofCase.Steps ? (SeriesOfSteps?)_step : null;
+        set { _step = value; _stepCase = value is null ? StepOneofCase.None : StepOneofCase.Steps; }
+    }
+
+    public MessageDescriptor Descriptor => null!;
+    public int CalculateSize()
+    {
+        int size = 0;
+        switch (_stepCase)
+        {
+            case StepOneofCase.CallAgent:
+                size += 1 + CodedOutputStream.ComputeMessageSize((CallAgent)_step!);
+                break;
+            case StepOneofCase.ReturnResponse:
+                size += 1 + CodedOutputStream.ComputeMessageSize((ReturnResponse)_step!);
+                break;
+            case StepOneofCase.Steps:
+                size += 1 + CodedOutputStream.ComputeMessageSize((SeriesOfSteps)_step!);
+                break;
+        }
+        return size;
+    }
+
+    public Instruction Clone() => new()
+    {
+        _stepCase = _stepCase,
+        _step = _stepCase switch
+        {
+            StepOneofCase.CallAgent => ((CallAgent)_step!).Clone(),
+            StepOneofCase.ReturnResponse => ((ReturnResponse)_step!).Clone(),
+            StepOneofCase.Steps => ((SeriesOfSteps)_step!).Clone(),
+            _ => null,
+        }
+    };
+
+    public bool Equals(Instruction? other) => other is not null && _stepCase == other._stepCase;
+
+    public void MergeFrom(Instruction message)
+    {
+        switch (message._stepCase)
+        {
+            case StepOneofCase.CallAgent:
+                CallAgent = message.CallAgent!.Clone();
+                break;
+            case StepOneofCase.ReturnResponse:
+                ReturnResponse = message.ReturnResponse!.Clone();
+                break;
+            case StepOneofCase.Steps:
+                Steps = message.Steps!.Clone();
+                break;
+        }
+    }
+
+    public void MergeFrom(CodedInputStream input)
+    {
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            switch (tag)
+            {
+                case 10: // field 1, wire type LEN
+                    var ca = new CallAgent();
+                    input.ReadMessage(ca);
+                    CallAgent = ca;
+                    break;
+                case 18: // field 2, wire type LEN
+                    var rr = new ReturnResponse();
+                    input.ReadMessage(rr);
+                    ReturnResponse = rr;
+                    break;
+                case 26: // field 3, wire type LEN
+                    var ss = new SeriesOfSteps();
+                    input.ReadMessage(ss);
+                    Steps = ss;
+                    break;
+                default:
+                    input.SkipLastField();
+                    break;
+            }
+        }
+    }
+
+    public void WriteTo(CodedOutputStream output)
+    {
+        switch (_stepCase)
+        {
+            case StepOneofCase.CallAgent:
+                output.WriteTag(1, WireFormat.WireType.LengthDelimited);
+                output.WriteMessage((CallAgent)_step!);
+                break;
+            case StepOneofCase.ReturnResponse:
+                output.WriteTag(2, WireFormat.WireType.LengthDelimited);
+                output.WriteMessage((ReturnResponse)_step!);
+                break;
+            case StepOneofCase.Steps:
+                output.WriteTag(3, WireFormat.WireType.LengthDelimited);
+                output.WriteMessage((SeriesOfSteps)_step!);
+                break;
+        }
+    }
+}
+
+public sealed class CallAgent : IMessage<CallAgent>
+{
+    public enum BehaviorOneofCase
+    {
+        None = 0,
+        SendMessage = 5,
+        PushNotification = 6,
+        Resubscribe = 7,
+    }
+
+    public string Transport { get; set; } = "";
+    public string AgentCardUri { get; set; } = "";
+    public Instruction? Instruction { get; set; }
+    public bool Streaming { get; set; }
+
+    private BehaviorOneofCase _behaviorCase = BehaviorOneofCase.None;
+    private object? _behavior;
+
+    public BehaviorOneofCase BehaviorCase => _behaviorCase;
+
+    public SendMessageBehavior? SendMessage
+    {
+        get => _behaviorCase == BehaviorOneofCase.SendMessage ? (SendMessageBehavior?)_behavior : null;
+        set { _behavior = value; _behaviorCase = value is null ? BehaviorOneofCase.None : BehaviorOneofCase.SendMessage; }
+    }
+
+    public PushNotificationBehavior? PushNotification
+    {
+        get => _behaviorCase == BehaviorOneofCase.PushNotification ? (PushNotificationBehavior?)_behavior : null;
+        set { _behavior = value; _behaviorCase = value is null ? BehaviorOneofCase.None : BehaviorOneofCase.PushNotification; }
+    }
+
+    public ResubscribeBehavior? Resubscribe
+    {
+        get => _behaviorCase == BehaviorOneofCase.Resubscribe ? (ResubscribeBehavior?)_behavior : null;
+        set { _behavior = value; _behaviorCase = value is null ? BehaviorOneofCase.None : BehaviorOneofCase.Resubscribe; }
+    }
+
+    public MessageDescriptor Descriptor => null!;
+
+    public int CalculateSize()
+    {
+        int size = 0;
+        if (Transport.Length > 0) size += 1 + CodedOutputStream.ComputeStringSize(Transport);
+        if (AgentCardUri.Length > 0) size += 1 + CodedOutputStream.ComputeStringSize(AgentCardUri);
+        if (Instruction is not null) size += 1 + CodedOutputStream.ComputeMessageSize(Instruction);
+        if (Streaming) size += 1 + 1;
+        switch (_behaviorCase)
+        {
+            case BehaviorOneofCase.SendMessage:
+                size += 1 + CodedOutputStream.ComputeMessageSize((SendMessageBehavior)_behavior!);
+                break;
+            case BehaviorOneofCase.PushNotification:
+                size += 1 + CodedOutputStream.ComputeMessageSize((PushNotificationBehavior)_behavior!);
+                break;
+            case BehaviorOneofCase.Resubscribe:
+                size += 1 + CodedOutputStream.ComputeMessageSize((ResubscribeBehavior)_behavior!);
+                break;
+        }
+        return size;
+    }
+
+    public CallAgent Clone() => new()
+    {
+        Transport = Transport,
+        AgentCardUri = AgentCardUri,
+        Instruction = Instruction?.Clone(),
+        Streaming = Streaming,
+        _behaviorCase = _behaviorCase,
+        _behavior = _behaviorCase switch
+        {
+            BehaviorOneofCase.SendMessage => ((SendMessageBehavior)_behavior!).Clone(),
+            BehaviorOneofCase.PushNotification => ((PushNotificationBehavior)_behavior!).Clone(),
+            BehaviorOneofCase.Resubscribe => ((ResubscribeBehavior)_behavior!).Clone(),
+            _ => null,
+        }
+    };
+
+    public bool Equals(CallAgent? other) => other is not null;
+
+    public void MergeFrom(CallAgent message)
+    {
+        if (message.Transport.Length > 0) Transport = message.Transport;
+        if (message.AgentCardUri.Length > 0) AgentCardUri = message.AgentCardUri;
+        if (message.Instruction is not null) Instruction = message.Instruction.Clone();
+        if (message.Streaming) Streaming = message.Streaming;
+    }
+
+    public void MergeFrom(CodedInputStream input)
+    {
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            switch (tag)
+            {
+                case 10: Transport = input.ReadString(); break;
+                case 18: AgentCardUri = input.ReadString(); break;
+                case 26:
+                    Instruction ??= new Instruction();
+                    input.ReadMessage(Instruction);
+                    break;
+                case 32: Streaming = input.ReadBool(); break;
+                case 42:
+                    var sm = new SendMessageBehavior();
+                    input.ReadMessage(sm);
+                    SendMessage = sm;
+                    break;
+                case 50:
+                    var pn = new PushNotificationBehavior();
+                    input.ReadMessage(pn);
+                    PushNotification = pn;
+                    break;
+                case 58:
+                    var rs = new ResubscribeBehavior();
+                    input.ReadMessage(rs);
+                    Resubscribe = rs;
+                    break;
+                default:
+                    input.SkipLastField();
+                    break;
+            }
+        }
+    }
+
+    public void WriteTo(CodedOutputStream output)
+    {
+        if (Transport.Length > 0) { output.WriteTag(1, WireFormat.WireType.LengthDelimited); output.WriteString(Transport); }
+        if (AgentCardUri.Length > 0) { output.WriteTag(2, WireFormat.WireType.LengthDelimited); output.WriteString(AgentCardUri); }
+        if (Instruction is not null) { output.WriteTag(3, WireFormat.WireType.LengthDelimited); output.WriteMessage(Instruction); }
+        if (Streaming) { output.WriteTag(4, WireFormat.WireType.Varint); output.WriteBool(Streaming); }
+        switch (_behaviorCase)
+        {
+            case BehaviorOneofCase.SendMessage:
+                output.WriteTag(5, WireFormat.WireType.LengthDelimited); output.WriteMessage((SendMessageBehavior)_behavior!);
+                break;
+            case BehaviorOneofCase.PushNotification:
+                output.WriteTag(6, WireFormat.WireType.LengthDelimited); output.WriteMessage((PushNotificationBehavior)_behavior!);
+                break;
+            case BehaviorOneofCase.Resubscribe:
+                output.WriteTag(7, WireFormat.WireType.LengthDelimited); output.WriteMessage((ResubscribeBehavior)_behavior!);
+                break;
+        }
+    }
+}
+
+public sealed class ReturnResponse : IMessage<ReturnResponse>
+{
+    public string Response { get; set; } = "";
+    public bool HoldTask { get; set; }
+
+    public MessageDescriptor Descriptor => null!;
+    public int CalculateSize()
+    {
+        int size = 0;
+        if (Response.Length > 0) size += 1 + CodedOutputStream.ComputeStringSize(Response);
+        if (HoldTask) size += 1 + 1;
+        return size;
+    }
+    public ReturnResponse Clone() => new() { Response = Response, HoldTask = HoldTask };
+    public bool Equals(ReturnResponse? other) => other is not null && Response == other.Response;
+    public void MergeFrom(ReturnResponse message) { if (message.Response.Length > 0) Response = message.Response; if (message.HoldTask) HoldTask = message.HoldTask; }
+    public void MergeFrom(CodedInputStream input)
+    {
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            switch (tag)
+            {
+                case 10: Response = input.ReadString(); break;
+                case 16: HoldTask = input.ReadBool(); break;
+                default: input.SkipLastField(); break;
+            }
+        }
+    }
+    public void WriteTo(CodedOutputStream output)
+    {
+        if (Response.Length > 0) { output.WriteTag(1, WireFormat.WireType.LengthDelimited); output.WriteString(Response); }
+        if (HoldTask) { output.WriteTag(2, WireFormat.WireType.Varint); output.WriteBool(HoldTask); }
+    }
+}
+
+public sealed class SeriesOfSteps : IMessage<SeriesOfSteps>
+{
+    public enum ResponseGeneratorType
+    {
+        Unspecified = 0,
+        Concat = 1,
+    }
+
+    public List<Instruction> Instructions { get; set; } = [];
+    public ResponseGeneratorType ResponseGenerator { get; set; } = ResponseGeneratorType.Unspecified;
+
+    public MessageDescriptor Descriptor => null!;
+    public int CalculateSize()
+    {
+        int size = 0;
+        foreach (var inst in Instructions)
+            size += 1 + CodedOutputStream.ComputeMessageSize(inst);
+        if (ResponseGenerator != ResponseGeneratorType.Unspecified)
+            size += 1 + CodedOutputStream.ComputeEnumSize((int)ResponseGenerator);
+        return size;
+    }
+    public SeriesOfSteps Clone() => new()
+    {
+        Instructions = Instructions.Select(i => i.Clone()).ToList(),
+        ResponseGenerator = ResponseGenerator,
+    };
+    public bool Equals(SeriesOfSteps? other) => other is not null;
+    public void MergeFrom(SeriesOfSteps message) { Instructions.AddRange(message.Instructions.Select(i => i.Clone())); }
+    public void MergeFrom(CodedInputStream input)
+    {
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            switch (tag)
+            {
+                case 10:
+                    var inst = new Instruction();
+                    input.ReadMessage(inst);
+                    Instructions.Add(inst);
+                    break;
+                case 16:
+                    ResponseGenerator = (ResponseGeneratorType)input.ReadEnum();
+                    break;
+                default:
+                    input.SkipLastField();
+                    break;
+            }
+        }
+    }
+    public void WriteTo(CodedOutputStream output)
+    {
+        foreach (var inst in Instructions)
+        {
+            output.WriteTag(1, WireFormat.WireType.LengthDelimited);
+            output.WriteMessage(inst);
+        }
+        if (ResponseGenerator != ResponseGeneratorType.Unspecified)
+        {
+            output.WriteTag(2, WireFormat.WireType.Varint);
+            output.WriteEnum((int)ResponseGenerator);
+        }
+    }
+}
+
+public sealed class SendMessageBehavior : IMessage<SendMessageBehavior>
+{
+    public MessageDescriptor Descriptor => null!;
+    public int CalculateSize() => 0;
+    public SendMessageBehavior Clone() => new();
+    public bool Equals(SendMessageBehavior? other) => other is not null;
+    public void MergeFrom(SendMessageBehavior message) { }
+    public void MergeFrom(CodedInputStream input) { while (input.ReadTag() != 0) input.SkipLastField(); }
+    public void WriteTo(CodedOutputStream output) { }
+}
+
+public sealed class PushNotificationBehavior : IMessage<PushNotificationBehavior>
+{
+    public string Url { get; set; } = "";
+
+    public MessageDescriptor Descriptor => null!;
+    public int CalculateSize() => Url.Length > 0 ? 1 + CodedOutputStream.ComputeStringSize(Url) : 0;
+    public PushNotificationBehavior Clone() => new() { Url = Url };
+    public bool Equals(PushNotificationBehavior? other) => other is not null && Url == other.Url;
+    public void MergeFrom(PushNotificationBehavior message) { if (message.Url.Length > 0) Url = message.Url; }
+    public void MergeFrom(CodedInputStream input)
+    {
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            switch (tag)
+            {
+                case 10: Url = input.ReadString(); break;
+                default: input.SkipLastField(); break;
+            }
+        }
+    }
+    public void WriteTo(CodedOutputStream output)
+    {
+        if (Url.Length > 0) { output.WriteTag(1, WireFormat.WireType.LengthDelimited); output.WriteString(Url); }
+    }
+}
+
+public sealed class ResubscribeBehavior : IMessage<ResubscribeBehavior>
+{
+    public MessageDescriptor Descriptor => null!;
+    public int CalculateSize() => 0;
+    public ResubscribeBehavior Clone() => new();
+    public bool Equals(ResubscribeBehavior? other) => other is not null;
+    public void MergeFrom(ResubscribeBehavior message) { }
+    public void MergeFrom(CodedInputStream input) { while (input.ReadTag() != 0) input.SkipLastField(); }
+    public void WriteTo(CodedOutputStream output) { }
+}

--- a/itk/Itk.csproj
+++ b/itk/Itk.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>A2A.Itk</RootNamespace>
+    <NoWarn>CA1067;CA1305;CA1310;CA1873</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../src/A2A/A2A.csproj" />
+    <ProjectReference Include="../src/A2A.AspNetCore/A2A.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+  </ItemGroup>
+
+</Project>

--- a/itk/ItkAgent.cs
+++ b/itk/ItkAgent.cs
@@ -173,7 +173,7 @@ public sealed class ItkAgent(IHttpClientFactory httpClientFactory, ILogger<ItkAg
         {
             "JSONRPC" => ProtocolBindingNames.JsonRpc,
             "HTTP+JSON" or "HTTP_JSON" or "REST" => ProtocolBindingNames.HttpJson,
-            _ => ProtocolBindingNames.JsonRpc
+            _ => throw new NotSupportedException($"Unsupported transport: {call.Transport}")
         };
 
         AgentCard agentCard;
@@ -384,10 +384,9 @@ public sealed class ItkAgent(IHttpClientFactory httpClientFactory, ILogger<ItkAg
     {
         var results = new List<string>();
 
-        Message? message = null;
-        if (response.Task?.Status?.Message is not null)
-            message = response.Task.Status.Message;
-        else if (response.StatusUpdate?.Status?.Message is not null)
+        Message? message = response.Message
+            ?? response.Task?.Status?.Message;
+        if (message is null && response.StatusUpdate?.Status?.Message is not null)
             message = response.StatusUpdate.Status.Message;
 
         if (message is not null)
@@ -406,7 +405,8 @@ public sealed class ItkAgent(IHttpClientFactory httpClientFactory, ILogger<ItkAg
     {
         var results = new List<string>();
 
-        Message? message = response.Task?.Status?.Message;
+        Message? message = response.Message
+            ?? response.Task?.Status?.Message;
         if (message is not null)
         {
             foreach (var part in message.Parts)
@@ -443,7 +443,7 @@ public sealed class ItkAgent(IHttpClientFactory httpClientFactory, ILogger<ItkAg
         Capabilities = new AgentCapabilities
         {
             Streaming = true,
-            PushNotifications = true,
+            PushNotifications = false,
         },
         DefaultInputModes = ["text/plain"],
         DefaultOutputModes = ["text/plain"],

--- a/itk/ItkAgent.cs
+++ b/itk/ItkAgent.cs
@@ -1,0 +1,466 @@
+using A2A;
+using A2A.Itk.Proto;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+
+namespace A2A.Itk;
+
+/// <summary>
+/// ITK instruction-handling agent. Parses nested traversal instructions,
+/// resolves agent cards, forwards messages, and collects traces.
+/// </summary>
+public sealed class ItkAgent(IHttpClientFactory httpClientFactory, ILogger<ItkAgent> logger) : IAgentHandler
+{
+    public async Task ExecuteAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+    {
+        var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
+        await updater.SubmitAsync(cancellationToken: cancellationToken);
+        await updater.StartWorkAsync(cancellationToken: cancellationToken);
+
+        var instruction = ExtractInstruction(context.Message);
+        if (instruction is null)
+        {
+            logger.LogError("No valid instruction found in request");
+            await updater.FailAsync(
+                new Message { Role = Role.Agent, MessageId = Guid.NewGuid().ToString("N"), Parts = [Part.FromText("No valid instruction found in request")] },
+                cancellationToken: cancellationToken);
+            return;
+        }
+
+        bool shouldHold = ShouldHoldTask(instruction);
+
+        try
+        {
+            var results = await HandleInstructionAsync(instruction, cancellationToken);
+            var responseText = string.Join("\n", results);
+            logger.LogInformation("Response: {Response}", responseText);
+
+            if (shouldHold)
+            {
+                logger.LogInformation("Holding task {TaskId} as requested", context.TaskId);
+                // Emit response + task-finished marker, then keep emitting status updates
+                await updater.StartWorkAsync(
+                    new Message
+                    {
+                        Role = Role.Agent,
+                        MessageId = Guid.NewGuid().ToString("N"),
+                        Parts = [Part.FromText(responseText + "\ntask-finished")]
+                    },
+                    cancellationToken: cancellationToken);
+
+                await Task.Delay(2000, cancellationToken);
+
+                // Keep emitting periodic status updates until cancelled
+                try
+                {
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        await updater.StartWorkAsync(cancellationToken: cancellationToken);
+                        await Task.Delay(2000, cancellationToken);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    logger.LogInformation("Task {TaskId} cancelled", context.TaskId);
+                }
+            }
+            else
+            {
+                await updater.CompleteAsync(
+                    new Message
+                    {
+                        Role = Role.Agent,
+                        MessageId = Guid.NewGuid().ToString("N"),
+                        Parts = [Part.FromText(responseText)]
+                    },
+                    cancellationToken: cancellationToken);
+                logger.LogInformation("Task {TaskId} completed", context.TaskId);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error during instruction handling");
+            await updater.FailAsync(cancellationToken: cancellationToken);
+        }
+    }
+
+    public async Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Cancel requested for task {TaskId}", context.TaskId);
+        var updater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
+        await updater.CancelAsync(cancellationToken: cancellationToken);
+    }
+
+    private Instruction? ExtractInstruction(Message message)
+    {
+        foreach (var part in message.Parts)
+        {
+            // Binary protobuf part
+            if (part.Raw is not null &&
+                (part.MediaType == "application/x-protobuf" || part.Filename == "instruction.bin"))
+            {
+                try
+                {
+                    var inst = new Instruction();
+                    inst.MergeFrom(new CodedInputStream(part.Raw));
+                    return inst;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Failed to parse instruction from binary part");
+                }
+            }
+
+            // Base64-encoded instruction in text part
+            if (part.Text is not null)
+            {
+                try
+                {
+                    var raw = Convert.FromBase64String(part.Text);
+                    var inst = new Instruction();
+                    inst.MergeFrom(new CodedInputStream(raw));
+                    return inst;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Failed to parse instruction from text part");
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ShouldHoldTask(Instruction inst)
+    {
+        if (inst.ReturnResponse is { HoldTask: true })
+            return true;
+        if (inst.Steps is not null)
+            return inst.Steps.Instructions.Any(ShouldHoldTask);
+        return false;
+    }
+
+    private async Task<List<string>> HandleInstructionAsync(Instruction inst, CancellationToken cancellationToken)
+    {
+        if (inst.CallAgent is not null)
+            return await HandleCallAgentAsync(inst.CallAgent, cancellationToken);
+
+        if (inst.ReturnResponse is not null)
+            return [inst.ReturnResponse.Response];
+
+        if (inst.Steps is not null)
+        {
+            var results = new List<string>();
+            foreach (var step in inst.Steps.Instructions)
+            {
+                var stepResults = await HandleInstructionAsync(step, cancellationToken);
+                results.AddRange(stepResults);
+            }
+            return results;
+        }
+
+        throw new InvalidOperationException("Unknown instruction type");
+    }
+
+    private async Task<List<string>> HandleCallAgentAsync(CallAgent call, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Calling agent {AgentCardUri} via {Transport}", call.AgentCardUri, call.Transport);
+
+        var httpClient = httpClientFactory.CreateClient();
+
+        // Select protocol binding based on transport
+        var preferredBinding = call.Transport.ToUpperInvariant() switch
+        {
+            "JSONRPC" => ProtocolBindingNames.JsonRpc,
+            "HTTP+JSON" or "HTTP_JSON" or "REST" => ProtocolBindingNames.HttpJson,
+            _ => ProtocolBindingNames.JsonRpc
+        };
+
+        AgentCard agentCard;
+        try
+        {
+            // Try to resolve agent card from the URI to discover transport-specific endpoints
+            var baseUri = call.AgentCardUri.EndsWith('/') ? call.AgentCardUri : call.AgentCardUri + "/";
+            var cardResolver = new A2ACardResolver(new Uri(baseUri), httpClient);
+            agentCard = await cardResolver.GetAgentCardAsync(cancellationToken);
+            logger.LogInformation("Resolved agent card with {Count} interfaces", agentCard.SupportedInterfaces?.Count ?? 0);
+        }
+        catch (Exception ex)
+        {
+            // Fall back to constructing a minimal card from instruction data
+            logger.LogWarning(ex, "Failed to resolve agent card, using constructed card");
+            agentCard = new AgentCard
+            {
+                Name = "remote",
+                Description = "remote",
+                Version = "1.0",
+                Capabilities = new AgentCapabilities { Streaming = true, PushNotifications = true },
+                DefaultInputModes = ["text/plain"],
+                DefaultOutputModes = ["text/plain"],
+                SupportedInterfaces =
+                [
+                    new AgentInterface
+                    {
+                        ProtocolBinding = preferredBinding,
+                        Url = call.AgentCardUri,
+                        ProtocolVersion = "1.0",
+                    }
+                ],
+            };
+        }
+
+        var clientOptions = new A2AClientOptions
+        {
+            PreferredBindings = [preferredBinding]
+        };
+
+        var client = A2AClientFactory.Create(agentCard, httpClient, clientOptions);
+
+        // Wrap nested instruction into a message
+        var nestedMessage = WrapInstructionToMessage(call.Instruction!);
+        var request = new SendMessageRequest { Message = nestedMessage };
+
+        // Configure push notification if specified
+        if (call.PushNotification is not null)
+        {
+            var url = call.PushNotification.Url;
+            if (!url.StartsWith("http://") && !url.StartsWith("https://"))
+                url = $"http://{url}";
+
+            request.Configuration = new SendMessageConfiguration
+            {
+                PushNotificationConfig = new PushNotificationConfig
+                {
+                    Url = $"{url}/notifications",
+                    Token = "itk-token"
+                }
+            };
+        }
+
+        var results = new List<string>();
+
+        if (call.Resubscribe is not null)
+        {
+            results.AddRange(await HandleResubscribeAsync(client, request, cancellationToken));
+        }
+        else if (call.Streaming)
+        {
+            // Use streaming only when explicitly requested
+            await foreach (var response in client.SendStreamingMessageAsync(request, cancellationToken))
+            {
+                logger.LogInformation("Stream event: {Response}", response);
+                results.AddRange(ExtractTextFromStreamResponse(response));
+            }
+        }
+        else
+        {
+            // Non-streaming send (works for both JSON-RPC and HTTP+JSON)
+            var response = await client.SendMessageAsync(request, cancellationToken);
+            logger.LogInformation("SendMessage response task state: {State}", response.Task?.Status?.State);
+            results.AddRange(ExtractTextFromSendMessageResponse(response));
+        }
+
+        return results;
+    }
+
+    private async Task<List<string>> HandleResubscribeAsync(IA2AClient client, SendMessageRequest request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Executing re-subscribe behavior");
+        var results = new List<string>();
+        string? taskId = null;
+
+        // Send initial message and disconnect after first event
+        await foreach (var response in client.SendStreamingMessageAsync(request, cancellationToken))
+        {
+            taskId = ExtractTaskId(response);
+            if (taskId is not null) break;
+        }
+
+        if (taskId is null)
+        {
+            throw new InvalidOperationException("No task ID received from initial stream");
+        }
+
+        logger.LogInformation("Disconnected from task {TaskId}. Now re-subscribing.", taskId);
+
+        // Re-subscribe to the task
+        var subscribeRequest = new SubscribeToTaskRequest { Id = taskId };
+        bool finished = false;
+
+        await foreach (var response in client.SubscribeToTaskAsync(subscribeRequest, cancellationToken))
+        {
+            logger.LogInformation("Event after re-subscribe: {Response}", response);
+
+            var texts = ExtractTextFromStreamResponse(response);
+            foreach (var text in texts)
+            {
+                var processed = text.Replace("task-finished", "");
+                results.Add(processed);
+            }
+
+            if (texts.Any(t => t.Contains("task-finished")))
+            {
+                logger.LogInformation("Received task-finished after re-subscribe");
+                finished = true;
+                break;
+            }
+
+            // Also check task history
+            if (response.Task is not null)
+            {
+                foreach (var msg in response.Task.History ?? [])
+                {
+                    if (msg.Role == Role.Agent)
+                    {
+                        foreach (var part in msg.Parts)
+                        {
+                            if (part.Text is not null && part.Text.Contains("task-finished"))
+                            {
+                                results.Add(part.Text.Replace("task-finished", ""));
+                                finished = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (finished) break;
+                }
+            }
+
+            if (finished) break;
+        }
+
+        // Cancel if not finished naturally
+        if (!finished)
+        {
+            logger.LogInformation("Canceling task {TaskId} after retrieval", taskId);
+            try
+            {
+                await client.CancelTaskAsync(new CancelTaskRequest { Id = taskId }, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to cancel task {TaskId}", taskId);
+                throw;
+            }
+        }
+
+        return results;
+    }
+
+    private static Message WrapInstructionToMessage(Instruction instruction)
+    {
+        using var ms = new MemoryStream();
+        using var cos = new CodedOutputStream(ms);
+        instruction.WriteTo(cos);
+        cos.Flush();
+        var bytes = ms.ToArray();
+
+        return new Message
+        {
+            Role = Role.User,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Parts =
+            [
+                new Part
+                {
+                    Raw = bytes,
+                    MediaType = "application/x-protobuf",
+                    Filename = "instruction.bin"
+                }
+            ]
+        };
+    }
+
+    private static string? ExtractTaskId(StreamResponse response)
+    {
+        if (response.Task is not null)
+            return response.Task.Id;
+        if (response.StatusUpdate is not null)
+            return response.StatusUpdate.TaskId;
+        return null;
+    }
+
+    private static List<string> ExtractTextFromStreamResponse(StreamResponse response)
+    {
+        var results = new List<string>();
+
+        Message? message = null;
+        if (response.Task?.Status?.Message is not null)
+            message = response.Task.Status.Message;
+        else if (response.StatusUpdate?.Status?.Message is not null)
+            message = response.StatusUpdate.Status.Message;
+
+        if (message is not null)
+        {
+            foreach (var part in message.Parts)
+            {
+                if (part.Text is not null)
+                    results.Add(part.Text);
+            }
+        }
+
+        return results;
+    }
+
+    private static List<string> ExtractTextFromSendMessageResponse(SendMessageResponse response)
+    {
+        var results = new List<string>();
+
+        Message? message = response.Task?.Status?.Message;
+        if (message is not null)
+        {
+            foreach (var part in message.Parts)
+            {
+                if (part.Text is not null)
+                    results.Add(part.Text);
+            }
+        }
+
+        // Also check history
+        if (response.Task?.History is not null)
+        {
+            foreach (var msg in response.Task.History)
+            {
+                if (msg.Role == Role.Agent)
+                {
+                    foreach (var part in msg.Parts)
+                    {
+                        if (part.Text is not null)
+                            results.Add(part.Text);
+                    }
+                }
+            }
+        }
+
+        return results;
+    }
+
+    public static AgentCard GetAgentCard(int httpPort) => new()
+    {
+        Name = "ITK .NET Agent",
+        Description = ".NET agent for ITK compatibility testing.",
+        Version = "1.0.0",
+        Capabilities = new AgentCapabilities
+        {
+            Streaming = true,
+            PushNotifications = true,
+        },
+        DefaultInputModes = ["text/plain"],
+        DefaultOutputModes = ["text/plain"],
+        SupportedInterfaces =
+        [
+            new AgentInterface
+            {
+                ProtocolBinding = "JSONRPC",
+                Url = $"http://127.0.0.1:{httpPort}/jsonrpc",
+                ProtocolVersion = "1.0",
+            },
+            new AgentInterface
+            {
+                ProtocolBinding = "HTTP+JSON",
+                Url = $"http://127.0.0.1:{httpPort}/",
+                ProtocolVersion = "1.0",
+            },
+        ],
+    };
+}

--- a/itk/Program.cs
+++ b/itk/Program.cs
@@ -1,0 +1,43 @@
+using A2A;
+using A2A.AspNetCore;
+using A2A.Itk;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var httpPort = 10102;
+var grpcPort = 11002;
+
+// Parse CLI args (ITK passes --httpPort and --grpcPort)
+for (int i = 0; i < args.Length; i++)
+{
+    if (args[i] == "--httpPort" && i + 1 < args.Length)
+        httpPort = int.Parse(args[++i]);
+    else if (args[i] == "--grpcPort" && i + 1 < args.Length)
+        grpcPort = int.Parse(args[++i]);
+}
+
+builder.WebHost.UseUrls($"http://127.0.0.1:{httpPort}");
+
+var agentCard = ItkAgent.GetAgentCard(httpPort);
+builder.Services.AddA2AAgent<ItkAgent>(agentCard);
+builder.Services.AddHttpClient();
+
+var app = builder.Build();
+
+// Serve the agent card at /.well-known/agent-card.json
+app.MapWellKnownAgentCard(agentCard);
+
+// Also serve at /jsonrpc/.well-known/agent-card.json (ITK readiness check path)
+app.MapGet("/jsonrpc/.well-known/agent-card.json", () => Results.Ok(agentCard));
+
+// JSON-RPC endpoint at /jsonrpc (ITK expects this path)
+app.MapA2A("/jsonrpc");
+
+// Also map at root for direct access
+app.MapA2A("/");
+
+// HTTP+JSON REST endpoints at root
+var handler = app.Services.GetRequiredService<IA2ARequestHandler>();
+app.MapHttpA2A(handler);
+
+app.Run();

--- a/itk/README.md
+++ b/itk/README.md
@@ -37,7 +37,7 @@ The script will:
 
 ### PR Tests vs Nightly
 
-- **PR tests** (`scenarios.json`): Focused star topology with core behaviors
+- **PR tests** (`scenarios_ci.json`): Focused star topology with core behaviors
 - **Nightly tests** (`scenarios_full.json`): Full protocol matrix with all behaviors
 
 To run nightly:

--- a/itk/README.md
+++ b/itk/README.md
@@ -1,6 +1,6 @@
 # Running ITK Tests Locally
 
-This directory contains the .NET ITK (Integration Test Kit) agent and scripts to run
+This directory contains the .NET ITK (Interoperability Test Kit) agent and scripts to run
 cross-SDK compatibility tests against the A2A .NET SDK.
 
 ## What is ITK?

--- a/itk/README.md
+++ b/itk/README.md
@@ -1,0 +1,70 @@
+# Running ITK Tests Locally
+
+This directory contains the .NET ITK (Integration Test Kit) agent and scripts to run
+cross-SDK compatibility tests against the A2A .NET SDK.
+
+## What is ITK?
+
+ITK verifies that A2A SDK implementations can interoperate by routing messages through
+a cluster of agents built with different SDKs (Python, Go, .NET) across multiple
+transport protocols (JSON-RPC, HTTP+JSON, gRPC).
+
+## Prerequisites
+
+- **Docker** (or Podman with docker compatibility)
+- **.NET 8.0 SDK** (for building the .NET agent)
+
+## Running Tests
+
+### 1. Set Environment Variable
+
+```bash
+export A2A_ITK_REVISION=main
+```
+
+### 2. Execute Tests
+
+```bash
+cd itk
+./run_itk.sh
+```
+
+The script will:
+1. Clone `a2a-itk` (if not already present)
+2. Build the ITK service Docker image (includes Python, Go, .NET runtimes)
+3. Mount this repo as the "current" agent under test
+4. Run test scenarios and output results
+
+### PR Tests vs Nightly
+
+- **PR tests** (`scenarios.json`): Focused star topology with core behaviors
+- **Nightly tests** (`scenarios_full.json`): Full protocol matrix with all behaviors
+
+To run nightly:
+```bash
+export ITK_NIGHTLY_RUN=TRUE
+./run_itk.sh
+```
+
+## Debugging
+
+```bash
+export ITK_LOG_LEVEL=DEBUG
+./run_itk.sh
+```
+
+Logs will be saved to `itk/logs/`.
+
+## Architecture
+
+The .NET ITK agent (`ItkAgent.cs`) implements the ITK instruction protocol:
+
+1. **Receives** a protobuf-encoded instruction embedded in an A2A message
+2. **Parses** the instruction (CallAgent, ReturnResponse, or SeriesOfSteps)
+3. **Executes** the instruction:
+   - `CallAgent`: Resolves the target's agent card, creates an A2A client, forwards the nested instruction
+   - `ReturnResponse`: Returns the specified text
+   - `SeriesOfSteps`: Executes each step sequentially, concatenates results
+4. **Returns** the collected trace as the task response
+
+Supported behaviors: `send_message`, `push_notification`, `resubscribe` (streaming with disconnect/reconnect).

--- a/itk/main.py
+++ b/itk/main.py
@@ -1,0 +1,62 @@
+"""ITK agent launcher for .NET.
+
+This script is detected by the ITK runner (current.py) as a Python agent,
+but actually launches the pre-built .NET ITK agent binary. This is necessary
+because 'dotnet run --project' does restore+build which exceeds the ITK's
+35-second readiness timeout on first run.
+
+The run_itk.sh script (or container setup) must 'dotnet publish' first.
+This launcher just execs the published binary for instant startup.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--httpPort', type=int, required=True)
+    parser.add_argument('--grpcPort', type=int, required=False, default=0)
+    args = parser.parse_args()
+
+    itk_dir = Path(__file__).parent
+    publish_dir = itk_dir / 'publish'
+    published_dll = publish_dir / 'Itk.dll'
+
+    # If not pre-published, build now
+    if not published_dll.exists():
+        print('[main.py] No published output found, building...', flush=True)
+        env = os.environ.copy()
+        env['DOTNET_CLI_TELEMETRY_OPTOUT'] = '1'
+        env['DOTNET_NOLOGO'] = '1'
+        build_result = subprocess.run(
+            ['dotnet', 'publish', '-c', 'Release', '-o', str(publish_dir),
+             str(itk_dir / 'Itk.csproj')],
+            cwd=str(itk_dir),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if build_result.returncode != 0:
+            print(f'[main.py] Build failed:\n{build_result.stdout}\n{build_result.stderr}',
+                  flush=True)
+            sys.exit(1)
+        print('[main.py] Build succeeded.', flush=True)
+
+    # Run the published DLL directly (instant startup)
+    cmd = [
+        'dotnet', str(published_dll),
+        '--httpPort', str(args.httpPort),
+    ]
+    if args.grpcPort:
+        cmd.extend(['--grpcPort', str(args.grpcPort)])
+
+    print(f'[main.py] Starting: {" ".join(cmd)}', flush=True)
+    os.execvp('dotnet', cmd)
+
+
+if __name__ == '__main__':
+    main()

--- a/itk/pyproject.toml
+++ b/itk/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "itk-dotnet-agent"
+version = "0.1.0"
+description = "Launcher for the .NET ITK agent"
+requires-python = ">=3.10"
+dependencies = []

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -38,8 +38,10 @@ if git symbolic-ref -q HEAD > /dev/null; then
 fi
 cd ..
 
-# 2. Build the ITK service Docker image from a2a-itk root
-docker build -t itk_service a2a-itk
+# 2. Build the ITK service Docker image from a2a-itk root (skip if pre-built)
+if ! docker image inspect itk_service:latest > /dev/null 2>&1; then
+  docker build -t itk_service a2a-itk
+fi
 
 # 3. Start Docker service
 # Mount a2a-dotnet as repo and itk/ as the current agent

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -ex
+
+# Set default log level
+export ITK_LOG_LEVEL="${ITK_LOG_LEVEL:-INFO}"
+
+# Initialize default exit code
+RESULT=1
+
+# Cleanup function to be called on exit
+cleanup() {
+  set +x
+  echo "Cleaning up artifacts..."
+  docker stop itk-service > /dev/null 2>&1 || true
+  docker rm itk-service > /dev/null 2>&1 || true
+  docker rmi itk_service > /dev/null 2>&1 || true
+  rm -rf a2a-itk > /dev/null 2>&1 || true
+  echo "Done. Final exit code: $RESULT"
+}
+
+# Register cleanup function to run on script exit
+trap cleanup EXIT
+
+# 1. Pull a2a-itk and checkout revision
+: "${A2A_ITK_REVISION:?A2A_ITK_REVISION environment variable must be set}"
+
+if [ ! -d "a2a-itk" ]; then
+  git clone https://github.com/a2aproject/a2a-itk.git a2a-itk
+fi
+cd a2a-itk
+git fetch origin
+git checkout "$A2A_ITK_REVISION"
+
+# Only pull if it's a branch (not a detached HEAD)
+if git symbolic-ref -q HEAD > /dev/null; then
+  git pull origin "$A2A_ITK_REVISION"
+fi
+cd ..
+
+# 2. Build the ITK service Docker image from a2a-itk root
+docker build -t itk_service a2a-itk
+
+# 3. Start Docker service
+# Mount a2a-dotnet as repo and itk/ as the current agent
+A2A_DOTNET_ROOT=$(cd .. && pwd)
+ITK_DIR=$(pwd)
+
+# Stop existing container if any
+docker rm -f itk-service || true
+
+# Create logs directory if debug
+if [ "${ITK_LOG_LEVEL^^}" = "DEBUG" ]; then
+  mkdir -p "$ITK_DIR/logs"
+fi
+
+DOCKER_MOUNT_LOGS=""
+if [ "${ITK_LOG_LEVEL^^}" = "DEBUG" ]; then
+  DOCKER_MOUNT_LOGS="-v $ITK_DIR/logs:/app/logs"
+fi
+
+docker run -d --name itk-service \
+  -v "$A2A_DOTNET_ROOT:/app/agents/repo" \
+  -v "$ITK_DIR:/app/agents/repo/itk" \
+  $DOCKER_MOUNT_LOGS \
+  -e ITK_LOG_LEVEL="$ITK_LOG_LEVEL" \
+  -e ITK_READINESS_TIMEOUT=180 \
+  -p 8000:8000 \
+  itk_service
+
+# 3.1. Fix dubious ownership for git
+docker exec -u root itk-service git config --system --add safe.directory /app/agents/repo
+docker exec -u root itk-service git config --system --add safe.directory /app/agents/repo/itk
+
+# 4. Verify service is up
+MAX_RETRIES=30
+echo "Waiting for ITK service to start on 127.0.0.1:8000..."
+set +e
+for i in $(seq 1 $MAX_RETRIES); do
+  if curl -s http://127.0.0.1:8000/ > /dev/null; then
+    echo "Service is up!"
+    break
+  fi
+  echo "Still waiting... ($i/$MAX_RETRIES)"
+  sleep 2
+done
+
+# If we reached the end of the loop without success
+if ! curl -s http://127.0.0.1:8000/ > /dev/null; then
+  echo "Error: ITK service failed to start on port 8000"
+  docker logs itk-service
+  exit 1
+fi
+
+SCENARIO_FILE="scenarios_ci.json"
+if [ "${ITK_NIGHTLY_RUN^^}" = "TRUE" ]; then
+  SCENARIO_FILE="scenarios_full.json"
+fi
+
+echo "ITK Service is up! Sending compatibility test request using $SCENARIO_FILE..."
+RESPONSE=$(curl -s -X POST http://127.0.0.1:8000/run \
+  -H "Content-Type: application/json" \
+  -d "@$SCENARIO_FILE")
+
+if [ "${ITK_NIGHTLY_RUN^^}" = "TRUE" ]; then
+  echo "Nightly run detected. Saving raw results..."
+  echo "$RESPONSE" > raw_results.json
+  python3 a2a-itk/scripts/process_results.py \
+    --history_output_file itk_dotnet.json \
+    --history_url https://github.com/a2aproject/a2a-dotnet/releases/download/nightly-metrics/itk_dotnet.json
+  RESULT=$?
+else
+  echo "--------------------------------------------------------"
+  echo "ITK TEST RESULTS:"
+  echo "--------------------------------------------------------"
+  echo "$RESPONSE" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    all_passed = data.get('all_passed', False)
+    results = data.get('results', {})
+    for test, details in results.items():
+        if isinstance(details, dict):
+            status = 'PASSED' if details.get('passed', False) else 'FAILED'
+        else:
+            status = 'PASSED' if details else 'FAILED'
+        print(f'{test}: {status}')
+    print('--------------------------------------------------------')
+    print(f'OVERALL STATUS: {\"PASSED\" if all_passed else \"FAILED\"}')
+    if not all_passed:
+        sys.exit(1)
+except Exception as e:
+    print(f'Error parsing results: {e}')
+    print(f'Raw response: {data if \"data\" in locals() else \"no data\"}')
+    sys.exit(1)
+"
+  RESULT=$?
+fi
+set -e
+
+if [ $RESULT -ne 0 ]; then
+  echo "Tests failed. Container logs:"
+  docker logs itk-service
+fi
+echo "--------------------------------------------------------"
+
+# Final exit result will be captured by trap cleanup
+exit $RESULT

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -15,6 +15,7 @@ cleanup() {
   docker rm itk-service > /dev/null 2>&1 || true
   docker rmi itk_service > /dev/null 2>&1 || true
   rm -rf a2a-itk > /dev/null 2>&1 || true
+  rm -rf publish > /dev/null 2>&1 || true
   echo "Done. Final exit code: $RESULT"
 }
 
@@ -46,6 +47,10 @@ A2A_DOTNET_ROOT=$(cd .. && pwd)
 ITK_DIR=$(pwd)
 
 # Stop existing container if any
+# Pre-publish the .NET agent so the container doesn't need .NET 10 SDK
+echo "Pre-publishing ITK agent..."
+dotnet publish -c Release -o "$ITK_DIR/publish" "$ITK_DIR/Itk.csproj"
+
 docker rm -f itk-service || true
 
 # Create logs directory if debug

--- a/itk/scenarios.json
+++ b/itk/scenarios.json
@@ -1,0 +1,41 @@
+{
+  "tests": [
+    {
+      "name": "Star Topology - JSONRPC",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology - HTTP_JSON",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["http_json"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology - JSONRPC (Streaming)",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "send_message"
+    },
+    {
+      "name": "Push Notification Test - JSONRPC",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "push_notification"
+    },
+    {
+      "name": "Resubscribe Test - JSONRPC",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "resubscribe"
+    }
+  ]
+}

--- a/itk/scenarios_ci.json
+++ b/itk/scenarios_ci.json
@@ -1,0 +1,34 @@
+{
+  "tests": [
+    {
+      "name": "Star Topology - JSONRPC",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology - HTTP_JSON",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["http_json"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology - JSONRPC (Streaming)",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "send_message"
+    },
+    {
+      "name": "Resubscribe Test - JSONRPC",
+      "sdks": ["current", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "resubscribe"
+    }
+  ]
+}

--- a/itk/scenarios_full.json
+++ b/itk/scenarios_full.json
@@ -1,0 +1,79 @@
+{
+  "tests": [
+    {
+      "name": "Star Topology (Full) - JSONRPC & GRPC",
+      "sdks": ["current", "python_v10", "python_v03", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology - HTTP_JSON",
+      "sdks": ["current", "python_v10", "python_v03", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+      "protocols": ["http_json"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology (Full) - JSONRPC (Streaming)",
+      "sdks": ["current", "python_v10", "python_v03", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology - HTTP_JSON (Streaming)",
+      "sdks": ["current", "python_v10", "python_v03", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+      "protocols": ["http_json"],
+      "streaming": true,
+      "behavior": "send_message"
+    },
+    {
+      "name": "Push Notification Test - JSONRPC",
+      "sdks": ["current", "python_v10", "python_v03", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "push_notification"
+    },
+    {
+      "name": "Push Notification Test - HTTP_JSON",
+      "sdks": ["current", "python_v10", "python_v03"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["http_json"],
+      "behavior": "push_notification"
+    },
+    {
+      "name": "Resubscribe Test - JSONRPC",
+      "sdks": ["current", "python_v10", "python_v03", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "resubscribe"
+    },
+    {
+      "name": "Resubscribe Test - HTTP_JSON",
+      "sdks": ["current", "python_v10", "python_v03", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+      "protocols": ["http_json"],
+      "streaming": true,
+      "behavior": "resubscribe"
+    },
+    {
+      "name": "Full Backwards Compat - JSONRPC",
+      "sdks": ["python_v03", "go_v03", "current", "go_v10"],
+      "protocols": ["jsonrpc"],
+      "edges": ["3->0", "3->1", "2->0", "2->1", "0->2", "0->3", "1->2", "1->3"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Full Backwards Compat - JSONRPC (Streaming)",
+      "sdks": ["python_v03", "go_v03", "current", "go_v10"],
+      "protocols": ["jsonrpc"],
+      "edges": ["3->0", "3->1", "2->0", "2->1", "0->2", "0->3", "1->2", "1->3"],
+      "streaming": true,
+      "behavior": "send_message"
+    }
+  ]
+}

--- a/itk/scenarios_full.json
+++ b/itk/scenarios_full.json
@@ -1,7 +1,7 @@
 {
   "tests": [
     {
-      "name": "Star Topology (Full) - JSONRPC & GRPC",
+      "name": "Star Topology (Full) - JSONRPC",
       "sdks": ["current", "python_v10", "python_v03", "go_v10", "go_v03"],
       "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
       "protocols": ["jsonrpc"],

--- a/itk/uv.lock
+++ b/itk/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "itk-dotnet-agent"
+version = "0.1.0"
+source = { virtual = "." }


### PR DESCRIPTION
## Summary

Adds a .NET ITK (Interoperability Test Kit) agent that enables cross-SDK testing via the a2a-itk harness.

### What's included

- **itk/** directory with the full agent implementation:
  - ASP.NET Core minimal API hosting the A2A server
  - ITK instruction protocol handler (send_message, streaming, resubscribe, push_notification)
  - Hand-rolled protobuf deserialization (no codegen dependency)
  - Python launcher (main.py) for polyglot harness detection
  - run_itk.sh for local/CI execution
  - CI and full scenario definitions

- **CI workflow** (.github/workflows/itk.yaml) triggered on src/ and itk/ changes

- **Directory.Packages.props** updated with Google.Protobuf

### Test Results (CI set - 4/4 passing)

| Scenario | Result |
|----------|--------|
| Star Topology - JSONRPC | Pass |
| Star Topology - HTTP_JSON | Pass |
| Streaming - JSONRPC | Pass |
| Resubscribe - JSONRPC | Pass |

Push notification test excluded from CI (known SDK gap - server does not implement push delivery). Included in scenarios_full.json for nightly tracking.

### Next steps

- Add dotnet entry to a2a-itk matrix.yaml
- Implement push notification delivery in SDK server