### PR TITLE
fix: Return pre-stream errors as JSON-RPC responses

### DIFF
--- a/src/A2A.AspNetCore/JsonRpcStreamedResult.cs
+++ b/src/A2A.AspNetCore/JsonRpcStreamedResult.cs
@@ -29,13 +29,10 @@ public sealed class JsonRpcStreamedResult : IResult
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        var responseTypeInfo = A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcResponse));
-        await using var enumerator = _events.GetAsyncEnumerator(httpContext.RequestAborted);
-
-        bool hasFirstEvent;
+        IAsyncEnumerator<StreamResponse> enumerator;
         try
         {
-            hasFirstEvent = await enumerator.MoveNextAsync().ConfigureAwait(false);
+            enumerator = _events.GetAsyncEnumerator(httpContext.RequestAborted);
         }
         catch (OperationCanceledException)
         {
@@ -43,32 +40,36 @@ public sealed class JsonRpcStreamedResult : IResult
         }
         catch (Exception ex)
         {
-            await new JsonRpcResponseResult(CreateErrorResponse(ex))
-                .ExecuteAsync(httpContext).ConfigureAwait(false);
+            await WriteErrorAsync(httpContext, ex, streamStarted: false).ConfigureAwait(false);
             return;
         }
 
-        httpContext.Response.StatusCode = StatusCodes.Status200OK;
-        httpContext.Response.ContentType = "text/event-stream";
-        httpContext.Response.Headers.Append("Cache-Control", "no-cache");
-
-        if (!hasFirstEvent)
-        {
-            return;
-        }
-
+        Exception? failure = null;
+        var streamStarted = false;
+        var completedWithoutEvents = false;
         try
         {
-            await SseFormatter.WriteAsync(
-                EnumerateFromCurrentAsync(enumerator)
-                    .Select(e => new SseItem<JsonRpcResponse>(JsonRpcResponse.CreateJsonRpcResponse(_requestId, e))),
-                httpContext.Response.Body,
-                (item, writer) =>
-                {
-                    using Utf8JsonWriter json = new(writer, new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
-                    JsonSerializer.Serialize(json, item.Data, responseTypeInfo);
-                },
-                httpContext.RequestAborted).ConfigureAwait(false);
+            if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+            {
+                ConfigureSseResponse(httpContext);
+                streamStarted = true;
+
+                var responseTypeInfo = A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcResponse));
+                await SseFormatter.WriteAsync(
+                    EnumerateFromCurrentAsync(enumerator)
+                        .Select(e => new SseItem<JsonRpcResponse>(JsonRpcResponse.CreateJsonRpcResponse(_requestId, e))),
+                    httpContext.Response.Body,
+                    (item, writer) =>
+                    {
+                        using Utf8JsonWriter json = new(writer, new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+                        JsonSerializer.Serialize(json, item.Data, responseTypeInfo);
+                    },
+                    httpContext.RequestAborted).ConfigureAwait(false);
+            }
+            else
+            {
+                completedWithoutEvents = true;
+            }
         }
         catch (OperationCanceledException)
         {
@@ -76,29 +77,73 @@ public sealed class JsonRpcStreamedResult : IResult
         }
         catch (Exception ex)
         {
-            // Stream error — response already started, cannot change status code.
-            // Best effort: write an error event if the response body is still writable.
-            // Preserve A2AException error codes; fall back to -32603 for unexpected errors.
+            failure = ex;
+        }
+        finally
+        {
             try
             {
-                var errorResponse = CreateErrorResponse(ex);
-                var errorJson = JsonSerializer.Serialize(errorResponse, responseTypeInfo);
-                var errorBytes = Encoding.UTF8.GetBytes($"data: {errorJson}\n\n");
-                await httpContext.Response.Body.WriteAsync(errorBytes, httpContext.RequestAborted);
-                await httpContext.Response.Body.FlushAsync(httpContext.RequestAborted);
+                await enumerator.DisposeAsync().ConfigureAwait(false);
             }
-            catch
+            catch (OperationCanceledException)
             {
-                // Response body is no longer writable — silently abandon
+                // Client disconnected — expected
             }
+            catch (Exception ex)
+            {
+                failure ??= ex;
+            }
+        }
+
+        if (failure is not null)
+        {
+            await WriteErrorAsync(httpContext, failure, streamStarted).ConfigureAwait(false);
+        }
+        else if (completedWithoutEvents)
+        {
+            ConfigureSseResponse(httpContext);
         }
     }
 
-    private JsonRpcResponse CreateErrorResponse(Exception exception) =>
+    private static void ConfigureSseResponse(HttpContext httpContext)
+    {
+        httpContext.Response.StatusCode = StatusCodes.Status200OK;
+        httpContext.Response.ContentType = "text/event-stream";
+        httpContext.Response.Headers.Append("Cache-Control", "no-cache");
+    }
+
+    private async Task WriteErrorAsync(HttpContext httpContext, Exception exception, bool streamStarted)
+    {
+        var errorResponse = CreateErrorResponse(
+            exception,
+            streamStarted
+                ? "An internal error occurred during streaming."
+                : "An internal error occurred.");
+
+        if (!streamStarted)
+        {
+            await new JsonRpcResponseResult(errorResponse).ExecuteAsync(httpContext).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            var responseTypeInfo = A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcResponse));
+            var errorJson = JsonSerializer.Serialize(errorResponse, responseTypeInfo);
+            var errorBytes = Encoding.UTF8.GetBytes($"data: {errorJson}\n\n");
+            await httpContext.Response.Body.WriteAsync(errorBytes, httpContext.RequestAborted);
+            await httpContext.Response.Body.FlushAsync(httpContext.RequestAborted);
+        }
+        catch
+        {
+            // Response body is no longer writable — silently abandon
+        }
+    }
+
+    private JsonRpcResponse CreateErrorResponse(Exception exception, string internalErrorMessage) =>
         exception is A2AException a2aException
             ? JsonRpcResponse.CreateJsonRpcErrorResponse(_requestId, a2aException)
-            : JsonRpcResponse.InternalErrorResponse(
-                _requestId, "An internal error occurred during streaming.");
+            : JsonRpcResponse.InternalErrorResponse(_requestId, internalErrorMessage);
 
     private static async IAsyncEnumerable<StreamResponse> EnumerateFromCurrentAsync(
         IAsyncEnumerator<StreamResponse> enumerator)

--- a/src/A2A.AspNetCore/JsonRpcStreamedResult.cs
+++ b/src/A2A.AspNetCore/JsonRpcStreamedResult.cs
@@ -29,15 +29,39 @@ public sealed class JsonRpcStreamedResult : IResult
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
+        var responseTypeInfo = A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcResponse));
+        await using var enumerator = _events.GetAsyncEnumerator(httpContext.RequestAborted);
+
+        bool hasFirstEvent;
+        try
+        {
+            hasFirstEvent = await enumerator.MoveNextAsync().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (Exception ex)
+        {
+            await new JsonRpcResponseResult(CreateErrorResponse(ex))
+                .ExecuteAsync(httpContext).ConfigureAwait(false);
+            return;
+        }
+
         httpContext.Response.StatusCode = StatusCodes.Status200OK;
         httpContext.Response.ContentType = "text/event-stream";
         httpContext.Response.Headers.Append("Cache-Control", "no-cache");
 
-        var responseTypeInfo = A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcResponse));
+        if (!hasFirstEvent)
+        {
+            return;
+        }
+
         try
         {
             await SseFormatter.WriteAsync(
-                _events.Select(e => new SseItem<JsonRpcResponse>(JsonRpcResponse.CreateJsonRpcResponse(_requestId, e))),
+                EnumerateFromCurrentAsync(enumerator)
+                    .Select(e => new SseItem<JsonRpcResponse>(JsonRpcResponse.CreateJsonRpcResponse(_requestId, e))),
                 httpContext.Response.Body,
                 (item, writer) =>
                 {
@@ -57,10 +81,7 @@ public sealed class JsonRpcStreamedResult : IResult
             // Preserve A2AException error codes; fall back to -32603 for unexpected errors.
             try
             {
-                var errorResponse = ex is A2AException a2aEx
-                    ? JsonRpcResponse.CreateJsonRpcErrorResponse(_requestId, a2aEx)
-                    : JsonRpcResponse.InternalErrorResponse(
-                        _requestId, "An internal error occurred during streaming.");
+                var errorResponse = CreateErrorResponse(ex);
                 var errorJson = JsonSerializer.Serialize(errorResponse, responseTypeInfo);
                 var errorBytes = Encoding.UTF8.GetBytes($"data: {errorJson}\n\n");
                 await httpContext.Response.Body.WriteAsync(errorBytes, httpContext.RequestAborted);
@@ -71,5 +92,21 @@ public sealed class JsonRpcStreamedResult : IResult
                 // Response body is no longer writable — silently abandon
             }
         }
+    }
+
+    private JsonRpcResponse CreateErrorResponse(Exception exception) =>
+        exception is A2AException a2aException
+            ? JsonRpcResponse.CreateJsonRpcErrorResponse(_requestId, a2aException)
+            : JsonRpcResponse.InternalErrorResponse(
+                _requestId, "An internal error occurred during streaming.");
+
+    private static async IAsyncEnumerable<StreamResponse> EnumerateFromCurrentAsync(
+        IAsyncEnumerator<StreamResponse> enumerator)
+    {
+        do
+        {
+            yield return enumerator.Current;
+        }
+        while (await enumerator.MoveNextAsync().ConfigureAwait(false));
     }
 }

--- a/src/A2A.V0_3Compat/V03JsonRpcStreamedResult.cs
+++ b/src/A2A.V0_3Compat/V03JsonRpcStreamedResult.cs
@@ -26,25 +26,49 @@ internal sealed class V03JsonRpcStreamedResult : IResult
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        httpContext.Response.StatusCode = StatusCodes.Status200OK;
-        httpContext.Response.ContentType = "text/event-stream";
-        httpContext.Response.Headers.Append("Cache-Control", "no-cache");
-
         var responseTypeInfo = V03.A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(V03.JsonRpcResponse));
         var eventTypeInfo = V03.A2AJsonUtilities.DefaultOptions.GetTypeInfo(typeof(V03.A2AEvent));
 
+        IAsyncEnumerator<V03.A2AEvent> enumerator;
         try
         {
-            await SseFormatter.WriteAsync(
-                _events.Select(e => new SseItem<V03.JsonRpcResponse>(
-                    V03.JsonRpcResponse.CreateJsonRpcResponse(_requestId, e, eventTypeInfo))),
-                httpContext.Response.Body,
-                (item, writer) =>
-                {
-                    using Utf8JsonWriter json = new(writer, new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
-                    JsonSerializer.Serialize(json, item.Data, responseTypeInfo);
-                },
-                httpContext.RequestAborted).ConfigureAwait(false);
+            enumerator = _events.GetAsyncEnumerator(httpContext.RequestAborted);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (Exception ex)
+        {
+            await WriteErrorAsync(httpContext, ex, streamStarted: false, responseTypeInfo).ConfigureAwait(false);
+            return;
+        }
+
+        Exception? failure = null;
+        var streamStarted = false;
+        var completedWithoutEvents = false;
+        try
+        {
+            if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+            {
+                ConfigureSseResponse(httpContext);
+                streamStarted = true;
+
+                await SseFormatter.WriteAsync(
+                    EnumerateFromCurrentAsync(enumerator).Select(e => new SseItem<V03.JsonRpcResponse>(
+                        V03.JsonRpcResponse.CreateJsonRpcResponse(_requestId, e, eventTypeInfo))),
+                    httpContext.Response.Body,
+                    (item, writer) =>
+                    {
+                        using Utf8JsonWriter json = new(writer, new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+                        JsonSerializer.Serialize(json, item.Data, responseTypeInfo);
+                    },
+                    httpContext.RequestAborted).ConfigureAwait(false);
+            }
+            else
+            {
+                completedWithoutEvents = true;
+            }
         }
         catch (OperationCanceledException)
         {
@@ -52,21 +76,83 @@ internal sealed class V03JsonRpcStreamedResult : IResult
         }
         catch (Exception ex)
         {
+            failure = ex;
+        }
+        finally
+        {
             try
             {
-                var errorResponse = ex is A2AException a2aEx
-                    ? V03.JsonRpcResponse.CreateJsonRpcErrorResponse(_requestId,
-                        new V03.A2AException(a2aEx.Message, (V03.A2AErrorCode)(int)a2aEx.ErrorCode))
-                    : V03.JsonRpcResponse.InternalErrorResponse(_requestId, "An internal error occurred during streaming.");
-                var errorJson = JsonSerializer.Serialize(errorResponse, responseTypeInfo);
-                var errorBytes = Encoding.UTF8.GetBytes($"data: {errorJson}\n\n");
-                await httpContext.Response.Body.WriteAsync(errorBytes, httpContext.RequestAborted);
-                await httpContext.Response.Body.FlushAsync(httpContext.RequestAborted);
+                await enumerator.DisposeAsync().ConfigureAwait(false);
             }
-            catch
+            catch (OperationCanceledException)
             {
-                // Response body is no longer writable — silently abandon
+                // Client disconnected — expected
+            }
+            catch (Exception ex)
+            {
+                failure ??= ex;
             }
         }
+
+        if (failure is not null)
+        {
+            await WriteErrorAsync(httpContext, failure, streamStarted, responseTypeInfo).ConfigureAwait(false);
+        }
+        else if (completedWithoutEvents)
+        {
+            ConfigureSseResponse(httpContext);
+        }
+    }
+
+    private static void ConfigureSseResponse(HttpContext httpContext)
+    {
+        httpContext.Response.StatusCode = StatusCodes.Status200OK;
+        httpContext.Response.ContentType = "text/event-stream";
+        httpContext.Response.Headers.Append("Cache-Control", "no-cache");
+    }
+
+    private async Task WriteErrorAsync(
+        HttpContext httpContext,
+        Exception exception,
+        bool streamStarted,
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo responseTypeInfo)
+    {
+        var errorResponse = exception is A2AException a2aException
+            ? V03.JsonRpcResponse.CreateJsonRpcErrorResponse(
+                _requestId,
+                new V03.A2AException(a2aException.Message, (V03.A2AErrorCode)(int)a2aException.ErrorCode))
+            : V03.JsonRpcResponse.InternalErrorResponse(
+                _requestId,
+                streamStarted
+                    ? "An internal error occurred during streaming."
+                    : "An internal error occurred.");
+
+        if (!streamStarted)
+        {
+            await new V03JsonRpcResponseResult(errorResponse).ExecuteAsync(httpContext).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            var errorJson = JsonSerializer.Serialize(errorResponse, responseTypeInfo);
+            var errorBytes = Encoding.UTF8.GetBytes($"data: {errorJson}\n\n");
+            await httpContext.Response.Body.WriteAsync(errorBytes, httpContext.RequestAborted);
+            await httpContext.Response.Body.FlushAsync(httpContext.RequestAborted);
+        }
+        catch
+        {
+            // Response body is no longer writable — silently abandon
+        }
+    }
+
+    private static async IAsyncEnumerable<V03.A2AEvent> EnumerateFromCurrentAsync(
+        IAsyncEnumerator<V03.A2AEvent> enumerator)
+    {
+        do
+        {
+            yield return enumerator.Current;
+        }
+        while (await enumerator.MoveNextAsync().ConfigureAwait(false));
     }
 }

--- a/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/A2AJsonRpcProcessorTests.cs
@@ -411,6 +411,36 @@ public class A2AJsonRpcProcessorTests
         Assert.Equal("Invalid parameters", BodyContent.Error.Message);
     }
 
+    [Fact]
+    public async Task StreamResponse_SubscribeToTerminalTask_ReturnsUnsupportedOperationError()
+    {
+        // Arrange
+        var (requestHandler, store) = CreateTestServerWithStore();
+        await store.SaveTaskAsync("terminal-task", new AgentTask
+        {
+            Id = "terminal-task",
+            ContextId = "ctx-1",
+            Status = new TaskStatus { State = TaskState.Completed },
+        });
+        var parameters = ToJsonElement(new SubscribeToTaskRequest { Id = "terminal-task" });
+
+        // Act
+        var result = A2AJsonRpcProcessor.StreamResponse(
+            requestHandler, "10", A2AMethods.SubscribeToTask, parameters, CancellationToken.None);
+        var responseResult = Assert.IsType<JsonRpcStreamedResult>(result);
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        await responseResult.ExecuteAsync(context);
+
+        // Assert
+        context.Response.Body.Position = 0;
+        var response = await JsonSerializer.DeserializeAsync<JsonRpcResponse>(
+            context.Response.Body, A2AJsonUtilities.DefaultOptions);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal("application/json", context.Response.ContentType);
+        Assert.Equal((int)A2AErrorCode.UnsupportedOperation, response?.Error?.Code);
+    }
+
     [Theory]
     [InlineData("{invalid json", "completely malformed JSON")]
     [InlineData("not json at all", "plain text")]

--- a/tests/A2A.AspNetCore.UnitTests/JsonRpcStreamedResultTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/JsonRpcStreamedResultTests.cs
@@ -77,7 +77,7 @@ public class JsonRpcStreamedResultTests
         Assert.Equal((int)A2AErrorCode.InternalError, response.Error.Code);
         // Must NOT leak the original exception message
         Assert.DoesNotContain("sensitive internal details", response.Error.Message);
-        Assert.Equal("An internal error occurred during streaming.", response.Error.Message);
+        Assert.Equal("An internal error occurred.", response.Error.Message);
     }
 
     [Fact]
@@ -137,6 +137,78 @@ public class JsonRpcStreamedResultTests
         var doc = JsonDocument.Parse(json);
         Assert.Equal("2.0", doc.RootElement.GetProperty("jsonrpc").GetString());
         Assert.Equal((int)A2AErrorCode.InvalidParams, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleEvents_EmitsFirstEventOnceAndInOrder()
+    {
+        // Arrange
+        var result = new JsonRpcStreamedResult(
+            MultipleEventsAsyncEnumerable(), new JsonRpcId("req-7"));
+        var httpContext = CreateHttpContext();
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        var body = GetResponseBody(httpContext);
+        Assert.Equal(1, body.Split("\"task-1\"", StringSplitOptions.None).Length - 1);
+        Assert.Equal(1, body.Split("\"task-2\"", StringSplitOptions.None).Length - 1);
+        Assert.True(
+            body.IndexOf("\"task-1\"", StringComparison.Ordinal) <
+            body.IndexOf("\"task-2\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GetAsyncEnumeratorThrows_ReturnsJsonRpcError()
+    {
+        // Arrange
+        var result = new JsonRpcStreamedResult(
+            new ThrowingGetAsyncEnumerable(), new JsonRpcId("req-8"));
+        var httpContext = CreateHttpContext();
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        var response = ParseJsonRpcResponse(GetResponseBody(httpContext));
+        Assert.Equal("application/json", httpContext.Response.ContentType);
+        Assert.Equal((int)A2AErrorCode.InternalError, response.Error?.Code);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DisposeAsyncThrowsAfterFirstEvent_ReturnsSseError()
+    {
+        // Arrange
+        var result = new JsonRpcStreamedResult(
+            new ThrowingDisposeAsyncEnumerable(), new JsonRpcId("req-9"));
+        var httpContext = CreateHttpContext();
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        var body = GetResponseBody(httpContext);
+        Assert.Equal("text/event-stream", httpContext.Response.ContentType);
+        Assert.Contains("\"task-1\"", body);
+        Assert.Contains("\"error\"", body);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DisposeAsyncThrowsBeforeFirstEvent_ReturnsJsonRpcError()
+    {
+        // Arrange
+        var result = new JsonRpcStreamedResult(
+            new ThrowingDisposeAsyncEnumerable(yieldEvent: false), new JsonRpcId("req-10"));
+        var httpContext = CreateHttpContext();
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        var response = ParseJsonRpcResponse(GetResponseBody(httpContext));
+        Assert.Equal("application/json", httpContext.Response.ContentType);
+        Assert.Equal((int)A2AErrorCode.InternalError, response.Error?.Code);
     }
 
     [Fact]
@@ -228,5 +300,58 @@ public class JsonRpcStreamedResultTests
         }
 
         throw exception;
+    }
+
+    private static async IAsyncEnumerable<StreamResponse> MultipleEventsAsyncEnumerable(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        yield return CreateTaskResponse("task-1");
+        yield return CreateTaskResponse("task-2");
+    }
+
+    private static StreamResponse CreateTaskResponse(string taskId) =>
+        new()
+        {
+            Task = new AgentTask
+            {
+                Id = taskId,
+                ContextId = "context-1",
+                Status = new TaskStatus { State = TaskState.Working },
+            },
+        };
+
+    private sealed class ThrowingGetAsyncEnumerable : IAsyncEnumerable<StreamResponse>
+    {
+        public IAsyncEnumerator<StreamResponse> GetAsyncEnumerator(
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("Failed to create enumerator.");
+    }
+
+    private sealed class ThrowingDisposeAsyncEnumerable :
+        IAsyncEnumerable<StreamResponse>, IAsyncEnumerator<StreamResponse>
+    {
+        private readonly bool _yieldEvent;
+        private bool _hasYielded;
+
+        public ThrowingDisposeAsyncEnumerable(bool yieldEvent = true)
+        {
+            _yieldEvent = yieldEvent;
+        }
+
+        public StreamResponse Current { get; } = CreateTaskResponse("task-1");
+
+        public IAsyncEnumerator<StreamResponse> GetAsyncEnumerator(
+            CancellationToken cancellationToken = default) => this;
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            var shouldYield = _yieldEvent && !_hasYielded;
+            _hasYielded = true;
+            return ValueTask.FromResult(shouldYield);
+        }
+
+        public ValueTask DisposeAsync() =>
+            ValueTask.FromException(new InvalidOperationException("Failed to dispose enumerator."));
     }
 }

--- a/tests/A2A.AspNetCore.UnitTests/JsonRpcStreamedResultTests.cs
+++ b/tests/A2A.AspNetCore.UnitTests/JsonRpcStreamedResultTests.cs
@@ -8,7 +8,7 @@ namespace A2A.AspNetCore.Tests;
 public class JsonRpcStreamedResultTests
 {
     [Fact]
-    public async Task ExecuteAsync_A2AException_PreservesErrorCode()
+    public async Task ExecuteAsync_A2AExceptionBeforeFirstEvent_ReturnsJsonRpcError()
     {
         // Arrange
         var requestId = new JsonRpcId("req-1");
@@ -24,8 +24,9 @@ public class JsonRpcStreamedResultTests
 
         // Assert
         var body = GetResponseBody(httpContext);
-        var response = ParseSseDataLine(body);
+        var response = ParseJsonRpcResponse(body);
 
+        Assert.Equal("application/json", httpContext.Response.ContentType);
         Assert.NotNull(response.Error);
         Assert.Equal((int)errorCode, response.Error.Code);
         Assert.Equal(errorMessage, response.Error.Message);
@@ -33,7 +34,7 @@ public class JsonRpcStreamedResultTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_A2AExceptionMethodNotFound_PreservesErrorCode()
+    public async Task ExecuteAsync_A2AExceptionMethodNotFoundBeforeFirstEvent_ReturnsJsonRpcError()
     {
         // Arrange
         var requestId = new JsonRpcId("req-2");
@@ -47,15 +48,16 @@ public class JsonRpcStreamedResultTests
 
         // Assert
         var body = GetResponseBody(httpContext);
-        var response = ParseSseDataLine(body);
+        var response = ParseJsonRpcResponse(body);
 
+        Assert.Equal("application/json", httpContext.Response.ContentType);
         Assert.NotNull(response.Error);
         Assert.Equal((int)A2AErrorCode.MethodNotFound, response.Error.Code);
         Assert.Equal("Method not found", response.Error.Message);
     }
 
     [Fact]
-    public async Task ExecuteAsync_GenericException_ReturnsInternalError()
+    public async Task ExecuteAsync_GenericExceptionBeforeFirstEvent_ReturnsInternalError()
     {
         // Arrange
         var requestId = new JsonRpcId("req-3");
@@ -68,8 +70,9 @@ public class JsonRpcStreamedResultTests
 
         // Assert
         var body = GetResponseBody(httpContext);
-        var response = ParseSseDataLine(body);
+        var response = ParseJsonRpcResponse(body);
 
+        Assert.Equal("application/json", httpContext.Response.ContentType);
         Assert.NotNull(response.Error);
         Assert.Equal((int)A2AErrorCode.InternalError, response.Error.Code);
         // Must NOT leak the original exception message
@@ -99,7 +102,7 @@ public class JsonRpcStreamedResultTests
     {
         // Arrange
         var requestId = new JsonRpcId("req-5");
-        var events = ThrowingAsyncEnumerable(new A2AException("test", A2AErrorCode.InternalError));
+        var events = SingleEventAsyncEnumerable();
         var result = new JsonRpcStreamedResult(events, requestId);
         var httpContext = CreateHttpContext();
 
@@ -113,11 +116,11 @@ public class JsonRpcStreamedResultTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ErrorResponseIsValidSseFormat()
+    public async Task ExecuteAsync_A2AExceptionAfterFirstEvent_ReturnsSseError()
     {
         // Arrange
         var requestId = new JsonRpcId("req-6");
-        var events = ThrowingAsyncEnumerable(
+        var events = YieldThenThrowAsyncEnumerable(
             new A2AException("Bad params", A2AErrorCode.InvalidParams));
         var result = new JsonRpcStreamedResult(events, requestId);
         var httpContext = CreateHttpContext();
@@ -178,6 +181,12 @@ public class JsonRpcStreamedResultTests
             ?? throw new InvalidOperationException("Failed to deserialize JsonRpcResponse");
     }
 
+    private static JsonRpcResponse ParseJsonRpcResponse(string body)
+    {
+        return JsonSerializer.Deserialize<JsonRpcResponse>(body, A2AJsonUtilities.DefaultOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize JsonRpcResponse");
+    }
+
     private static async IAsyncEnumerable<StreamResponse> ThrowingAsyncEnumerable(
         Exception exception, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
@@ -193,5 +202,31 @@ public class JsonRpcStreamedResultTests
     {
         await Task.CompletedTask;
         yield break;
+    }
+
+    private static async IAsyncEnumerable<StreamResponse> SingleEventAsyncEnumerable(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        yield return new StreamResponse
+        {
+            Task = new AgentTask
+            {
+                Id = "task-1",
+                ContextId = "context-1",
+                Status = new TaskStatus { State = TaskState.Working },
+            },
+        };
+    }
+
+    private static async IAsyncEnumerable<StreamResponse> YieldThenThrowAsyncEnumerable(
+        Exception exception, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var response in SingleEventAsyncEnumerable(cancellationToken))
+        {
+            yield return response;
+        }
+
+        throw exception;
     }
 }

--- a/tests/A2A.V0_3Compat.UnitTests/V03JsonRpcStreamedResultTests.cs
+++ b/tests/A2A.V0_3Compat.UnitTests/V03JsonRpcStreamedResultTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+
+using V03 = A2A.V0_3;
+
+namespace A2A.V0_3Compat.UnitTests;
+
+public class V03JsonRpcStreamedResultTests
+{
+    [Fact]
+    public async Task ExecuteAsync_A2AExceptionBeforeFirstEvent_ReturnsJsonRpcError()
+    {
+        // Arrange
+        var events = ThrowingAsyncEnumerable(
+            new A2AException("Task not found.", A2AErrorCode.TaskNotFound));
+        var result = new V03JsonRpcStreamedResult(events, new V03.JsonRpcId("req-1"));
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        httpContext.Response.Body.Position = 0;
+        using var reader = new StreamReader(httpContext.Response.Body, Encoding.UTF8);
+        var body = await reader.ReadToEndAsync();
+        var response = JsonSerializer.Deserialize<V03.JsonRpcResponse>(
+            body, V03.A2AJsonUtilities.DefaultOptions);
+
+        Assert.Equal("application/json", httpContext.Response.ContentType);
+        Assert.Equal((int)V03.A2AErrorCode.TaskNotFound, response?.Error?.Code);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DisposeAsyncThrowsBeforeFirstEvent_ReturnsJsonRpcError()
+    {
+        // Arrange
+        var result = new V03JsonRpcStreamedResult(
+            new EmptyThrowingDisposeAsyncEnumerable(), new V03.JsonRpcId("req-2"));
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        httpContext.Response.Body.Position = 0;
+        using var reader = new StreamReader(httpContext.Response.Body, Encoding.UTF8);
+        var body = await reader.ReadToEndAsync();
+        var response = JsonSerializer.Deserialize<V03.JsonRpcResponse>(
+            body, V03.A2AJsonUtilities.DefaultOptions);
+
+        Assert.Equal("application/json", httpContext.Response.ContentType);
+        Assert.Equal((int)V03.A2AErrorCode.InternalError, response?.Error?.Code);
+    }
+
+    private static async IAsyncEnumerable<V03.A2AEvent> ThrowingAsyncEnumerable(
+        Exception exception, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        throw exception;
+#pragma warning disable CS0162 // Unreachable code required for an async enumerable
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private sealed class EmptyThrowingDisposeAsyncEnumerable :
+        IAsyncEnumerable<V03.A2AEvent>, IAsyncEnumerator<V03.A2AEvent>
+    {
+        public V03.A2AEvent Current => throw new InvalidOperationException();
+
+        public IAsyncEnumerator<V03.A2AEvent> GetAsyncEnumerator(
+            CancellationToken cancellationToken = default) => this;
+
+        public ValueTask<bool> MoveNextAsync() => ValueTask.FromResult(false);
+
+        public ValueTask DisposeAsync() =>
+            ValueTask.FromException(new InvalidOperationException("Failed to dispose enumerator."));
+    }
+}

--- a/tests/A2A.V0_3Compat.UnitTests/V03ServerProcessorTests.cs
+++ b/tests/A2A.V0_3Compat.UnitTests/V03ServerProcessorTests.cs
@@ -116,6 +116,21 @@ public class V03ServerProcessorTests
         Assert.Equal(-32001, errorEl.GetProperty("code").GetInt32()); // TaskNotFound
     }
 
+    [Fact]
+    public async Task ProcessRequestAsync_V03TasksResubscribe_NonExistentTask_ReturnsTaskNotFoundError()
+    {
+        var handler = CreateRequestHandler();
+        var request = CreateHttpRequest(
+            """{"jsonrpc":"2.0","method":"tasks/resubscribe","id":1,"params":{"id":"nonexistent-task-v03"}}""");
+
+        var result = await V03ServerProcessor.ProcessRequestAsync(handler, request, CancellationToken.None);
+
+        using var body = await ExecuteAndParseJson(result);
+        Assert.True(body.RootElement.TryGetProperty("error", out var errorEl),
+            "Expected error for nonexistent task");
+        Assert.Equal(-32001, errorEl.GetProperty("code").GetInt32()); // TaskNotFound
+    }
+
     // ── v1.0 method routing through V03ServerProcessor ──────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

- inspect the first streaming result before committing SSE response headers
- return pre-stream failures as normal JSON-RPC error responses
- preserve SSE delivery and error events after a stream has started

## TCK failures

### STREAM-SUB-004: invalid task

`tests/compatibility/core_operations/test_requirements.py::test_must_requirement[STREAM-SUB-004-jsonrpc]`

`tests/compatibility/jsonrpc/test_sse_streaming.py::TestSseSubscribeToTask::test_subscribe_nonexistent_task_returns_error`

```text
STREAM-SUB-004 [SubscribeToTask returns TaskNotFoundError for invalid task] failed on jsonrpc: Expected TaskNotFoundError but operation succeeded
```

For a nonexistent task, `A2AServer.SubscribeToTaskAsync()` correctly throws `TaskNotFoundError` (`-32001`). Because the check runs when the lazy async enumerable is first advanced, `JsonRpcStreamedResult` previously committed `200 OK` with `Content-Type: text/event-stream` before observing the exception. The response then contained the error as an SSE event, causing clients to classify the subscription itself as successful.

### STREAM-SUB-003: terminal task

`tests/compatibility/core_operations/test_task_lifecycle.py::TestSubscribeLifecycle::test_subscribe_rejects_terminal_task[jsonrpc]`

```text
STREAM-SUB-003 [SubscribeToTask rejects terminal tasks] failed on jsonrpc: SubscribeToTask on a terminal task should return an error, but yielded an event
```

For a terminal task, `A2AServer.SubscribeToTaskAsync()` correctly throws `UnsupportedOperationError` (`-32004`) before yielding a snapshot. The same response-format issue converted that exception into an SSE `data:` frame, which the TCK treated as a successfully yielded event.

## Resolution

This change advances the stream once before selecting the response format. An exception before the first event is returned as an `application/json` JSON-RPC error. Once the first event exists, the result commits the SSE response, replays that event, and continues consuming the same enumerator. Errors after streaming begins retain the existing best-effort SSE error event.

## Tests

- verifies invalid-task and terminal-task subscriptions return normal JSON-RPC errors
- verifies enumerator acquisition and disposal failures remain inside the response-format boundary
- verifies prefetched events are emitted exactly once and in order
- verifies equivalent behavior for the v0.3 compatibility path
- `dotnet test A2A.slnx --no-restore --nologo`

